### PR TITLE
Add Contracts and DryTypes Includes Rubocop Rules

### DIFF
--- a/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
+++ b/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
@@ -1,0 +1,125 @@
+#
+# In preparation for adding Sorbet to the codebase we must remove all dynamic imports as these
+# make type checking impossible. The biggest single offender in our codebase is `Dry::Types.module`
+# which includes all the types like Strict::String, Coercible::Int, Types::Bool, etc.
+#
+# Instead of using these auto-magic includes, we must use ths static path. In most cases this is
+# can be done automatically by this class, so:
+#
+# Strict::String -> Dry::Types['strict.string']
+# Coercible::Int -> Dry::Types['coercible.string']
+# Types::Bool -> Dry::Types['bool']
+# Strict::Array.of(Strict::String) -> Dry::Types["strict.array"].of
+# Strict::DateTime -> Dry::Types["strict.date_time"]
+# Instance(Carrier) -> Dry::Types::Definition.new(Carrier).constrained(type: Carrier)
+#
+# Some were not automate-able and must be done manually. These are:
+#
+# Any -> Dry::Types::Any
+# Hash -> Dry::Types["hash"]
+# Nil -> Dry::Types["nil"]
+#
+module RuboCop
+  module Cop
+    module Sorbet
+      class NoDynamicContractIncludes < Cop
+        MSG = "Sorbet disallows dynamic includes. Do not include Dry::Types.module directly; use direct path instead.".freeze
+        MSG_PATH = "Sorbet disallows dynamic includes. Use full Dry::Types path instead.".freeze
+
+        def_node_matcher :include_statement, <<-PATTERN
+          (send _ :include (send (const (const _ :Dry) :Types) _))
+        PATTERN
+
+        def_node_matcher :instance_statement, <<-PATTERN
+          (send _ :Instance (const ...))
+        PATTERN
+
+        def_node_matcher :const_statement, <<-PATTERN
+          (const (const _ {:Strict :Coercible}) _)
+        PATTERN
+
+        def_node_matcher :types_statement, <<-PATTERN
+          (const (const _ :Types) {:DateTime :String :Bool :Array :Int :Hash :Date})
+        PATTERN
+
+        def on_const(node)
+          types_statement(node) do |statement|
+            add_offense(node, message: format(MSG_PATH, statement: statement))
+          end
+          const_statement(node) do |statement|
+            add_offense(node, message: format(MSG_PATH, statement: statement))
+          end
+        end
+
+        def on_send(node)
+          instance_statement(node) do |statement|
+            add_offense(node, message: format(MSG, statement: statement))
+          end
+          include_statement(node) do |statement|
+            add_offense(node, message: format(MSG, statement: statement))
+          end
+        end
+
+        DYNAMIC_REFERENCE_PATTERN = NodePattern.new("$(const (const _ ${:Strict :Coercible}) $_)")
+        INSTANCE_PATTERN = NodePattern.new("$(send _ :Instance (const _ $_))")
+        TYPES_PATTERN = NodePattern.new("$(const (const _ :Types) ${:DateTime :String :Bool :Array :Int :Hash :Date})")
+
+        def autocorrect(node)
+          if DYNAMIC_REFERENCE_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+            correct_dynamic_class_reference(node)
+          elsif INSTANCE_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+            correct_instance_class_reference(node)
+          elsif TYPES_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+            correct_types_reference(node)
+          end
+        end
+
+        def klass_to_str(klass)
+          klass_str = klass.to_s.downcase
+          if klass_str == "datetime"
+            "date_time"
+          else
+            klass_str
+          end
+        end
+
+        def correct_types_reference(node)
+          full_source, klass = TYPES_PATTERN.match(node)
+          klass_str = klass_to_str(klass)
+          new_source = format("Dry::Types[\"%s\"]", klass_str) # rubocop:disable Style/FormatStringToken
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+
+        def correct_instance_class_reference(node)
+          full_source, klass = INSTANCE_PATTERN.match(node)
+          klass_str = klass.to_s
+          new_source = format("Dry::Types::Definition.new(%s).constrained(type: %s)", klass_str, klass_str) # rubocop:disable Style/FormatStringToken
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+
+        def correct_dynamic_class_reference(node)
+          full_source, strictness, primitive = DYNAMIC_REFERENCE_PATTERN.match(node)
+          strictness_str = strictness.to_s.downcase
+          primitive_str = klass_to_str(primitive)
+          new_source = format("Dry::Types[\"%s.%s\"]", strictness_str, primitive_str) # rubocop:disable Style/FormatStringToken
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
+++ b/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
@@ -65,11 +65,11 @@ module RuboCop
         TYPES_PATTERN = NodePattern.new("$(const (const _ :Types) ${:DateTime :String :Bool :Array :Int :Hash :Date})")
 
         def autocorrect(node)
