### PR TITLE
Accept splats after default keyword parameters

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/keyword_argument_ordering.rb
+++ b/lib/rubocop/cop/sorbet/signatures/keyword_argument_ordering.rb
@@ -35,7 +35,7 @@ module RuboCop
           out_of_kwoptarg = false
 
           parameters.reverse.each do |param|
-            out_of_kwoptarg = true unless param.type == :kwoptarg || param.type == :blockarg
+            out_of_kwoptarg = true unless param.type == :kwoptarg || param.type == :blockarg || param.type == :kwrestarg
 
             next unless param.type == :kwoptarg && out_of_kwoptarg
 

--- a/spec/cop/sorbet/signatures/keyword_argument_ordering_spec.rb
+++ b/spec/cop/sorbet/signatures/keyword_argument_ordering_spec.rb
@@ -28,4 +28,32 @@ RSpec.describe(RuboCop::Cop::Sorbet::KeywordArgumentOrdering, :config) do
       def foo; end
     RUBY
   end
+
+  it('does not add offense when splats are after keyword parameters') do
+    expect_no_offenses(<<~RUBY)
+      sig { params(a: String, b: Integer, c: String, d: Integer).void }
+      def foo(a, b:, c:, **d); end
+    RUBY
+  end
+
+  it('does not add offense when splats are after optional keyword parameters') do
+    expect_no_offenses(<<~RUBY)
+      sig { params(a: String, b: Integer, c: String, d: Integer).void }
+      def foo(a, b: 1, c: 'a', **d); end
+    RUBY
+  end
+
+  it('does not add offense when there is only a splat') do
+    expect_no_offenses(<<~RUBY)
+      sig { params(a: String).void }
+      def foo(**a); end
+    RUBY
+  end
+
+  it('does not add offense when there is a splat after a standard parameter') do
+    expect_no_offenses(<<~RUBY)
+      sig { params(a: String, b: Integer).void }
+      def foo(a, **b); end
+    RUBY
+  end
 end

--- a/spec/cop/sorbet/signatures/keyword_argument_ordering_spec.rb
+++ b/spec/cop/sorbet/signatures/keyword_argument_ordering_spec.rb
@@ -56,4 +56,12 @@ RSpec.describe(RuboCop::Cop::Sorbet::KeywordArgumentOrdering, :config) do
       def foo(a, **b); end
     RUBY
   end
+
+  it('adds offense when optional arguments are after default ones and there is a splat') do
+    expect_offense(<<~RUBY)
+      sig { params(a: String, b: Integer, c: String, d: Integer).void }
+      def foo(a, b: 1, c:, **d); end
+                 ^^^^ Optional keyword arguments must be at the end of the parameter list.
+    RUBY
+  end
 end


### PR DESCRIPTION
As raised by @Mangara:

This snippet should not raise any error:

```ruby
sig { params(a: String, b: Integer, c: String, d: Integer).void }
def foo(a, b: 1, c: 'a', **d); end
```

This PR fixes the `KeywordArgumentOrdering` cop so those constructs are accepted (see [`tests`](https://github.com/Shopify/rubocop-sorbet/commit/0dd142436efeb72801f820b38c8be9eae10d5471#diff-fd5be9f30e2845592e2bfae314bfd456) for more details).