### PR TITLE
Add cop to forbid T.untyped in T::Struct props

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_untyped_struct_props.rb
+++ b/lib/rubocop/cop/sorbet/forbid_untyped_struct_props.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop disallows use of `T.untyped` or `T.nilable(T.untyped)`
+      # as a prop type for `T::Struct`.
+      #
+      # @example
+      #
+      #   # bad
+      #   class SomeClass
+      #     const :foo, T.untyped
+      #     prop :bar, T.nilable(T.untyped)
+      #   end
+      #
+      #   # good
+      #   class SomeClass
+      #     const :foo, Integer
+      #     prop :bar, T.nilable(String)
+      #   end
+      class ForbidUntypedStructProps < RuboCop::Cop::Cop
+        MSG = 'Struct props cannot be T.untyped'
+
+        def_node_matcher :t_struct, <<~PATTERN
+          (const (const nil? :T) :Struct)
+        PATTERN
+
+        def_node_matcher :t_untyped, <<~PATTERN
+          (send (const nil? :T) :untyped)
+        PATTERN
+
+        def_node_matcher :t_nilable_untyped, <<~PATTERN
+          (send (const nil? :T) :nilable #t_untyped)
+        PATTERN
+
+        def_node_matcher :subclass_of_t_struct?, <<~PATTERN
+          (class (const ...) #t_struct ...)
+        PATTERN
+
+        def_node_search :untyped_props, <<~PATTERN
+          (send nil? {:prop :const} _ {#t_untyped #t_nilable_untyped} ...)
+        PATTERN
+
+        def on_class(node)
+          return unless subclass_of_t_struct?(node)
+
+          untyped_props(node).each do |untyped_prop|
+            add_offense(untyped_prop.child_nodes[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/forbid_untyped_struct_props.rb
+++ b/lib/rubocop/cop/sorbet/forbid_untyped_struct_props.rb
@@ -34,7 +34,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :t_nilable_untyped, <<~PATTERN
-          (send (const nil? :T) :nilable #t_untyped)
+          (send (const nil? :T) :nilable {#t_untyped #t_nilable_untyped})
         PATTERN
 
         def_node_matcher :subclass_of_t_struct?, <<~PATTERN

--- a/lib/rubocop_sorbet.rb
+++ b/lib/rubocop_sorbet.rb
@@ -4,6 +4,7 @@ require_relative 'rubocop/cop/sorbet/binding_constants_without_type_alias'
 require_relative 'rubocop/cop/sorbet/constants_from_strings'
 require_relative 'rubocop/cop/sorbet/forbid_superclass_const_literal'
 require_relative 'rubocop/cop/sorbet/forbid_include_const_literal'
+require_relative 'rubocop/cop/sorbet/forbid_untyped_struct_props'
 
 require_relative 'rubocop/cop/sorbet/signatures/allow_incompatible_override'
 require_relative 'rubocop/cop/sorbet/signatures/checked_true_in_signature'

--- a/spec/cop/sorbet/forbid_untyped_struct_props_spec.rb
+++ b/spec/cop/sorbet/forbid_untyped_struct_props_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidUntypedStructProps, :config) do
                     ^^^^^^^^^ Struct props cannot be T.untyped
         const :nilable_foo, T.nilable(T.untyped)
                             ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+        const :nested_foo, T.nilable(T.nilable(T.untyped))
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
         prop :bar, T.untyped
                    ^^^^^^^^^ Struct props cannot be T.untyped
         prop :nilable_bar, T.nilable(T.untyped)

--- a/spec/cop/sorbet/forbid_untyped_struct_props_spec.rb
+++ b/spec/cop/sorbet/forbid_untyped_struct_props_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../lib/rubocop/cop/sorbet/forbid_superclass_const_literal'
+
+RSpec.describe(RuboCop::Cop::Sorbet::ForbidUntypedStructProps, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  it 'adds offense when const is T.untyped' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        const :foo, T.untyped
+                    ^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'adds offense when const is T.nilable(T.untyped)' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        const :foo, T.nilable(T.untyped)
+                    ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'adds offense when prop is T.untyped' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        prop :foo, T.untyped
+                   ^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'adds offense when prop is T.nilable(T.untyped)' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        prop :foo, T.nilable(T.untyped)
+                   ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'adds offense when prop is T.nilable(T.untyped) and has other options' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        prop :foo, T.nilable(T.untyped), immutable: true
+                   ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'adds offense when multiple props are untyped' do
+    expect_offense(<<~RUBY)
+      class MyClass < T::Struct
+        const :foo, T.untyped
+                    ^^^^^^^^^ Struct props cannot be T.untyped
+        const :nilable_foo, T.nilable(T.untyped)
+                            ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+        prop :bar, T.untyped
+                   ^^^^^^^^^ Struct props cannot be T.untyped
+        prop :nilable_bar, T.nilable(T.untyped)
+                           ^^^^^^^^^^^^^^^^^^^^ Struct props cannot be T.untyped
+      end
+    RUBY
+  end
+
+  it 'does not add offense when class is not subclass of T::Struct' do
+    expect_no_offenses(<<~RUBY)
+      class MyClass < SomethingElse
+        const :foo, Integer
+        const :nilable_foo, T.nilable(String)
+        prop :bar, Date
+        prop :nilable_bar, T.nilable(Float)
+      end
+    RUBY
+  end
+
+  it 'does not add offense when props have types' do
+    expect_no_offenses(<<~RUBY)
+      class MyClass < T::Struct
+        const :foo, Integer
+        const :nilable_foo, T.nilable(String)
+        prop :bar, Date
+        prop :nilable_bar, T.nilable(Float)
+        const :array, T::Array[T.untyped]
+        const :hash, T::Hash[T.untyped, T.untyped]
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
At Gusto we make heavy use of `T::Struct` and we're converting all of our `ValueObject` (an internal class very similar to T::Struct but without types) to be `T::Struct` instead. During the conversion we're making generous use of `T.untyped` to allow us to safely convert object without breaking anything but we'd like to discourage new `T::Struct`s from having `T.untyped` props.