### PR TITLE
Use the higher of `Suggested` and `Minimum` strictness when autocorrecting

### DIFF
--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -142,12 +142,12 @@ module RuboCop
 
         # Default is `'false'`
         def suggested_strictness
-          cop_config['SuggestedStrictness'] || 'false'
+          STRICTNESS_LEVELS.include?(cop_config['SuggestedStrictness']) ? cop_config['SuggestedStrictness'] : 'false'
         end
 
         # Default is `nil`
         def minimum_strictness
-          cop_config['MinimumStrictness']
+          cop_config['MinimumStrictness'] if STRICTNESS_LEVELS.include?(cop_config['MinimumStrictness'])
         end
       end
     end

--- a/spec/cop/sorbet/sigils/valid_sigil_spec.rb
+++ b/spec/cop/sorbet/sigils/valid_sigil_spec.rb
@@ -205,4 +205,80 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSigil, :config) do
       RUBY
     end
   end
+
+  describe('SuggestedStrictness: true, MinimumStrictness: false') do
+    let(:cop_config) do
+      {
+        'Enabled' => true,
+        'RequireSigilOnAllFiles' => true,
+        'MinimumStrictness' => 'false',
+        'SuggestedStrictness' => 'true',
+      }
+    end
+    it_should_behave_like 'offense for an invalid sigil'
+
+    it 'suggest the default strictness if the sigil is missing' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ No Sorbet sigil found in file. Try a `typed: true` to start (you can also use `rubocop -a` to automatically add this).
+        class Foo; end
+      RUBY
+    end
+
+    describe('autocorrect') do
+      it_should_behave_like 'no autocorrect on files with sigil'
+
+      it('autocorrects by adding typed: true to file without sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # typed: true
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+      end
+    end
+  end
+
+  describe('SuggestedStrictness: false, MinimumStrictness: ignore') do
+    let(:cop_config) do
+      {
+        'Enabled' => true,
+        'RequireSigilOnAllFiles' => true,
+        'MinimumStrictness' => 'ignore',
+        'SuggestedStrictness' => 'false',
+      }
+    end
+    it_should_behave_like 'offense for an invalid sigil'
+
+    it 'suggest the default strictness if the sigil is missing' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ No Sorbet sigil found in file. Try a `typed: false` to start (you can also use `rubocop -a` to automatically add this).
+        class Foo; end
+      RUBY
+    end
+
+    describe('autocorrect') do
+      it_should_behave_like 'no autocorrect on files with sigil'
+
+      it('autocorrects by adding typed: false to file without sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # typed: false
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+      end
+    end
+  end
 end

--- a/spec/cop/sorbet/sigils/valid_sigil_spec.rb
+++ b/spec/cop/sorbet/sigils/valid_sigil_spec.rb
@@ -281,4 +281,42 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSigil, :config) do
       end
     end
   end
+
+  describe('SuggestedStrictness: invalid_value, MinimumStrictness: true') do
+    let(:cop_config) do
+      {
+        'Enabled' => true,
+        'RequireSigilOnAllFiles' => true,
+        'MinimumStrictness' => 'true',
+        'SuggestedStrictness' => 'invalid_value',
+      }
+    end
+    it_should_behave_like 'offense for an invalid sigil'
+
+    it 'suggest the default strictness if the sigil is missing' do
+      expect_offense(<<~RUBY)
+        # frozen_string_literal: true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ No Sorbet sigil found in file. Try a `typed: true` to start (you can also use `rubocop -a` to automatically add this).
+        class Foo; end
+      RUBY
+    end
+
+    describe('autocorrect') do
+      it_should_behave_like 'no autocorrect on files with sigil'
+
+      it('autocorrects by adding typed: true to file without sigil') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            # typed: true
+            # frozen_string_literal: true
+            class Foo; end
+          RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
We want to use config like this:

```yml
Sorbet/FalseSigil:
  Enabled: true
  SuggestedStrictness: true
```

So that we can require at least a `false` sigil on *all* files, but add `typed: true` to new files. This way we know that Sorbet adoption will go up over time as new files are added (we have a separate Danger rule that warns against downgrading a file's type).

This PR adds the ability to do that, by choosing the higher level out of the suggested and minimum levels when autocorrecting. There is a special case when you are using `ignore` as your minimum level in which this doesn't take place, I did this rather than change existing specs so as to not create a breaking change.