### PR TITLE
Fix `ParametersOrderingInSignature` crash on invalid sig

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/parameters_ordering_in_signature.rb
+++ b/lib/rubocop/cop/sorbet/signatures/parameters_ordering_in_signature.rb
@@ -26,13 +26,9 @@ module RuboCop
 
         def on_signature(node)
           sig_params = signature_params(node).first
-          sig_params_order =
-            if sig_params.nil?
-              []
-            else
-              sig_params.arguments.first.keys.map(&:value)
-            end
 
+          sig_params_order = extract_parameters(sig_params)
+          return if sig_params_order.nil?
           method_node = node.parent.children[node.sibling_index + 1]
           return if method_node.nil? || method_node.type != :def
           method_parameters = method_node.arguments
@@ -41,6 +37,18 @@ module RuboCop
         end
 
         private
+
+        def extract_parameters(sig_params)
+          return [] if sig_params.nil?
+
+          arguments = sig_params.arguments.first
+          return arguments.keys.map(&:value) if RuboCop::AST::HashNode === arguments
+
+          add_offense(
+            sig_params,
+            message: "Invalid signature."
+          )
+        end
 
         def check_for_inconsistent_param_ordering(sig_params_order, parameters)
           parameters.each_with_index do |param, index|

--- a/spec/rubocop/cop/sorbet/signatures/parameters_ordering_in_signature_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/parameters_ordering_in_signature_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe(RuboCop::Cop::Sorbet::ParametersOrderingInSignature, :config) do
     RUBY
   end
 
+  it('adds offense when the signature is incorrect') do
+    expect_offense(<<~RUBY)
+      sig do
+        params(String, Integer, T::Boolean).void
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid signature.
+      end
+      def foo(a, b:, c:); end
+    RUBY
+  end
+
   it('does not add offense when order is correct') do
     expect_no_offenses(<<~RUBY)
       sig { params(a: String, b: Integer, c: Integer, blk: Proc).void }


### PR DESCRIPTION
`ParametersOrderingInSignature` was erroring out when it was not supplied a parameter set that was a `HashNode` since the code was assuming it would always get a valid signature.

We now check for the node type before accessing its keys and add an invalid signature offense if the `params` block is malformed.

Fixes: #28 