### PR TITLE
Support for new `T.type_alias {}` syntax

### DIFF
--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -14,18 +14,18 @@ module RuboCop
       #   FooOrBar = T.any(Foo, Bar)
       #
       #   # good
-      #   FooOrBar = T.type_alias(T.any(Foo, Bar))
+      #   FooOrBar = T.type_alias { T.any(Foo, Bar) }
       class BindingConstantWithoutTypeAlias < RuboCop::Cop::Cop
         def_node_matcher(:binding_unaliased_type?, <<-PATTERN)
           (casgn _ _ [#not_nil? #not_t_let? #method_needing_aliasing_on_t?])
         PATTERN
 
         def_node_matcher(:using_type_alias?, <<-PATTERN)
-          (
-            send
-            (const nil? :T)
-            :type_alias
-            _
+          (block
+            (send
+              (const nil? :T) :type_alias)
+              _
+              _
           )
         PATTERN
 
@@ -69,7 +69,7 @@ module RuboCop
           lambda do |corrector|
             corrector.replace(
               node.source_range,
-              "T.type_alias(#{node.source})"
+              "T.type_alias { #{node.source} }"
             )
           end
         end

--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -71,7 +71,9 @@ module RuboCop
             add_offense(
               node.children[2],
               message: "It looks like you're using the old `T.type_alias` syntax. " \
-              '`T.type_alias` now expects a block.'
+              '`T.type_alias` now expects a block.' \
+              'Run Sorbet with the options "--autocorrect --error-white-list=5043" ' \
+              'to automatically upgrade to the new syntax.'
             )
             return
           end

--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -84,14 +84,6 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            if using_deprecated_type_alias_syntax?(node)
-              corrector.replace(
-                node.source_range,
-                "T.type_alias { #{node.children[2].source} }"
-              )
-              return
-            end
-
             corrector.replace(
               node.source_range,
               "T.type_alias { #{node.source} }"

--- a/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
 
   def deprecation
     "It looks like you're using the old `T.type_alias` syntax. " \
-    '`T.type_alias` now expects a block.'
+    '`T.type_alias` now expects a block.' \
+    'Run Sorbet with the options "--autocorrect --error-white-list=5043" ' \
+    'to automatically upgrade to the new syntax.'
   end
 
   describe('offenses') do

--- a/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -118,10 +118,5 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
             ^^^^^^^^^^^^^^^^^^^^^^^^^ #{deprecation}
       RUBY
     end
-
-    it('autocorrects to the new `T.type_alias` block syntax') do
-      expect(autocorrect_source('Foo = T.type_alias(T.any(String, Integer))'))
-        .to(eq('Foo = T.type_alias { T.any(String, Integer) }'))
-    end
   end
 end

--- a/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
 
     it('allows binding the return of T.any, T.all, etc when using T.type_alias') do
       expect_no_offenses(<<~RUBY)
-        A = T.type_alias(T.any(String, Integer))
-        B = T.type_alias(T.all(String, Integer))
-        C = T.type_alias(T.noreturn)
-        D = T.type_alias(T.class_of(String))
-        E = T.type_alias(T.proc.void)
-        F = T.type_alias(T.untyped)
-        G = T.type_alias(T.nilable(String))
-        H = T.type_alias(T.self_type)
+        A = T.type_alias { T.any(String, Integer) }
+        B = T.type_alias { T.all(String, Integer) }
+        C = T.type_alias { T.noreturn }
+        D = T.type_alias { T.class_of(String) }
+        E = T.type_alias { T.proc.void }
+        F = T.type_alias { T.untyped }
+        G = T.type_alias { T.nilable(String) }
+        H = T.type_alias { T.self_type }
       RUBY
     end
 
@@ -84,7 +84,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
 
     it('autocorrects to T.type_alias') do
       expect(autocorrect_source('Foo = T.any(String, Integer)'))
-        .to(eq('Foo = T.type_alias(T.any(String, Integer))'))
+        .to(eq('Foo = T.type_alias { T.any(String, Integer) }'))
     end
 
     it("doesn't crash when assigning constants by destructuring") do


### PR DESCRIPTION
This PR updates the `BindingConstantWithoutTypeAlias` cop so it accepts the block syntax for `T.type_alias`.

I also added a custom error when the cop detects the old syntax and an autocorrect to the new block syntax so:

```ruby
Foo = T.type_alias(T.any(String, Integer))
```

Is autocorrected to:

```ruby
Foo = T.type_alias { T.any(String, Integer) }
```

Fixes #15.

cc. @ghiculescu.