-          if DYNAMIC_REFERENCE_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+          if DYNAMIC_REFERENCE_PATTERN.match(node)
             correct_dynamic_class_reference(node)
-          elsif INSTANCE_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+          elsif INSTANCE_PATTERN.match(node)
             correct_instance_class_reference(node)
-          elsif TYPES_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+          elsif TYPES_PATTERN.match(node)
             correct_types_reference(node)
           end
         end
@@ -86,7 +86,7 @@ module RuboCop
         def correct_types_reference(node)
           full_source, klass = TYPES_PATTERN.match(node)
           klass_str = klass_to_str(klass)
-          new_source = format("Dry::Types[\"%s\"]", klass_str) # rubocop:disable Style/FormatStringToken
+          new_source = format("Dry::Types[\"%s\"]", klass_str)
           lambda do |corrector|
             corrector.replace(
               full_source.source_range,
@@ -98,7 +98,7 @@ module RuboCop
         def correct_instance_class_reference(node)
           full_source, klass = INSTANCE_PATTERN.match(node)
           klass_str = klass.to_s
-          new_source = format("Dry::Types::Definition.new(%s).constrained(type: %s)", klass_str, klass_str) # rubocop:disable Style/FormatStringToken
+          new_source = format("Dry::Types::Definition.new(%s).constrained(type: %s)", klass_str, klass_str)
           lambda do |corrector|
             corrector.replace(
               full_source.source_range,
@@ -111,7 +111,7 @@ module RuboCop
           full_source, strictness, primitive = DYNAMIC_REFERENCE_PATTERN.match(node)
           strictness_str = strictness.to_s.downcase
           primitive_str = klass_to_str(primitive)
-          new_source = format("Dry::Types[\"%s.%s\"]", strictness_str, primitive_str) # rubocop:disable Style/FormatStringToken
+          new_source = format("Dry::Types[\"%s.%s\"]", strictness_str, primitive_str)
           lambda do |corrector|
             corrector.replace(
               full_source.source_range,

--- a/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
+++ b/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
@@ -44,19 +44,19 @@ module RuboCop
 
         def on_const(node)
           types_statement(node) do |statement|
-            add_offense(node, message: format(MSG_PATH, statement: statement))
+            add_offense(node, message: MSG_PATH)
           end
           const_statement(node) do |statement|
-            add_offense(node, message: format(MSG_PATH, statement: statement))
+            add_offense(node, message: MSG_PATH)
           end
         end
 
         def on_send(node)
           instance_statement(node) do |statement|
-            add_offense(node, message: format(MSG, statement: statement))
+            add_offense(node, message: MSG)
           end
           include_statement(node) do |statement|
-            add_offense(node, message: format(MSG, statement: statement))
+            add_offense(node, message: MSG)
           end
         end
 

--- a/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
+++ b/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
@@ -1,0 +1,84 @@
+require "rubocop/sorbet_from_contract_service.rb"
+module RuboCop
+  module Cop
+    module Sorbet
+      class PreferSorbetOverContracts < Cop
+        MSG = "Instead of Contracts use Sorbet signatures.".freeze
+
+        def_node_matcher :contract_statement, <<-PATTERN
+          (send _ :Contract ...)
+        PATTERN
+
+        def on_send(node)
+          contract_statement(node) do |statement|
+            add_offense(node, message: format(MSG, statement: statement))
+          end
+        end
+
+        CONTRACT_PATTERN = NodePattern.new("$(send _ :Contract $... (:hash (:pair $_ $_)))")
+        EXTEND_T_SIG_PATTERN = NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
+
+        def autocorrect(node)
+          if CONTRACT_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+            return convert_contract_multi_args(node)
+          end
+        end
+
+        def convert_contract_multi_args(node)
+          full_source, arg0, arg1, ret, = CONTRACT_PATTERN.match(node)
+          # Conracts puts the first argument types in one list and the list on its own.
+          # IE in Contract String, Boolean, Integer => Number, [String, Boolean] end up in one
+          # list of nodes and Integer ends up as the first key in a (:pair) node where the values
+          # are the return types. I guess this is to allow the => syntax?
+          args = arg0 << arg1
+
+          new_source = ::Sorbet::SorbetFromContractService.source(node, args, ret)
+          return nil if new_source.nil?
+
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+            add_extend_tsig(corrector, node)
+          end
+        end
+
+        # Add `extend T::Sig` if not present
+        def add_extend_tsig(corrector, node)
+          return if node.parent.children.detect { |sib| EXTEND_T_SIG_PATTERN.match(sib) }
+          white_space = leading_white_space(node)
+          extend_t_source = "extend T::Sig#{white_space}"
+          corrector.replace(
+            node.parent.children.first.source_range.begin,
+            extend_t_source,
+          )
+        end
+
+        def previous_line(parent)
+          if parent.sibling_index > 1
+            previous = parent.parent.children[parent.sibling_index - 1]
+            if previous && previous.source_range
+              return previous
+            end
+          end
+          parent.parent.children.first
+        end
+
+        # Need to replicate the white space leading up to the node
+        def leading_white_space(node)
+          parent = node.parent
+          next_line = parent.children.first
+          previous = previous_line(parent)
+          end_previous = previous.source_range.end_pos
+          begin_next = next_line.source_range.begin_pos
+          Parser::Source::Range.new(
+            node.parent.source_range.source_buffer,
+            end_previous,
+            begin_next,
+          ).source.gsub(/[0-9a-z\<\_\-]/i, "")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
+++ b/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
@@ -19,7 +19,7 @@ module RuboCop
         EXTEND_T_SIG_PATTERN = NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
 
         def autocorrect(node)
-          if CONTRACT_PATTERN.match(node) # rubocop:disable Performance/RegexpMatch
+          if CONTRACT_PATTERN.match(node)
             return convert_contract_multi_args(node)
           end
         end

--- a/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
+++ b/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
@@ -11,7 +11,7 @@ module RuboCop
 
         def on_send(node)
           contract_statement(node) do |statement|
-            add_offense(node, message: format(MSG, statement: statement))
+            add_offense(node, message: MSG)
           end
         end
 

--- a/lib/rubocop/sorbet_from_contract_service.rb
+++ b/lib/rubocop/sorbet_from_contract_service.rb
@@ -6,8 +6,6 @@ module Sorbet
     EXTEND_T_SIG_PATTERN = RuboCop::NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
 
     INSTANCE_ARG_MATCHER = RuboCop::NodePattern.new("(def _ (:args $...) ...)")
-    ARG_NAMES_MATCHER = RuboCop::NodePattern.new("(defs _ _ (:args $...) ...)")
-    PRIVATE_CLASS_ARG_MATCHER = RuboCop::NodePattern.new("(send _ :private_class_method (defs _ _ (:args $...) ...))")
     CONST_PATTERN = RuboCop::NodePattern.new("(const nil? $_)")
     TWO_CONST_PATTERN = RuboCop::NodePattern.new("(const (const nil? $_) $_)")
     THREE_CONST_PATTERN = RuboCop::NodePattern.new("(const (const (const nil? $_) $_) $_)")

--- a/lib/rubocop/sorbet_from_contract_service.rb
+++ b/lib/rubocop/sorbet_from_contract_service.rb
@@ -1,0 +1,159 @@
+module Sorbet
+  class SorbetFromContractService
+    class AutoCorrectError < StandardError; end
+    CONTRACT_PATTERN = RuboCop::NodePattern.new("$(send _ :Contract $... (:hash (:pair $_ $_)))")
+
+    EXTEND_T_SIG_PATTERN = RuboCop::NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
+
+    INSTANCE_ARG_MATCHER = RuboCop::NodePattern.new("(def _ (:args $...) ...)")
+    ARG_NAMES_MATCHER = RuboCop::NodePattern.new("(defs _ _ (:args $...) ...)")
+    PRIVATE_CLASS_ARG_MATCHER = RuboCop::NodePattern.new("(send _ :private_class_method (defs _ _ (:args $...) ...))")
+    CONST_PATTERN = RuboCop::NodePattern.new("(const nil? $_)")
+    TWO_CONST_PATTERN = RuboCop::NodePattern.new("(const (const nil? $_) $_)")
+    THREE_CONST_PATTERN = RuboCop::NodePattern.new("(const (const (const nil? $_) $_) $_)")
+    FOUR_CONST_PATTERN = RuboCop::NodePattern.new("(const (const (const (const nil? $_) $_) $_) $_)")
+    SEND_PATTERN = RuboCop::NodePattern.new("(send $_ _ $...)")
+    NIL_PATTERN = RuboCop::NodePattern.new("nil")
+    HASH_PATTERN = RuboCop::NodePattern.new("(hash $...)")
+    PAIR_MATCHER = RuboCop::NodePattern.new("(pair ({sym str} $_) $_)")
+    CONST_PAIR_MATCHER = RuboCop::NodePattern.new("(hash (pair (const nil? $_) (const nil? $_)))")
+    CONTRACT_ARGS_PATTERN = RuboCop::NodePattern.new("({arg optarg blockarg kwoptarg kwarg} $_ ...)")
+
+    ARG_NAMES_MATCHER = RuboCop::NodePattern.new("(defs _ _ (:args $...) ...)")
+    INSTANCE_ARG_MATCHER = RuboCop::NodePattern.new("(def _ (:args $...) ...)")
+    PRIVATE_CLASS_ARG_MATCHER = RuboCop::NodePattern.new("(send _ :private_class_method (defs _ _ (:args $...) ...))")
+
+    def self.source(node, args, ret)
+      arg_names = arg_names(node)
+      arg_types = args.map { |arg| convert(arg) }.flatten
+      return nil unless arg_types.any? && arg_types.all?
+      return_types = convert(ret)
+      return format_source(arg_types, arg_names, return_types)
+    rescue AutoCorrectError => e
+      puts e.message
+      return nil
+    end
+
+    def self.format_source(arg_types, arg_names, return_types)
+      if arg_types.length == 1 && arg_types[0] == "None"
+        return format("sig { returns(%s) }", return_types)
+      else
+        params = arg_names.zip(arg_types).map do |arg, arg_type|
+          arg_name = CONTRACT_ARGS_PATTERN.match(arg).to_s
+          "#{arg_name}: #{arg_type}"
+        end.join(", ")
+        if return_types.nil?
+          return format("sig { params(%s).void }", params)
+        else
+          return format("sig { params(%s).returns(%s) }", params, return_types)
+        end
+      end
+    end
+
+    def self.arg_names(node)
+      sibling = node.parent.children[node.sibling_index + 1]
+      arg_names = ARG_NAMES_MATCHER.match(sibling)
+      arg_names ||= INSTANCE_ARG_MATCHER.match(sibling)
+      arg_names ||= PRIVATE_CLASS_ARG_MATCHER.match(sibling)
+      arg_names
+    end
+
+    def self.convert(src)
+      if CONST_PATTERN.match(src)
+        return map_const(CONST_PATTERN.match(src))
+      end
+      if TWO_CONST_PATTERN.match(src)
+        return map_consts(TWO_CONST_PATTERN.match(src))
+      end
+      if THREE_CONST_PATTERN.match(src)
+        return map_consts(THREE_CONST_PATTERN.match(src))
+      end
+      if FOUR_CONST_PATTERN.match(src)
+        return map_consts(FOUR_CONST_PATTERN.match(src))
+      end
+      if SEND_PATTERN.match(src)
+        send, rest = SEND_PATTERN.match(src)
+        send_value = map_send(convert(send))
+        if send_value == "KeywordArgs"
+          # For KeywordArgs we don't want to return the hash as the type;
+          # instead, the contents of the hash are the type.
+          return hash_entries(rest.first).map { |pair| convert(pair[1]) }
+        end
+        if send_value && rest
+          rest_string = rest.map { |part| convert(part) }.join(", ")
+          return format(send_value, rest_string)
+        end
+      end
+      if NIL_PATTERN.match(src)
+        return nil
+      end
+      if CONST_PAIR_MATCHER.match(src)
+        first, second = CONST_PAIR_MATCHER.match(src)
+        return format("%s, %s", first, second)
+      end
+      if HASH_PATTERN.match(src)
+        hash_vals = hash_entries(src).map { |match| "#{match[0]}: #{convert(match[1])}" }.join(", ")
+        return format("{%s}", hash_vals)
+      end
+      # Know we (at least) cannot handle literals
+      raise AutoCorrectError.new("Could not recognize source #{src}")
+    end
+
+    # Given a hash node, return a list of key,value
+    def self.hash_entries(hash)
+      HASH_PATTERN.match(hash).map { |part| PAIR_MATCHER.match(part) }
+    end
+
+    def self.map_consts(consts)
+      ret = consts.map(&:to_s).join("::")
+      map_const(ret)
+    end
+
+    # Map Contract classes to the Sorbet equivalent
+    def self.map_const(contracts_value)
+      case contracts_value.to_s
+      when "Boolean", "Bool", "Contracts::Bool"
+        return "T::Boolean"
+      when "Any", "Contracts::Any"
+        return "T.untyped"
+      when "Hash"
+        return "T::Hash"
+      when "Proc"
+        return "T.proc.void"
+      when "Contracts::Num"
+        return "Numeric"
+      when "Int", "Contracts::Int"
+        return "Integer"
+      else
+        contracts_value.to_s
+      end
+    end
+
+    # Map Contract functions and generic classes to the Sorbet equivalent
+    def self.map_send(contracts_value)
+      case contracts_value
+      when "Maybe", "Contracts::Maybe"
+        return "T.nilable(%s)"
+      when "ArrayOf", "Contracts::ArrayOf"
+        return "T::Array[%s]"
+      when "HashOf", "Contracts::HashOf"
+        return "T::Hash[%s]"
+      when "Or", "Contracts::Or"
+        return "T.any(%s)"
+      when "KeywordArgs"
+        # KeywordArgs is handled specifically
+        return "KeywordArgs"
+      when "Optional"
+        return "%s"
+      when "SetOf"
+        return "T::Set[%s]"
+      when "TryOf"
+        return "Try[%s]"
+      else
+        # Know we (at least) cannot handle Enum and KeywordArgs
+        raise AutoCorrectError.new("Could not recognize send value #{contracts_value}")
+      end
+    end
+  end
+end
+# rubocop:enable Style/FormatStringToken, Performance/RegexpMatch

--- a/lib/rubocop/sorbet_from_contract_service.rb
+++ b/lib/rubocop/sorbet_from_contract_service.rb
@@ -30,7 +30,6 @@ module Sorbet
       return_types = convert(ret)
       return format_source(arg_types, arg_names, return_types)
     rescue AutoCorrectError => e
-      puts e.message
       return nil
     end
 
@@ -120,7 +119,7 @@ module Sorbet
         return "T::Hash"
       when "Proc"
         return "T.proc.void"
-      when "Contracts::Num"
+      when "Num", "Contracts::Num"
         return "Numeric"
       when "Int", "Contracts::Int"
         return "Integer"

--- a/spec/cop/sorbet/no_dynamic_contract_includes_spec.rb
+++ b/spec/cop/sorbet/no_dynamic_contract_includes_spec.rb
@@ -1,0 +1,132 @@
+require "spec_helper"
+
+require_relative '../../../lib/rubocop/cop/sorbet/no_dynamic_contract_includes'
+
+RSpec.describe RuboCop::Cop::Sorbet::NoDynamicContractIncludes do
+  subject(:cop) { RuboCop::Cop::Sorbet::NoDynamicContractIncludes.new }
+
+  context "Fixes Dry::Types.module imports" do
+    describe "Detects include" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet disallows dynamic includes. Do not include Dry::Types.module directly; use direct path instead.
+            class Unit < Dry::Struct
+              attribute :name, Strict::Symbol
+                               ^^^^^^^^^^^^^^ Sorbet disallows dynamic includes. Use full Dry::Types path instead.
+              attribute :power, Strict::Int
+                                ^^^^^^^^^^^ Sorbet disallows dynamic includes. Use full Dry::Types path instead.
+            end
+          end
+        RUBY
+      end
+
+      it "adds offenses" do
+        expect_offense(source)
+      end
+    end
+
+    describe "Autocorrect works for objects" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord
+            def index_schema
+              {
+                booking_mode: Types::Strict::String,
+                on_date: Types::DateTime,
+                page: Types::Coercible::Int,
+                pages: Types::Array,
+                hash: Types::Hash.schema,
+              }
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord
+            def index_schema
+              {
+                booking_mode: Dry::Types["strict.string"],
+                on_date: Dry::Types["date_time"],
+                page: Dry::Types["coercible.int"],
+                pages: Dry::Types["array"],
+                hash: Dry::Types["hash"].schema,
+              }
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for attribute" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            class Unit < Dry::Struct
+              attribute :instance, Instance(CoolClass)
+              attribute :name, Strict::Symbol
+              attribute :power, Strict::Int
+              attribute :sweet, Dry::Types["strict.int"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            class Unit < Dry::Struct
+              attribute :instance, Dry::Types::Definition.new(CoolClass).constrained(type: CoolClass)
+              attribute :name, Dry::Types["strict.symbol"]
+              attribute :power, Dry::Types["strict.int"]
+              attribute :sweet, Dry::Types["strict.int"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for normal" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            SampleEnum = Strict::Symbol.enum(
+              :first,
+              :second,
+              :third
+            )
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            SampleEnum = Dry::Types["strict.symbol"].enum(
+              :first,
+              :second,
+              :third
+            )
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+  end
+end

--- a/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
+++ b/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
@@ -1,0 +1,709 @@
+require "spec_helper"
+
+require_relative "../../../lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts"
+
+RSpec.describe RuboCop::Cop::Sorbet::PreferSorbetOverContracts do
+  subject(:cop) { RuboCop::Cop::Sorbet::PreferSorbetOverContracts.new }
+
+  context "Fixes Contracts" do
+    describe "Auto-correct works for constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            include Contracts::Core
+            include Contracts::Builtin
+
+            def self.dummy
+              'will'
+            end
+
+            Contract Integer => AirProcurement::AllotmentEntity
+            def self.number_is_even(num)
+              return false
+            end
+
+            Contract A::B::C => D::E::F
+            def self.three_args(abc)
+              return false
+            end
+
+            Contract A::B::C::D => D::E::F::G
+            def self.four_args(abcd)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            include Contracts::Core
+            include Contracts::Builtin
+
+            def self.dummy
+              'will'
+            end
+
+            sig { params(num: Integer).returns(AirProcurement::AllotmentEntity) }
+            def self.number_is_even(num)
+              return false
+            end
+
+            sig { params(abc: A::B::C).returns(D::E::F) }
+            def self.three_args(abc)
+              return false
+            end
+
+            sig { params(abcd: A::B::C::D).returns(D::E::F::G) }
+            def self.four_args(abcd)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Auto-corrects none" do
+      let(:source) do
+        <<~RUBY
+          class Example < ExampleBase
+            Contract Or[Time, DateTime] => Or[Time, DateTime]
+            def self.cool_thing(time)
+              return "will"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example < ExampleBase
+            extend T::Sig
+            sig { params(time: T.any(Time, DateTime)).returns(T.any(Time, DateTime)) }
+            def self.cool_thing(time)
+              return "will"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Auto-corrects none" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract None => String
+            def self.cool_thing
+              return "will"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { returns(String) }
+            def self.cool_thing
+              return "will"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Auto-corrects void" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract String => nil
+            def self.cool_thing(str)
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(str: String).void }
+            def self.cool_thing(str)
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for two constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Integer, Boolean => String
+            def self.cool_thing(number, bool)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(number: Integer, bool: T::Boolean).returns(String) }
+            def self.cool_thing(number, bool)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for private class methods" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract OperationalRoute::Graph, Integer, User => Result
+            private_class_method def self.find_or_create_warehouse_node(graph, warehouse_id, updated_by)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(graph: OperationalRoute::Graph, warehouse_id: Integer, updated_by: User).returns(Result) }
+            private_class_method def self.find_or_create_warehouse_node(graph, warehouse_id, updated_by)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for five constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Integer, Boolean, String, Date, Integer  => String
+            def self.cool_thing(number, bool, string, date, integer)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(number: Integer, bool: T::Boolean, string: String, date: Date, integer: Integer).returns(String) }
+            def self.cool_thing(number, bool, string, date, integer)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for maybe and array" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Maybe[Integer], Maybe[Boolean] => ArrayOf[String]
+            def self.cool_thing(integers, booleans)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(integers: T.nilable(Integer), booleans: T.nilable(T::Boolean)).returns(T::Array[String]) }
+            def self.cool_thing(integers, booleans)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for nested sends" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Maybe[Air::Man], Maybe[ArrayOf[String]] => Maybe[ArrayOf[Red::Sox]]
+            def cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(jordan: T.nilable(Air::Man), strings: T.nilable(T::Array[String])).returns(T.nilable(T::Array[Red::Sox])) }
+            def cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrect works for hashes" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract HashOf[String, Any], HashOf[String, Chris::Sale] => Maybe[HashOf[String, Red::Sox]]
+            def self.cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(jordan: T::Hash[String, T.untyped], strings: T::Hash[String, Chris::Sale]).returns(T.nilable(T::Hash[String, Red::Sox])) }
+            def self.cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Fixes KeywordArgs" do
+      let(:src) do
+        <<~RUBY
+          class Example
+            Contract KeywordArgs[pats: Maybe[Tom::Brady], sox: Maybe[Big::Papi]] => ArrayOf[Gronk]
+            def self.cool_thing(pats: nil, sox: nil)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(pats: T.nilable(Tom::Brady), sox: T.nilable(Big::Papi)).returns(T::Array[Gronk]) }
+            def self.cool_thing(pats: nil, sox: nil)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Leaves Enums alone" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract ArrayOf[Enum[*PERMITTED_KEYS]] => Maybe[String]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            Contract ArrayOf[Enum[*PERMITTED_KEYS]] => Maybe[String]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrects full path ArrayOf" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract String => Contracts::ArrayOf[ContainerUse]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            def self.buffer
+              nil
+            end
+
+            sig { params(key: String).returns(T::Array[ContainerUse]) }
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrects with param default values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract String, Maybe[Hash] => Bool
+            def self.cool_thing(key = "cool", hash = nil)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(key: String, hash: T.nilable(T::Hash)).returns(T::Boolean) }
+            def self.cool_thing(key = "cool", hash = nil)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Auto-correct works for constants" do
+      let(:source) do
+        <<~RUBY
+          module Outer
+            class Example
+              include Contracts::Core
+              include Contracts::Builtin
+
+              Contract Integer => AirProcurement::AllotmentEntity
+              def self.number_is_even(num)
+                return false
+              end
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          module Outer
+            class Example
+              extend T::Sig
+              include Contracts::Core
+              include Contracts::Builtin
+
+              sig { params(num: Integer).returns(AirProcurement::AllotmentEntity) }
+              def self.number_is_even(num)
+                return false
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Autocorrects with mixed param default values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Maybe[CompanyEntity], Maybe[CompanyEntity], Integer => ArrayOf[ShippingInstruction]
+            def self.historic_shipper_shipping_instructions(shipper, consignee, number_of_record: DEFAULT_NUMBER_HISTORIC_RECORD)
+              return []
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(shipper: T.nilable(CompanyEntity), consignee: T.nilable(CompanyEntity), number_of_record: Integer).returns(T::Array[ShippingInstruction]) }
+            def self.historic_shipper_shipping_instructions(shipper, consignee, number_of_record: DEFAULT_NUMBER_HISTORIC_RECORD)
+              return []
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Does not change literal values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract Or["scheduled", "actual"] => Any
+            def self.cool_thing(key)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract Or["scheduled", "actual"] => Any
+            def self.cool_thing(key)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Handles &block param" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Maybe[String], Proc => Any
+            def with_frontend_context(event_source, &block)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(event_source: T.nilable(String), block: T.proc.void).returns(T.untyped) }
+            def with_frontend_context(event_source, &block)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Handles => syntax" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract None => HashOf[String => Integer]
+            def with_frontend_context
+              return {}
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { returns(T::Hash[String, Integer]) }
+            def with_frontend_context
+              return {}
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Handles shapes" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract ArrayOf[
+                 {
+                   "place_id" => Or[Num, String],
+                   "tags_list" => ArrayOf[String],
+                 }
+             ],
+            String => Maybe[Num]
+            def with_frontend_context(arr, num)
+              return 1
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(arr: T::Array[{place_id: T.any(Num, String), tags_list: T::Array[String]}], num: String).returns(T.nilable(Num)) }
+            def with_frontend_context(arr, num)
+              return 1
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Handles Contract::" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Contracts::Bool, Contracts::Maybe[Contracts::Num] => Contracts::Any
+            def with_frontend_context(bool, num)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(bool: T::Boolean, num: T.nilable(Numeric)).returns(T.untyped) }
+            def with_frontend_context(bool, num)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+
+    describe "Handles Contract::" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract String, {from_warehouse: Contracts::Bool, cool: String} => {result: {errors: Contracts::ArrayOf[String]}}
+            def self.generate_deliveries_report(email, from_warehouse:)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(email: String, from_warehouse: {from_warehouse: T::Boolean, cool: String}).returns({result: {errors: T::Array[String]}}) }
+            def self.generate_deliveries_report(email, from_warehouse:)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to eq(fixed_source)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a couple of Rubocop rules/auto-corrections that we've used with good results at Flexport.

`PreferSorbetOverContracts`: forbids the creation of new [`Contract`s](https://github.com/egonSchiele/contracts.ruby) in favor of Sorbet signatures. Additionally, can convert most existing Contracts into Sorbet signatures automatically.

`NoDynamicContractIncludes`: the [`Dry::Types`](https://github.com/dry-rb/dry-types) library makes frequent use of dynamic includes to populate the name space with its types; so you use `include Dry::Types.module` and then can access `Strict::Int` or `Types::Array`. Since Sorbet does not allow dynamic includes, forbid this pattern. The Cop can also automatically remove the `include`s and replace with the static path IE `Dry::Types["strict.int"]` 