### PR TITLE
Add Contracts and DryTypes Includes Rubocop Rules

### DIFF
--- a/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
+++ b/lib/rubocop/cop/sorbet/no_dynamic_contract_includes.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+#
+# In preparation for adding Sorbet to the codebase we must remove all dynamic imports as these
+# make type checking impossible. The biggest single offender in our codebase is `Dry::Types.module`
+# which includes all the types like Strict::String, Coercible::Int, Types::Bool, etc.
+#
+# Instead of using these auto-magic includes, we must use ths static path. In most cases this is
+# can be done automatically by this class, so:
+#
+# Strict::String -> Dry::Types['strict.string']
+# Coercible::Int -> Dry::Types['coercible.string']
+# Types::Bool -> Dry::Types['bool']
+# Strict::Array.of(Strict::String) -> Dry::Types["strict.array"].of
+# Strict::DateTime -> Dry::Types["strict.date_time"]
+# Instance(Carrier) -> Dry::Types::Definition.new(Carrier).constrained(type: Carrier)
+#
+# Some were not automate-able and must be done manually. These are:
+#
+# Any -> Dry::Types::Any
+# Hash -> Dry::Types["hash"]
+# Nil -> Dry::Types["nil"]
+#
+module RuboCop
+  module Cop
+    module Sorbet
+      class NoDynamicContractIncludes < Cop
+        MSG = "Sorbet disallows dynamic includes. Do not include Dry::Types.module directly; use direct path instead."
+        MSG_PATH = "Sorbet disallows dynamic includes. Use full Dry::Types path instead."
+
+        def_node_matcher :include_statement, <<-PATTERN
+          (send _ :include (send (const (const _ :Dry) :Types) _))
+        PATTERN
+
+        def_node_matcher :instance_statement, <<-PATTERN
+          (send _ :Instance (const ...))
+        PATTERN
+
+        def_node_matcher :const_statement, <<-PATTERN
+          (const (const _ {:Strict :Coercible}) _)
+        PATTERN
+
+        def_node_matcher :types_statement, <<-PATTERN
+          (const (const _ :Types) {:DateTime :String :Bool :Array :Int :Hash :Date})
+        PATTERN
+
+        def on_const(node)
+          types_statement(node) do |_statement|
+            add_offense(node, message: MSG_PATH)
+          end
+          const_statement(node) do |_statement|
+            add_offense(node, message: MSG_PATH)
+          end
+        end
+
+        def on_send(node)
+          instance_statement(node) do |_statement|
+            add_offense(node, message: MSG)
+          end
+          include_statement(node) do |_statement|
+            add_offense(node, message: MSG)
+          end
+        end
+
+        DYNAMIC_REFERENCE_PATTERN = NodePattern.new("$(const (const _ ${:Strict :Coercible}) $_)")
+        INSTANCE_PATTERN = NodePattern.new("$(send _ :Instance (const _ $_))")
+        TYPES_PATTERN = NodePattern.new("$(const (const _ :Types) ${:DateTime :String :Bool :Array :Int :Hash :Date})")
+
+        def autocorrect(node)
+          if DYNAMIC_REFERENCE_PATTERN.match(node)
+            correct_dynamic_class_reference(node)
+          elsif INSTANCE_PATTERN.match(node)
+            correct_instance_class_reference(node)
+          elsif TYPES_PATTERN.match(node)
+            correct_types_reference(node)
+          end
+        end
+
+        def klass_to_str(klass)
+          klass_str = klass.to_s.downcase
+          if klass_str == "datetime"
+            "date_time"
+          else
+            klass_str
+          end
+        end
+
+        def correct_types_reference(node)
+          full_source, klass = TYPES_PATTERN.match(node)
+          klass_str = klass_to_str(klass)
+          new_source = format("Dry::Types[\"%s\"]", klass_str)
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+
+        def correct_instance_class_reference(node)
+          full_source, klass = INSTANCE_PATTERN.match(node)
+          klass_str = klass.to_s
+          new_source = format("Dry::Types::Definition.new(%s).constrained(type: %s)", klass_str, klass_str)
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+
+        def correct_dynamic_class_reference(node)
+          full_source, strictness, primitive = DYNAMIC_REFERENCE_PATTERN.match(node)
+          strictness_str = strictness.to_s.downcase
+          primitive_str = klass_to_str(primitive)
+          new_source = format("Dry::Types[\"%s.%s\"]", strictness_str, primitive_str)
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
+++ b/lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative "../../sorbet_from_contract_service.rb"
+module RuboCop
+  module Cop
+    module Sorbet
+      class PreferSorbetOverContracts < Cop
+        MSG = "Instead of Contracts use Sorbet signatures."
+
+        def_node_matcher :contract_statement, <<-PATTERN
+          (send _ :Contract ...)
+        PATTERN
+
+        def on_send(node)
+          contract_statement(node) do |statement|
+            add_offense(node, message: format(MSG, statement: statement))
+          end
+        end
+
+        CONTRACT_PATTERN = NodePattern.new("$(send _ :Contract $... (:hash (:pair $_ $_)))")
+        SHORTHAND_CONTRACT_PATTERN = NodePattern.new("$(send _ :Contract $_)")
+        EXTEND_T_SIG_PATTERN = NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
+
+        def autocorrect(node)
+          if CONTRACT_PATTERN.match(node)
+            convert_contract_multi_args(node)
+          elsif SHORTHAND_CONTRACT_PATTERN.match(node)
+            convert_shorthand_contract(node)
+          end
+        end
+
+        def convert_shorthand_contract(node)
+          full_source, ret = SHORTHAND_CONTRACT_PATTERN.match(node)
+          convert_node(node, full_source, [], ret)
+        end
+
+        def convert_contract_multi_args(node)
+          full_source, arg0, arg1, ret, = CONTRACT_PATTERN.match(node)
+          # Conracts puts the first argument types in one list and the list on its own.
+          # IE in Contract String, Boolean, Integer => Number, [String, Boolean] end up in one
+          # list of nodes and Integer ends up as the first key in a (:pair) node where the values
+          # are the return types. I guess this is to allow the => syntax?
+          args = arg0 << arg1
+          convert_node(node, full_source, args, ret)
+        end
+
+        def convert_node(node, full_source, args, ret)
+          new_source = ::Sorbet::SorbetFromContractService.source(node, args, ret)
+          return nil if new_source.nil?
+
+          lambda do |corrector|
+            corrector.replace(
+              full_source.source_range,
+              new_source,
+            )
+            add_extend_tsig(corrector, node)
+          end
+        end
+
+        # Add `extend T::Sig` if not present
+        def add_extend_tsig(corrector, node)
+          return if node.parent.children.detect { |sib| EXTEND_T_SIG_PATTERN.match(sib) }
+          white_space = leading_white_space(node)
+          extend_t_source = "extend T::Sig#{white_space}"
+          corrector.replace(
+            node.parent.children.first.source_range.begin,
+            extend_t_source,
+          )
+        end
+
+        def previous_line(parent)
+          if parent.sibling_index > 1
+            previous = parent.parent.children[parent.sibling_index - 1]
+            if previous&.source_range
+              return previous
+            end
+          end
+          parent.parent.children.first
+        end
+
+        # Need to replicate the white space leading up to the node
+        def leading_white_space(node)
+          parent = node.parent
+          next_line = parent.children.first
+          previous = previous_line(parent)
+          end_previous = previous.source_range.end_pos
+          begin_next = next_line.source_range.begin_pos
+          Parser::Source::Range.new(
+            node.parent.source_range.source_buffer,
+            end_previous,
+            begin_next,
+          ).source.gsub(/[0-9a-z\<\_\-]/i, "")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/sorbet_from_contract_service.rb
+++ b/lib/rubocop/sorbet_from_contract_service.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module Sorbet
+  class SorbetFromContractService
+    class AutoCorrectError < StandardError; end
+    CONTRACT_PATTERN = RuboCop::NodePattern.new("$(send _ :Contract $... (:hash (:pair $_ $_)))")
+
+    EXTEND_T_SIG_PATTERN = RuboCop::NodePattern.new("(send _ :extend (const (const _ :T) :Sig))")
+
+    CONST_PATTERN = RuboCop::NodePattern.new("(const {nil? (cbase)} $_)")
+    TWO_CONST_PATTERN = RuboCop::NodePattern.new("(const (const {nil? (cbase)} $_) $_)")
+    THREE_CONST_PATTERN = RuboCop::NodePattern.new("(const (const (const {nil? (cbase)} $_) $_) $_)")
+    FOUR_CONST_PATTERN = RuboCop::NodePattern.new("(const (const (const (const {nil? (cbase)} $_) $_) $_) $_)")
+    SEND_PATTERN = RuboCop::NodePattern.new("(send $_ _ $...)")
+    NIL_PATTERN = RuboCop::NodePattern.new("nil")
+    SELF_PATTERN = RuboCop::NodePattern.new("self")
+    HASH_PATTERN = RuboCop::NodePattern.new("(hash $...)")
+    PAIR_MATCHER = RuboCop::NodePattern.new("(pair ({sym str} $_) $_)")
+    CONST_PAIR_MATCHER = RuboCop::NodePattern.new("(hash (pair (const {nil? (cbase)} $_) (const {nil? (cbase)} $_)))")
+    CONTRACT_ARGS_PATTERN = RuboCop::NodePattern.new("({arg optarg blockarg kwoptarg kwarg} $_ ...)")
+    TUPLE_PATTERN = RuboCop::NodePattern.new("(array $...)")
+
+    ARG_NAMES_MATCHER = RuboCop::NodePattern.new("(defs _ _ (:args $...) ...)")
+    INSTANCE_ARG_MATCHER = RuboCop::NodePattern.new("(def _ (:args $...) ...)")
+    PRIVATE_CLASS_ARG_MATCHER = RuboCop::NodePattern.new("(send _ :private_class_method (defs _ _ (:args $...) ...))")
+
+    def self.source(node, args, ret)
+      arg_names = arg_names(node)
+      arg_types = args.map { |arg| convert(arg) }.flatten
+      return_types = convert(ret)
+      format_source(arg_types, arg_names, return_types)
+    rescue AutoCorrectError => e
+      puts e.message
+      nil
+    end
+
+    def self.format_source(arg_types, arg_names, return_types)
+      if arg_names.empty?
+        if return_types.nil?
+          format("sig { void }", [])
+        else
+          format("sig { returns(%s) }", return_types)
+        end
+      else
+        params = arg_names.zip(arg_types).map do |arg, arg_type|
+          arg_name = CONTRACT_ARGS_PATTERN.match(arg).to_s
+          "#{arg_name}: #{arg_type}"
+        end.join(", ")
+        if return_types.nil?
+          return format("sig { params(%s).void }", params)
+        else
+          return format("sig { params(%s).returns(%s) }", params, return_types)
+        end
+      end
+    end
+
+    def self.arg_names(node)
+      sibling = node.parent.children[node.sibling_index + 1]
+      arg_names = ARG_NAMES_MATCHER.match(sibling)
+      arg_names ||= INSTANCE_ARG_MATCHER.match(sibling)
+      arg_names ||= PRIVATE_CLASS_ARG_MATCHER.match(sibling)
+      arg_names
+    end
+
+    def self.convert(src)
+      if CONST_PATTERN.match(src)
+        return map_const(CONST_PATTERN.match(src))
+      end
+      if TWO_CONST_PATTERN.match(src)
+        return map_consts(TWO_CONST_PATTERN.match(src))
+      end
+      if THREE_CONST_PATTERN.match(src)
+        return map_consts(THREE_CONST_PATTERN.match(src))
+      end
+      if FOUR_CONST_PATTERN.match(src)
+        return map_consts(FOUR_CONST_PATTERN.match(src))
+      end
+      if SEND_PATTERN.match(src)
+        send, rest = SEND_PATTERN.match(src)
+        send_value = map_send(convert(send))
+        if send_value == "KeywordArgs"
+          # For KeywordArgs we don't want to return the hash as the type;
+          # instead, the contents of the hash are the type.
+          return hash_entries(rest.first).map { |pair| convert(pair[1]) }
+        end
+        if send_value && rest
+          rest_string = rest.map { |part| convert(part) }.join(", ")
+          return format(send_value, rest_string)
+        end
+      end
+      if NIL_PATTERN.match(src)
+        return nil
+      end
+      if SELF_PATTERN.match(src)
+        return "T.self_type"
+      end
+      if CONST_PAIR_MATCHER.match(src)
+        first, second = CONST_PAIR_MATCHER.match(src)
+        return format("%s, %s", first, second)
+      end
+      if HASH_PATTERN.match(src)
+        hash_vals = hash_entries(src).map { |match| "#{match[0]}: #{convert(match[1])}" }.join(", ")
+        return format("{%s}", hash_vals)
+      end
+      if TUPLE_PATTERN.match(src)
+        values = TUPLE_PATTERN.match(src)
+        return format("[%s]", values.map { |value| convert(value) }.join(", "))
+      end
+      # Know we (at least) cannot handle literals
+      raise AutoCorrectError, "Could not recognize source #{src}"
+    end
+
+    # Given a hash node, return a list of key,value
+    def self.hash_entries(hash)
+      HASH_PATTERN.match(hash).map { |part| PAIR_MATCHER.match(part) }
+    end
+
+    def self.map_consts(consts)
+      ret = consts.map(&:to_s).join("::")
+      map_const(ret)
+    end
+
+    # Map Contract classes to the Sorbet equivalent
+    def self.map_const(contracts_value)
+      case contracts_value.to_s
+      when "Boolean", "Bool", "Contracts::Bool"
+        "T::Boolean"
+      when "Any", "Contracts::Any"
+        "T.untyped"
+      when "Hash"
+        "T::Hash[T.untyped, T.untyped]"
+      when "Proc"
+        "T.proc.void"
+      when "Num", "Contracts::Num", "Neg", "Contracts::Neg", "Pos", "Contracts::Pos"
+        "Numeric"
+      when "Int", "Contracts::Int", "Nat", "Contracts::Nat", "NatPos", "Contracts::NatPos"
+        "Integer"
+      else
+        contracts_value.to_s
+      end
+    end
+
+    # Map Contract functions and generic classes to the Sorbet equivalent
+    def self.map_send(contracts_value)
+      case contracts_value
+      when "Maybe", "Contracts::Maybe"
+        "T.nilable(%s)"
+      when "ArrayOf", "Contracts::ArrayOf"
+        "T::Array[%s]"
+      when "HashOf", "Contracts::HashOf"
+        "T::Hash[%s]"
+      when "Or", "Contracts::Or"
+        "T.any(%s)"
+      when "KeywordArgs", "Contracts::KeywordArgs"
+        # KeywordArgs is handled specifically
+        "KeywordArgs"
+      when "Optional", "Contracts::Optional"
+        "%s"
+      when "SetOf"
+        "T::Set[%s]"
+      when "TryOf"
+        "Try[%s]"
+      else
+        # Know we (at least) cannot handle Enum and KeywordArgs
+        raise AutoCorrectError, "Could not recognize send value #{contracts_value}"
+      end
+    end
+  end
+end

