### PR TITLE
Add `RequireSigilOnAllFiles` config flag to `ValidSorbetSigil` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,3 @@
+Sorbet/ValidSorbetSigil:
+  Enabled: true
+  EnforcedStyle: typed_files

--- a/spec/cop/sorbet/valid_sorbet_sigil_spec.rb
+++ b/spec/cop/sorbet/valid_sorbet_sigil_spec.rb
@@ -7,7 +7,14 @@ require_relative '../../../lib/rubocop/cop/sorbet/valid_sorbet_sigil'
 RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
   subject(:cop) { described_class.new(config) }
 
-  describe('offenses') do
+  describe('RequireSigilOnAllFiles: true') do
+    let(:cop_config) do
+      {
+        'Enabled' => true,
+        'RequireSigilOnAllFiles' => true,
+      }
+    end
+
     it 'enforces that the Sorbet sigil must exist' do
       expect_offense(<<~RUBY)
         # frozen_string_literal: true
@@ -49,51 +56,136 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
         class Foo; end
       RUBY
     end
+
+    describe('autocorrect') do
+      it('autocorrects by adding typed: false to file without sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # typed: false
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+      end
+
+      it('does not change files with a sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            # typed: strict
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # frozen_string_literal: true
+            # typed: strict
+            class Foo; end
+          RUBY
+      end
+
+      it('does not change files with an invalid sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            # typed: no
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # frozen_string_literal: true
+            # typed: no
+            class Foo; end
+          RUBY
+      end
+    end
   end
 
-  describe('autocorrect') do
-    it('autocorrects by adding typed: false to file without sigil') do
-      expect(
-        autocorrect_source(<<~RUBY)
-          # frozen_string_literal: true
-          class Foo; end
-        RUBY
-      )
-        .to(eq(<<~RUBY))
-          # typed: false
-          # frozen_string_literal: true
-          class Foo; end
-        RUBY
+  describe('RequireSigilOnAllFiles: false') do
+    let(:cop_config) do
+      {
+        'Enabled' => true,
+        'RequireSigilOnAllFiles' => false,
+      }
     end
 
-    it('does not change files with a sigil') do
-      expect(
-        autocorrect_source(<<~RUBY)
-          # frozen_string_literal: true
-          # typed: strict
-          class Foo; end
-        RUBY
-      )
-        .to(eq(<<~RUBY))
-          # frozen_string_literal: true
-          # typed: strict
-          class Foo; end
-        RUBY
+    it 'enforces that the Sorbet sigil must be valid' do
+      expect_offense(<<~RUBY)
+        # Hello world!
+        # typed: foobar
+        ^^^^^^^^^^^^^^^ Invalid Sorbet sigil `foobar`.
+        class Foo; end
+      RUBY
     end
 
-    it('does not change files with an invalid sigil') do
-      expect(
-        autocorrect_source(<<~RUBY)
-          # frozen_string_literal: true
-          # typed: no
-          class Foo; end
-        RUBY
-      )
-        .to(eq(<<~RUBY))
-          # frozen_string_literal: true
-          # typed: no
-          class Foo; end
-        RUBY
+    it 'allows the Sorbet sigil to not exist' do
+      expect_no_offenses(<<~RUBY)
+        # frozen_string_literal: true
+        class Foo; end
+      RUBY
+    end
+
+    it 'allows Sorbet sigil' do
+      expect_no_offenses(<<~RUBY)
+        # typed: true
+        class Foo; end
+      RUBY
+    end
+
+    it 'allows empty spaces at the beginning of the file' do
+      expect_no_offenses(<<~RUBY)
+
+        # typed: true
+        class Foo; end
+      RUBY
+    end
+
+    describe('autocorrect') do
+      it('does not change files without sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+      end
+
+      it('does not change files with a sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            # typed: strict
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # frozen_string_literal: true
+            # typed: strict
+            class Foo; end
+          RUBY
+      end
+
+      it('does not change files with an invalid sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            # typed: no
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # frozen_string_literal: true
+            # typed: no
+            class Foo; end
+          RUBY
+      end
     end
   end
 end

--- a/spec/cop/sorbet/valid_sorbet_sigil_spec.rb
+++ b/spec/cop/sorbet/valid_sorbet_sigil_spec.rb
@@ -7,6 +7,38 @@ require_relative '../../../lib/rubocop/cop/sorbet/valid_sorbet_sigil'
 RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
   subject(:cop) { described_class.new(config) }
 
+  shared_examples_for 'no autocorrect on files with sigil' do
+    it('does not change files with a sigil') do
+      expect(
+        autocorrect_source(<<~RUBY)
+          # frozen_string_literal: true
+          # typed: strict
+          class Foo; end
+        RUBY
+      )
+        .to(eq(<<~RUBY))
+          # frozen_string_literal: true
+          # typed: strict
+          class Foo; end
+        RUBY
+    end
+
+    it('does not change files with an invalid sigil') do
+      expect(
+        autocorrect_source(<<~RUBY)
+          # frozen_string_literal: true
+          # typed: no
+          class Foo; end
+        RUBY
+      )
+        .to(eq(<<~RUBY))
+          # frozen_string_literal: true
+          # typed: no
+          class Foo; end
+        RUBY
+    end
+  end
+
   describe('RequireSigilOnAllFiles: true') do
     let(:cop_config) do
       {
@@ -58,6 +90,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
     end
 
     describe('autocorrect') do
+      it_should_behave_like 'no autocorrect on files with sigil'
+
       it('autocorrects by adding typed: false to file without sigil') do
         expect(
           autocorrect_source(<<~RUBY)
@@ -68,36 +102,6 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
           .to(eq(<<~RUBY))
             # typed: false
             # frozen_string_literal: true
-            class Foo; end
-          RUBY
-      end
-
-      it('does not change files with a sigil') do
-        expect(
-          autocorrect_source(<<~RUBY)
-            # frozen_string_literal: true
-            # typed: strict
-            class Foo; end
-          RUBY
-        )
-          .to(eq(<<~RUBY))
-            # frozen_string_literal: true
-            # typed: strict
-            class Foo; end
-          RUBY
-      end
-
-      it('does not change files with an invalid sigil') do
-        expect(
-          autocorrect_source(<<~RUBY)
-            # frozen_string_literal: true
-            # typed: no
-            class Foo; end
-          RUBY
-        )
-          .to(eq(<<~RUBY))
-            # frozen_string_literal: true
-            # typed: no
             class Foo; end
           RUBY
       end
@@ -144,6 +148,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
     end
 
     describe('autocorrect') do
+      it_should_behave_like 'no autocorrect on files with sigil'
+
       it('does not change files without sigil') do
         expect(
           autocorrect_source(<<~RUBY)
@@ -153,36 +159,6 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSorbetSigil, :config) do
         )
           .to(eq(<<~RUBY))
             # frozen_string_literal: true
-            class Foo; end
-          RUBY
-      end
-
-      it('does not change files with a sigil') do
-        expect(
-          autocorrect_source(<<~RUBY)
-            # frozen_string_literal: true
-            # typed: strict
-            class Foo; end
-          RUBY
-        )
-          .to(eq(<<~RUBY))
-            # frozen_string_literal: true
-            # typed: strict
-            class Foo; end
-          RUBY
-      end
-
-      it('does not change files with an invalid sigil') do
-        expect(
-          autocorrect_source(<<~RUBY)
-            # frozen_string_literal: true
-            # typed: no
-            class Foo; end
-          RUBY
-        )
-          .to(eq(<<~RUBY))
-            # frozen_string_literal: true
-            # typed: no
             class Foo; end
           RUBY
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,13 @@ RSpec.configure do |config|
   if config.files_to_run.one?
     config.default_formatter = 'doc'
   end
+
+  config.before(:each) do
+    config = RuboCop::ConfigLoader.default_configuration
+    RuboCop::ConfigLoader.default_configuration = config.merge(rubocop_sorbet_default_file)
+  end
+
+  def rubocop_sorbet_default_file
+    YAML.load(File.read(File.join(File.dirname(__FILE__), '..', 'config', 'default.yml')))
+  end
 end


### PR DESCRIPTION
Adds a `RequireSigilOnAllFiles` config flag that when `false`, only checks for the syntax of the sigils and does not require that all files have a Sorbet sigil.