### PR TITLE
Autocorrect adds sigil after shebang line

### DIFF
--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -37,7 +37,12 @@ module RuboCop
 
             token = processed_source.tokens.first
             replace_with = suggested_strictness_level(minimum_strictness, suggested_strictness)
-            corrector.insert_before(token.pos, "# typed: #{replace_with}\n")
+            sigil = "# typed: #{replace_with}"
+            if token.text.start_with?("#!") # shebang line
+              corrector.insert_after(token.pos, "\n#{sigil}")
+            else
+              corrector.insert_before(token.pos, "#{sigil}\n")
+            end
           end
         end
 

--- a/spec/cop/sorbet/sigils/has_sigil_spec.rb
+++ b/spec/cop/sorbet/sigils/has_sigil_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe(RuboCop::Cop::Sorbet::HasSigil, :config) do
             class Foo; end
           RUBY
       end
+
+      it('adds the sigil after the shebang line, if present') do
+        expect(
+          autocorrect_source(<<~RUBY)
+            #!/usr/bin/env ruby
+            class Foo; end
+          RUBY
+        )
+          .to(eq(<<~RUBY))
+            #!/usr/bin/env ruby
+            # typed: false
+            class Foo; end
+          RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
When the Sorbet/HasSigil cop is enabled, autocorrecting causes the sigil to be added _before_ the shebang line:

```ruby
# typed: false
#!/usr/bin/env ruby
```

This prevents the script from being interpreted as a ruby script when called from the command line. This pull request checks for a shebang line and, if found, adds the sorbet sigil after it instead.