--- a/lib/rubocop_sorbet.rb
+++ b/lib/rubocop_sorbet.rb
@@ -4,6 +4,7 @@ require_relative 'rubocop/cop/sorbet/binding_constants_without_type_alias'
 require_relative 'rubocop/cop/sorbet/constants_from_strings'
 require_relative 'rubocop/cop/sorbet/forbid_superclass_const_literal'
 require_relative 'rubocop/cop/sorbet/forbid_include_const_literal'
+require_relative 'rubocop/cop/sorbet/prefer_sorbet_over_contracts'
 
 require_relative 'rubocop/cop/sorbet/signatures/allow_incompatible_override'
 require_relative 'rubocop/cop/sorbet/signatures/checked_true_in_signature'

--- a/spec/cop/sorbet/no_dynamic_contract_includes_spec.rb
+++ b/spec/cop/sorbet/no_dynamic_contract_includes_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require_relative '../../../lib/rubocop/cop/sorbet/no_dynamic_contract_includes'
+
+RSpec.describe(RuboCop::Cop::Sorbet::NoDynamicContractIncludes) do
+  subject(:cop) { RuboCop::Cop::Sorbet::NoDynamicContractIncludes.new }
+
+  context "Fixes Dry::Types.module imports" do
+    describe "Detects include" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet disallows dynamic includes. Do not include Dry::Types.module directly; use direct path instead.
+            class Unit < Dry::Struct
+              attribute :name, Strict::Symbol
+                               ^^^^^^^^^^^^^^ Sorbet disallows dynamic includes. Use full Dry::Types path instead.
+              attribute :power, Strict::Int
+                                ^^^^^^^^^^^ Sorbet disallows dynamic includes. Use full Dry::Types path instead.
+            end
+          end
+        RUBY
+      end
+
+      it "adds offenses" do
+        expect_offense(source)
+      end
+    end
+
+    describe "Autocorrect works for objects" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord
+            def index_schema
+              {
+                booking_mode: Types::Strict::String,
+                on_date: Types::DateTime,
+                page: Types::Coercible::Int,
+                pages: Types::Array,
+                hash: Types::Hash.schema,
+              }
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord
+            def index_schema
+              {
+                booking_mode: Dry::Types["strict.string"],
+                on_date: Dry::Types["date_time"],
+                page: Dry::Types["coercible.int"],
+                pages: Dry::Types["array"],
+                hash: Dry::Types["hash"].schema,
+              }
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for attribute" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            class Unit < Dry::Struct
+              attribute :instance, Instance(CoolClass)
+              attribute :name, Strict::Symbol
+              attribute :power, Strict::Int
+              attribute :sweet, Dry::Types["strict.int"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            include Dry::Types.module
+            class Unit < Dry::Struct
+              attribute :instance, Dry::Types::Definition.new(CoolClass).constrained(type: CoolClass)
+              attribute :name, Dry::Types["strict.symbol"]
+              attribute :power, Dry::Types["strict.int"]
+              attribute :sweet, Dry::Types["strict.int"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for normal" do
+      let(:source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            SampleEnum = Strict::Symbol.enum(
+              :first,
+              :second,
+              :third
+            )
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class ExampleRecord < Dry::Struct
+            SampleEnum = Dry::Types["strict.symbol"].enum(
+              :first,
+              :second,
+              :third
+            )
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+  end
+end

--- a/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
+++ b/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
@@ -1,0 +1,979 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require_relative "../../../lib/rubocop/cop/sorbet/prefer_sorbet_over_contracts"
+
+RSpec.describe(RuboCop::Cop::Sorbet::PreferSorbetOverContracts, :config) do
+  subject(:cop) { RuboCop::Cop::Sorbet::PreferSorbetOverContracts.new }
+
+  context "Fixes Contracts" do
+    describe "Auto-correct works for constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            include Contracts::Core
+            include Contracts::Builtin
+
+            def self.dummy
+              'will'
+            end
+
+            Contract Integer => AirProcurement::AllotmentEntity
+            def self.number_is_even(num)
+              return false
+            end
+
+            Contract A::B::C => D::E::F
+            def self.three_args(abc)
+              return false
+            end
+
+            Contract A::B::C::D => D::E::F::G
+            def self.four_args(abcd)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            include Contracts::Core
+            include Contracts::Builtin
+
+            def self.dummy
+              'will'
+            end
+
+            sig { params(num: Integer).returns(AirProcurement::AllotmentEntity) }
+            def self.number_is_even(num)
+              return false
+            end
+
+            sig { params(abc: A::B::C).returns(D::E::F) }
+            def self.three_args(abc)
+              return false
+            end
+
+            sig { params(abcd: A::B::C::D).returns(D::E::F::G) }
+            def self.four_args(abcd)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Auto-corrects none" do
+      let(:source) do
+        <<~RUBY
+          class Example < ExampleBase
+            Contract Or[Time, DateTime] => Or[Time, DateTime]
+            def self.cool_thing(time)
+              return "will"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example < ExampleBase
+            extend T::Sig
+            sig { params(time: T.any(Time, DateTime)).returns(T.any(Time, DateTime)) }
+            def self.cool_thing(time)
+              return "will"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Auto-corrects none" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract None => String
+            def self.cool_thing
+              return "will"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { returns(String) }
+            def self.cool_thing
+              return "will"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Auto-corrects void" do
+      context 'there is a param' do
+        context 'param is string' do
+          let(:source) do
+            <<~RUBY
+              class Example
+                Contract String => nil
+                def self.cool_thing(str)
+                end
+              end
+            RUBY
+          end
+          let(:fixed_source) do
+            <<~RUBY
+              class Example
+                extend T::Sig
+                sig { params(str: String).void }
+                def self.cool_thing(str)
+                end
+              end
+            RUBY
+          end
+
+          it "autocorrects the offense" do
+            new_source = autocorrect_source(source)
+            expect(new_source).to(eq(fixed_source))
+          end
+        end
+      end
+
+      context 'there is no param' do
+        let(:source) do
+          <<~RUBY
+            class Example
+              Contract None => nil
+              def self.cool_thing
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class Example
+              extend T::Sig
+              sig { void }
+              def self.cool_thing
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+    end
+
+    describe "Auto-corrects self" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract String => self
+            def self.cool_thing(str)
+              self
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(str: String).returns(T.self_type) }
+            def self.cool_thing(str)
+              self
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for two constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Integer, Boolean => String
+            def self.cool_thing(number, bool)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(number: Integer, bool: T::Boolean).returns(String) }
+            def self.cool_thing(number, bool)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for private class methods" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract OperationalRoute::Graph, Integer, User => Result
+            private_class_method def self.find_or_create_warehouse_node(graph, warehouse_id, updated_by)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(graph: OperationalRoute::Graph, warehouse_id: Integer, updated_by: User).returns(Result) }
+            private_class_method def self.find_or_create_warehouse_node(graph, warehouse_id, updated_by)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for five constants" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Integer, Boolean, String, Date, Integer  => String
+            def self.cool_thing(number, bool, string, date, integer)
+              return false
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(number: Integer, bool: T::Boolean, string: String, date: Date, integer: Integer).returns(String) }
+            def self.cool_thing(number, bool, string, date, integer)
+              return false
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for maybe and array" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Maybe[Integer], Maybe[Boolean] => ArrayOf[String]
+            def self.cool_thing(integers, booleans)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(integers: T.nilable(Integer), booleans: T.nilable(T::Boolean)).returns(T::Array[String]) }
+            def self.cool_thing(integers, booleans)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for nested sends" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract Maybe[Air::Man], Maybe[ArrayOf[String]] => Maybe[ArrayOf[Red::Sox]]
+            def cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(jordan: T.nilable(Air::Man), strings: T.nilable(T::Array[String])).returns(T.nilable(T::Array[Red::Sox])) }
+            def cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrect works for hashes" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract HashOf[String, Any], HashOf[String, Chris::Sale] => Maybe[HashOf[String, Red::Sox]]
+            def self.cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(jordan: T::Hash[String, T.untyped], strings: T::Hash[String, Chris::Sale]).returns(T.nilable(T::Hash[String, Red::Sox])) }
+            def self.cool_thing(jordan, strings)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Fixes KeywordArgs" do
+      let(:src) do
+        <<~RUBY
+          class Example
+            Contract Contracts::KeywordArgs[pats: Maybe[Tom::Brady], sox: Maybe[Big::Papi]] => ArrayOf[Gronk]
+            def self.cool_thing(pats: nil, sox: nil)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(pats: T.nilable(Tom::Brady), sox: T.nilable(Big::Papi)).returns(T::Array[Gronk]) }
+            def self.cool_thing(pats: nil, sox: nil)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Fixes tuple" do
+      let(:src) do
+        <<~RUBY
+          class Example
+            Contract [Maybe[Tom::Brady], Maybe[Big::Papi]] => ArrayOf[Gronk]
+            def self.cool_thing(args)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            extend T::Sig
+            sig { params(args: [T.nilable(Tom::Brady), T.nilable(Big::Papi)]).returns(T::Array[Gronk]) }
+            def self.cool_thing(args)
+              return ["cool", "will"]
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Leaves Enums alone" do
+      let(:source) do
+        <<~RUBY
+          class Example
+            Contract ArrayOf[Enum[*PERMITTED_KEYS]] => Maybe[String]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class Example
+            Contract ArrayOf[Enum[*PERMITTED_KEYS]] => Maybe[String]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrects full path ArrayOf" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract String => Contracts::ArrayOf[ContainerUse]
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            def self.buffer
+              nil
+            end
+
+            sig { params(key: String).returns(T::Array[ContainerUse]) }
+            def self.cool_thing(key)
+              return "coolwill"
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrects with param default values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract String, Maybe[Hash] => Bool
+            def self.cool_thing(key = "cool", hash = nil)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(key: String, hash: T.nilable(T::Hash[T.untyped, T.untyped])).returns(T::Boolean) }
+            def self.cool_thing(key = "cool", hash = nil)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Auto-correct works for constants" do
+      let(:source) do
+        <<~RUBY
+          module Outer
+            class Example
+              include Contracts::Core
+              include Contracts::Builtin
+
+              Contract Integer => ::AirProcurement::AllotmentEntity
+              def self.number_is_even(num)
+                return false
+              end
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          module Outer
+            class Example
+              extend T::Sig
+              include Contracts::Core
+              include Contracts::Builtin
+
+              sig { params(num: Integer).returns(AirProcurement::AllotmentEntity) }
+              def self.number_is_even(num)
+                return false
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Autocorrects with mixed param default values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Maybe[CompanyEntity], Maybe[CompanyEntity], Integer => ArrayOf[ShippingInstruction]
+            def self.historic_shipper_shipping_instructions(shipper, consignee, number_of_record: DEFAULT_NUMBER_HISTORIC_RECORD)
+              return []
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(shipper: T.nilable(CompanyEntity), consignee: T.nilable(CompanyEntity), number_of_record: Integer).returns(T::Array[ShippingInstruction]) }
+            def self.historic_shipper_shipping_instructions(shipper, consignee, number_of_record: DEFAULT_NUMBER_HISTORIC_RECORD)
+              return []
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Does not change literal values" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract Or["scheduled", "actual"] => Any
+            def self.cool_thing(key)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            def self.buffer
+              nil
+            end
+
+            Contract Or["scheduled", "actual"] => Any
+            def self.cool_thing(key)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Handles &block param" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Maybe[String], Proc => Any
+            def with_frontend_context(event_source, &block)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(event_source: T.nilable(String), block: T.proc.void).returns(T.untyped) }
+            def with_frontend_context(event_source, &block)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Handles => syntax" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract None => HashOf[String => Integer]
+            def with_frontend_context
+              return {}
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { returns(T::Hash[String, Integer]) }
+            def with_frontend_context
+              return {}
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Handles shapes" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract ArrayOf[
+                 {
+                   "place_id" => Or[Num, String],
+                   "tags_list" => ArrayOf[String],
+                 }
+             ],
+            String => Maybe[Num]
+            def with_frontend_context(arr, num)
+              return 1
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(arr: T::Array[{place_id: T.any(Numeric, String), tags_list: T::Array[String]}], num: String).returns(T.nilable(Numeric)) }
+            def with_frontend_context(arr, num)
+              return 1
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Handles Contract::" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract Contracts::Bool, Contracts::Maybe[Contracts::Num] => Contracts::Any
+            def with_frontend_context(bool, num)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(bool: T::Boolean, num: T.nilable(Numeric)).returns(T.untyped) }
+            def with_frontend_context(bool, num)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    describe "Handles Contract::" do
+      let(:src) do
+        <<~RUBY
+          class FullPathExample
+            Contract String, {from_warehouse: Contracts::Bool, cool: String} => {result: {errors: Contracts::ArrayOf[String]}}
+            def self.generate_deliveries_report(email, from_warehouse:)
+              return true
+            end
+          end
+        RUBY
+      end
+      let(:fixed_source) do
+        <<~RUBY
+          class FullPathExample
+            extend T::Sig
+            sig { params(email: String, from_warehouse: {from_warehouse: T::Boolean, cool: String}).returns({result: {errors: T::Array[String]}}) }
+            def self.generate_deliveries_report(email, from_warehouse:)
+              return true
+            end
+          end
+        RUBY
+      end
+
+      it "autocorrects the offense" do
+        new_source = autocorrect_source(src)
+        expect(new_source).to(eq(fixed_source))
+      end
+    end
+
+    context "when the contract has incorrect arity" do
+      describe "for a zero argument function" do
+        let(:src) do
+          <<~RUBY
+            class ZeroArgFunctionWithIncorrectButNotFailingContract
+              Contract Hash => String
+              def hello
+                return "Hello World"
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ZeroArgFunctionWithIncorrectButNotFailingContract
+              extend T::Sig
+              sig { returns(String) }
+              def hello
+                return "Hello World"
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(src)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+
+      describe "for a function with arguments" do
+        let(:src) do
+          <<~RUBY
+            class SeriouslyWhyDoesThisContractNotFail
+              Contract Integer, Integer => Integer
+              def plusOne(a)
+                return a+1
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class SeriouslyWhyDoesThisContractNotFail
+              extend T::Sig
+              sig { params(a: Integer).returns(Integer) }
+              def plusOne(a)
+                return a+1
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(src)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+    end
+
+    describe "Autocorrect works for shorthand no param list" do
+      context 'return param is a boolean' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract Bool
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T::Boolean) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+
+      end
+
+      context 'return param is a hash' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract HashOf[Symbol => Symbol]
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T::Hash[Symbol, Symbol]) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+
+      context 'return param is nil' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract nil
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { void }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+
+      context 'return param is any' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract Any
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T.untyped) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
(Hopefully) final branch getting this in.

Remakes https://github.com/Shopify/rubocop-sorbet/pull/20 in order to fix commit history. 

This PR adds a couple of Rubocop rules/auto-corrections that we've used with good results at Flexport.

`PreferSorbetOverContracts`: forbids the creation of new [`Contract`s](https://github.com/egonSchiele/contracts.ruby) in favor of Sorbet signatures. Additionally, can convert most existing Contracts into Sorbet signatures automatically.

`NoDynamicContractIncludes`: the [`Dry::Types`](https://github.com/dry-rb/dry-types) library makes frequent use of dynamic includes to populate the name space with its types; so you use `include Dry::Types.module` and then can access `Strict::Int` or `Types::Array`. Since Sorbet does not allow dynamic includes, forbid this pattern. The Cop can also automatically remove the `include`s and replace with the static path IE `Dry::Types["strict.int"]` 