### PR TITLE
Introduce `EnforceSignatures` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,6 @@
 Sorbet/ValidSigil:
   Enabled: true
   EnforcedStyle: typed_files
+
+Sorbet/EnforceSignatures:
+  Enabled: true

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'stringio'
+require_relative 'signature_cop'
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop checks that every method definition and attribute accessor has a Sorbet signature.
+      #
+      # It also suggest an autocorrect with placeholders so the following code:
+      #
+      # ```
+      # def foo(a, b, c); end
+      # ```
+      #
+      # Will be corrected as:
+      #
+      # ```
+      # sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped)
+      # def foo(a, b, c); end
+      # ```
+      #
+      # You can configure the placeholders used by changing the following options:
+      #
+      # * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
+      # * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
+      class EnforceSignatures < SignatureCop
+        def_node_matcher(:accessor?, <<-PATTERN)
+          (send nil? {:attr_reader :attr_writer :attr_accessor} ...)
+        PATTERN
+
+        def on_def(node)
+          check_node(node)
+        end
+
+        def on_defs(node)
+          check_node(node)
+        end
+
+        def on_send(node)
+          return unless accessor?(node)
+          check_node(node)
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            suggest = SigSuggestion.new(node.loc.column, param_type_placeholder, return_type_placeholder)
+
+            if node.is_a?(RuboCop::AST::DefNode) # def something
+              node.arguments.each do |arg|
+                suggest.params << arg.children.first
+              end
+            elsif accessor?(node) # attr reader, writer, accessor
+              method = node.children[1]
+              symbol = node.children[2]
+              suggest.params << symbol.value if symbol && (method == :attr_writer || method == :attr_accessor)
+              suggest.returns = 'void' if method == :attr_writer
+            end
+
+            corrector.insert_before(node.loc.expression, suggest.to_autocorrect)
+          end
+        end
+
+        private
+
+        def check_node(node)
+          prev = previous_node(node)
+          unless signature?(prev)
+            add_offense(
+              node,
+              message: "Each method is required to have a signature."
+            )
+          end
+        end
+
+        def previous_node(node)
+          parent = node.parent
+          return nil unless parent
+          parent.children[node.sibling_index - 1]
+        end
+
+        def param_type_placeholder
+          cop_config['ParameterTypePlaceholder'] || 'T.untyped'
+        end
+
+        def return_type_placeholder
+          cop_config['ReturnTypePlaceholder'] || 'T.untyped'
+        end
+
+        class SigSuggestion
+          attr_accessor :params, :returns
+
+          def initialize(indent, param_placeholder, return_placeholder)
+            @params = []
+            @returns = nil
+            @indent = indent
+            @param_placeholder = param_placeholder
+            @return_placeholder = return_placeholder
+          end
+
+          def to_autocorrect
+            out = StringIO.new
+            out << 'sig { '
+            out << generate_params
+            out << generate_return
+            out << " }\n"
+            out << ' ' * @indent # preserve indent for the next line
+            out.string
+          end
+
+          private
+
+          def generate_params
+            return if @params.empty?
+            out = StringIO.new
+            out << 'params('
+            out << @params.map do |param|
+              "#{param}: #{@param_placeholder}"
+            end.join(", ")
+            out << ').'
+            out.string
+          end
+
+          def generate_return
+            return "returns(#{@return_placeholder})" if @returns.nil?
+            return @returns if @returns == 'void'
+            "returns(#{@returns})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop_sorbet.rb
+++ b/lib/rubocop_sorbet.rb
@@ -10,6 +10,7 @@ require_relative 'rubocop/cop/sorbet/signatures/checked_true_in_signature'
 require_relative 'rubocop/cop/sorbet/signatures/keyword_argument_ordering'
 require_relative 'rubocop/cop/sorbet/signatures/parameters_ordering_in_signature'
 require_relative 'rubocop/cop/sorbet/signatures/signature_build_order'
+require_relative 'rubocop/cop/sorbet/signatures/enforce_signatures'
 
 require_relative 'rubocop/cop/sorbet/sigils/valid_sigil'
 require_relative 'rubocop/cop/sorbet/sigils/has_sigil'

