### PR TITLE
Reorder sig builders

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -15,13 +15,13 @@ module RuboCop
       class SignatureBuildOrder < SignatureCop
         ORDER =
           [
+            :abstract,
+            :override,
+            :overridable,
             :type_parameters,
             :params,
             :returns,
             :void,
-            :abstract,
-            :override,
-            :overridable,
             :soft,
             :checked,
             :on_failure,

--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -20,7 +20,6 @@ module RuboCop
             :returns,
             :void,
             :abstract,
-            :implementation,
             :override,
             :overridable,
             :soft,

--- a/spec/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -10,26 +10,26 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
   describe('offenses') do
     it('allows the correct order') do
       expect_no_offenses(<<~RUBY)
-        sig { params(x: Integer).returns(Integer).abstract }
+        sig { abstract.params(x: Integer).returns(Integer) }
 
         sig { params(x: Integer).void }
 
-        sig { void.abstract }
+        sig { abstract.void }
 
         sig { void.soft }
 
-        sig { void.override.checked(false) }
+        sig { override.void.checked(false) }
 
-        sig { void.overridable }
+        sig { overridable.void }
       RUBY
     end
 
     it('allows using multiline sigs') do
       expect_no_offenses(<<~RUBY)
         sig do
-          params(x: Integer)
+          abstract
+            .params(x: Integer)
             .returns(Integer)
-            .abstract
         end
       RUBY
     end

--- a/spec/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
 
         sig { void.abstract }
 
-        sig { void.implementation.soft }
+        sig { void.soft }
 
         sig { void.override.checked(false) }
 


### PR DESCRIPTION
This PR reorders the signature builders to put inheritance modifiers first.

My rationale is that `abstract`/`override`/`overridable` is the first thing you want to see about a method so you know that the signature is related to a parent class or an included module.

I also removed the `implementation` signature builder that has been removed from Sorbet a few months ago.