### PR TITLE
Add `on_failure` to signature build order cop

### DIFF
--- a/lib/rubocop/cop/sorbet/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signature_build_order.rb
@@ -24,6 +24,7 @@ module RuboCop
             :overridable,
             :soft,
             :checked,
+            :on_failure,
           ].each_with_index.to_h.freeze
 
         def_node_matcher(:signature?, <<~PATTERN)


### PR DESCRIPTION
This cop was raising exceptions on files with `on_failure`, due to `nil` comparisons in the `sort_by` on line 44. Adding the symbol to the ORDER hash fixes this.