--- a/spec/cop/sorbet/signatures/enforce_signatures_spec.rb
+++ b/spec/cop/sorbet/signatures/enforce_signatures_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../../lib/rubocop/cop/sorbet/signatures/enforce_signatures'
+
+RSpec.describe(RuboCop::Cop::Sorbet::EnforceSignatures, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe('require a signature for each method') do
+    it 'makes no offense if a top-level method has a signature' do
+      expect_no_offenses(<<~RUBY)
+        sig { void }
+        def foo; end
+      RUBY
+    end
+
+    it 'makes offense if a top-level method has no signature' do
+      expect_offense(<<~RUBY)
+        def foo; end
+        ^^^^^^^^^^^^ Each method is required to have a signature.
+      RUBY
+    end
+
+    it 'does not check signature validity' do # Validity will be checked by Sorbet
+      expect_no_offenses(<<~RUBY)
+        sig { foo(bar).baz }
+        def foo; end
+      RUBY
+    end
+
+    it 'makes no offense if a method has a signature' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          sig { void }
+          def foo1; end
+        end
+      RUBY
+    end
+
+    it 'makes offense if a method has no signature' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def foo; end
+          ^^^^^^^^^^^^ Each method is required to have a signature.
+        end
+      RUBY
+    end
+
+    it 'makes no offense if a singleton method has a signature' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          sig { void }
+          def self.foo1; end
+        end
+      RUBY
+    end
+
+    it 'makes offense if a singleton method has no signature' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def self.foo; end
+          ^^^^^^^^^^^^^^^^^ Each method is required to have a signature.
+        end
+      RUBY
+    end
+
+    it 'makes no offense if an accessor has a signature' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          sig { returns(String) }
+          attr_reader :foo
+          sig { params(bar: String).void }
+          attr_writer :bar
+          sig { params(bar: String).returns(String) }
+          attr_accessor :baz
+        end
+      RUBY
+    end
+
+    it 'makes offense if an accessor has no signature' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr_reader :foo
+          ^^^^^^^^^^^^^^^^ Each method is required to have a signature.
+          attr_writer :bar
+          ^^^^^^^^^^^^^^^^ Each method is required to have a signature.
+          attr_accessor :baz
+          ^^^^^^^^^^^^^^^^^^ Each method is required to have a signature.
+        end
+      RUBY
+    end
+
+    it 'does not check the signature for accessors' do # Validity will be checked by Sorbet
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          sig { void }
+          attr_reader :foo, :bar
+        end
+      RUBY
+    end
+
+    shared_examples_for('autocorrect with config') do
+      it('autocorrects methods by adding signature stubs') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            def foo; end
+            def bar(a, b = 2, c: Foo.new); end
+            def baz(&blk); end
+            def self.foo(a, b, &c); end
+            def self.bar(a, *b, **c); end
+            def self.baz(a:); end
+          RUBY
+        ).to(eq(<<~RUBY))
+          sig { returns(T.untyped) }
+          def foo; end
+          sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped) }
+          def bar(a, b = 2, c: Foo.new); end
+          sig { params(blk: T.untyped).returns(T.untyped) }
+          def baz(&blk); end
+          sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped) }
+          def self.foo(a, b, &c); end
+          sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped) }
+          def self.bar(a, *b, **c); end
+          sig { params(a: T.untyped).returns(T.untyped) }
+          def self.baz(a:); end
+          RUBY
+      end
+
+      it('autocorrects accessors by adding signature stubs') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            class Foo
+              attr_reader :foo
+              attr_writer :bar
+              attr_accessor :baz
+            end
+          RUBY
+        ).to(eq(<<~RUBY))
+          class Foo
+            sig { returns(T.untyped) }
+            attr_reader :foo
+            sig { params(bar: T.untyped).void }
+            attr_writer :bar
+            sig { params(baz: T.untyped).returns(T.untyped) }
+            attr_accessor :baz
+          end
+          RUBY
+      end
+    end
+
+    describe('autocorrect') do
+      it_should_behave_like 'autocorrect with config'
+    end
+
+    describe('autocorrect with default values') do
+      let(:cop_config) do
+        {
+          'Enabled' => true,
+          'ParameterTypePlaceholder' => 'T.untyped',
+          'ReturnTypePlaceholder' => 'T.untyped',
+        }
+      end
+      it_should_behave_like 'autocorrect with config'
+    end
+
+    describe('autocorrect with custom values') do
+      let(:cop_config) do
+        {
+          'Enabled' => true,
+          'ParameterTypePlaceholder' => 'PARAM',
+          'ReturnTypePlaceholder' => 'RET',
+        }
+      end
+
+      it('autocorrects methods by adding signature stubs') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            def foo; end
+            def bar(a, b = 2, c: Foo.new); end
+            def baz(&blk); end
+
+            class Foo
+              def foo
+              end
+
+              def bar(a, b, c)
+              end
+            end
+          RUBY
+        ).to(eq(<<~RUBY))
+          sig { returns(RET) }
+          def foo; end
+          sig { params(a: PARAM, b: PARAM, c: PARAM).returns(RET) }
+          def bar(a, b = 2, c: Foo.new); end
+          sig { params(blk: PARAM).returns(RET) }
+          def baz(&blk); end
+
+          class Foo
+            sig { returns(RET) }
+            def foo
+            end
+
+            sig { params(a: PARAM, b: PARAM, c: PARAM).returns(RET) }
+            def bar(a, b, c)
+            end
+          end
+          RUBY
+      end
+
+      it('autocorrects accessors by adding signature stubs') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            class Foo
+              attr_reader :foo
+              attr_writer :bar
+              attr_accessor :baz
+            end
+          RUBY
+        ).to(eq(<<~RUBY))
+          class Foo
+            sig { returns(RET) }
+            attr_reader :foo
+            sig { params(bar: PARAM).void }
+            attr_writer :bar
+            sig { params(baz: PARAM).returns(RET) }
+            attr_accessor :baz
+          end
+          RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop checks that every method definition and attribute accessor has a Sorbet signature.

It also suggest an autocorrect with placeholders so the following code:

```
def foo(a, b, c); end
```

Will be corrected as:

```
sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped)
def foo(a, b, c); end
```

You can configure the placeholders used by changing the following options:

* `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
* `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')

Note: the first 3 commits belongs to #12 you should focus only on commit 3a104f2.