### PR TITLE
Add cop for mutable T.let constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+
+## master (unreleased)
+
+### New features
+
+* [#35](https://github.com/Shopify/rubocop-sorbet/issues/35): Add cop for mutable T.let constants. ([@dduugg][])
+
+[@dduugg]: https://github.com/dduugg

--- a/config/default.yml
+++ b/config/default.yml
@@ -90,6 +90,17 @@ Sorbet/KeywordArgumentOrdering:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/MutableTLetConstant:
+  Description: 'Freeze mutable objects in T.let expressions assigned to constants.'
+  Enabled: true
+  VersionAdded: 0.5.0
+  EnforcedStyle: literals
+  SupportedStyles:
+    # literals: freeze literals assigned to constants
+    # strict: freeze all constants
+    - literals
+    - strict
+
 Sorbet/ParametersOrderingInSignature:
   Description: 'Enforces same parameter order between a method and its signature.'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/mutable_t_let_constant.rb
+++ b/lib/rubocop/cop/sorbet/mutable_t_let_constant.rb
@@ -1,0 +1,161 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop checks that arguments to T.let calls assigned to constants
+      # aren't mutable literals (e.g. array or hash). It is inspired by the
+      # Style/MutableConstant cop, but enforced on the argument to T.let,
+      # rather than the T.let call itself. (Note that freezing a T.let call
+      # will not satisfy the requirements of `# typed: strict` mode.)
+      #
+      # @see Rubocop::Cop::Style::MutableConstant
+      #
+      # @example EnforcedStyle: literals (default)
+      #   # bad
+      #   CONST = T.let([1, 2, 3], T::Array[Integer])
+      #
+      #   # good
+      #   CONST = T.let([1, 2, 3].freeze, T::Array[Integer])
+      #
+      #   # good
+      #   CONST = T.let(Something.new, Something)
+      #
+      # @example EnforcedStyle: strict
+      #   # bad
+      #   CONST = T.let(Something.new, Something)
+      #
+      #   # good
+      #   CONST = T.let(Something.new.freeze, Something)
+      class MutableTLetConstant < RuboCop::Cop::Cop
+        include FrozenStringLiteral
+        include ConfigurableEnforcedStyle
+
+        MSG = 'Freeze mutable objects in T.let expressions assigned to constants.'
+
+        def on_casgn(node)
+          _scope, _const_name, value = *node
+
+          t_let(value) do |constant|
+            on_assignment(constant)
+          end
+        end
+
+        def on_or_asgn(node)
+          lhs, value = *node
+
+          return unless lhs&.casgn_type?
+
+          t_let(value) do |constant|
+            on_assignment(constant)
+          end
+        end
+
+        def autocorrect(node)
+          expr = node.source_range
+
+          lambda do |corrector|
+            splat_value = splat_value(node)
+            if splat_value
+              correct_splat_expansion(corrector, expr, splat_value)
+            elsif node.array_type? && !node.bracketed?
+              corrector.wrap(expr, '[', ']')
+            elsif requires_parentheses?(node)
+              corrector.wrap(expr, '(', ')')
+            end
+
+            corrector.insert_after(expr, '.freeze')
+          end
+        end
+
+        private
+
+        def on_assignment(value)
+          if style == :strict
+            strict_check(value)
+          else
+            check(value)
+          end
+        end
+
+        def strict_check(value)
+          return if immutable_literal?(value)
+          return if operation_produces_immutable_object?(value)
+          return if frozen_string_literal?(value)
+
+          add_offense(value)
+        end
+
+        def check(value)
+          range_enclosed_in_parentheses = range_enclosed_in_parentheses?(value)
+
+          return unless mutable_literal?(value) ||
+                        range_enclosed_in_parentheses
+          return if FROZEN_STRING_LITERAL_TYPES.include?(value.type) &&
+                    frozen_string_literals_enabled?
+
+          add_offense(value)
+        end
+
+        def mutable_literal?(value)
+          value&.mutable_literal?
+        end
+
+        def immutable_literal?(node)
+          node.nil? || node.immutable_literal?
+        end
+
+        def frozen_string_literal?(node)
+          FROZEN_STRING_LITERAL_TYPES.include?(node.type) &&
+            frozen_string_literals_enabled?
+        end
+
+        def requires_parentheses?(node)
+          node.range_type? ||
+            (node.send_type? && node.loc.dot.nil?)
+        end
+
+        def correct_splat_expansion(corrector, expr, splat_value)
+          if range_enclosed_in_parentheses?(splat_value)
+            corrector.replace(expr, "#{splat_value.source}.to_a")
+          else
+            corrector.replace(expr, "(#{splat_value.source}).to_a")
+          end
+        end
+
+        def_node_matcher :splat_value, <<~PATTERN
+          (array (splat $_))
+        PATTERN
+
+        # Some of these patterns may not actually return an immutable object,
+        # but we want to consider them immutable for this cop.
+        def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
+          {
+            (const _ _)
+            (send (const nil? :Struct) :new ...)
+            (block (send (const nil? :Struct) :new ...) ...)
+            (send _ :freeze)
+            (send {float int} {:+ :- :* :** :/ :% :<<} _)
+            (send _ {:+ :- :* :** :/ :%} {float int})
+            (send _ {:== :=== :!= :<= :>= :< :>} _)
+            (send (const nil? :ENV) :[] _)
+            (or (send (const nil? :ENV) :[] _) _)
+            (send _ {:count :length :size} ...)
+            (block (send _ {:count :length :size} ...) ...)
+          }
+        PATTERN
+
+        def_node_matcher :range_enclosed_in_parentheses?, <<~PATTERN
+          (begin ({irange erange} _ _))
+        PATTERN
+
+        def_node_matcher :t_let, <<~PATTERN
+          (send (const nil? :T) :let $_constant _type)
+        PATTERN
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -4,6 +4,7 @@ require_relative 'sorbet/constants_from_strings'
 require_relative 'sorbet/forbid_superclass_const_literal'
 require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
+require_relative 'sorbet/mutable_t_let_constant'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/spec/rubocop/cop/sorbet/mutable_t_let_constant_spec.rb
+++ b/spec/rubocop/cop/sorbet/mutable_t_let_constant_spec.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(RuboCop::Cop::Sorbet::MutableTLetConstant, :config) do
+  # subject(:cop) { described_class.new(config) }
+  let(:prefix) { nil }
+
+  shared_examples 'mutable objects' do |o|
+    context 'when assigning with =' do
+      it "registers an offense for #{o} assigned to a constant" do
+        source = [prefix, "CONST = T.let(#{o}, Object)"].compact.join("\n")
+        inspect_source(source)
+        expect(cop.offenses.size).to(eq(1))
+      end
+
+      it 'auto-corrects by adding .freeze' do
+        source = [prefix, "CONST = T.let(#{o}, Object)"].compact.join("\n")
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq([prefix, "CONST = T.let(#{o}.freeze, Object)"].compact.join("\n")))
+      end
+    end
+
+    context 'when assigning with ||=' do
+      it "registers an offense for #{o} assigned to a constant" do
+        source = [prefix, "CONST ||= T.let(#{o}, Object)"].compact.join("\n")
+        inspect_source(source)
+        expect(cop.offenses.size).to(eq(1))
+      end
+
+      it 'auto-corrects by adding .freeze' do
+        source = [prefix, "CONST ||= T.let(#{o}, Object)"].compact.join("\n")
+        new_source = autocorrect_source(source)
+        expect(new_source).to(eq([prefix, "CONST ||= T.let(#{o}.freeze, Object)"].compact.join("\n")))
+      end
+    end
+  end
+
+  shared_examples 'immutable objects' do |o|
+    it "allows #{o} to be assigned to a constant" do
+      source = [prefix, "CONST = T.let(#{o}, Object)"].compact.join("\n")
+      expect_no_offenses(source)
+    end
+
+    it "allows #{o} to be ||= to a constant" do
+      source = [prefix, "CONST ||= T.let(#{o}, Object)"].compact.join("\n")
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'Strict: false' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literals' } }
+
+    it_behaves_like 'mutable objects', '[1, 2, 3]'
+    it_behaves_like 'mutable objects', '%w(a b c)'
+    it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+    it_behaves_like 'mutable objects', "'str'"
+    it_behaves_like 'mutable objects', '"top#{1 + 2}"'
+
+    it_behaves_like 'immutable objects', '1'
+    it_behaves_like 'immutable objects', '1.5'
+    it_behaves_like 'immutable objects', ':sym'
+    it_behaves_like 'immutable objects', 'FOO + BAR'
+    it_behaves_like 'immutable objects', 'FOO - BAR'
+    it_behaves_like 'immutable objects', "'foo' + 'bar'"
+    it_behaves_like 'immutable objects', "ENV['foo']"
+
+    it 'allows method call assignments' do
+      expect_no_offenses('TOP_TEST = T.let(Something.new, Something)')
+    end
+
+    context 'when assigning a word array' do
+      it 'auto-corrects by adding .freeze' do
+        new_source = autocorrect_source('XXX = T.let(%w(YYY ZZZ), T::Array[String])')
+        expect(new_source).to(eq('XXX = T.let(%w(YYY ZZZ).freeze, T::Array[String])'))
+      end
+    end
+
+    context 'when assigning a range (irange) without parenthesis' do
+      it 'adds parenthesis when auto-correcting' do
+        new_source = autocorrect_source('XXX = T.let(1..99, T::Range[Integer])')
+        expect(new_source).to(eq('XXX = T.let((1..99).freeze, T::Range[Integer])'))
+      end
+
+      it 'does not add parenthesis to range enclosed in parentheses' do
+        new_source = autocorrect_source('XXX = T.let((1..99), T::Range[Integer])')
+        expect(new_source).to(eq('XXX = T.let((1..99).freeze, T::Range[Integer])'))
+      end
+    end
+
+    context 'when assigning a range (erange) without parenthesis' do
+      it 'adds parenthesis when auto-correcting' do
+        new_source = autocorrect_source('XXX = T.let(1...99, T::Range[Integer])')
+        expect(new_source).to(eq('XXX = T.let((1...99).freeze, T::Range[Integer])'))
+      end
+
+      it 'does not add parenthesis to range enclosed in parentheses' do
+        new_source = autocorrect_source('XXX = T.let((1...99), T::Range[Integer])')
+        expect(new_source).to(eq('XXX = T.let((1...99).freeze, T::Range[Integer])'))
+      end
+    end
+
+    context 'when the constant is a frozen string literal' do
+      # TODO : It is not yet decided when frozen string will be the default.
+      # It has been abandoned in the Ruby 3.0 period, but may default in
+      # the long run. So these tests are left with a provisional value of 4.0.
+      if RuboCop::TargetRuby.supported_versions.include?(4.0)
+        context 'when the target ruby version >= 4.0' do
+          let(:ruby_version) { 4.0 }
+
+          context 'when the frozen string literal comment is missing' do
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+
+          context 'when the frozen string literal comment is true' do
+            let(:prefix) { '# frozen_string_literal: true' }
+
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+
+          context 'when the frozen string literal comment is false' do
+            let(:prefix) { '# frozen_string_literal: false' }
+
+            it_behaves_like 'immutable objects', '"#{a}"'
+          end
+        end
+      end
+
+      context 'when the frozen string literal comment is missing' do
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is true' do
+        let(:prefix) { '# frozen_string_literal: true' }
+
+        it_behaves_like 'immutable objects', '"#{a}"'
+      end
+
+      context 'when the frozen string literal comment is false' do
+        let(:prefix) { '# frozen_string_literal: false' }
+
+        it_behaves_like 'mutable objects', '"#{a}"'
+      end
+    end
+  end
+
+  context 'Strict: true' do
+    let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
+
+    it_behaves_like 'mutable objects', '[1, 2, 3]'
+    it_behaves_like 'mutable objects', '%w(a b c)'
+    it_behaves_like 'mutable objects', '{ a: 1, b: 2 }'
+    it_behaves_like 'mutable objects', "'str'"
+    it_behaves_like 'mutable objects', '"top#{1 + 2}"'
+    it_behaves_like 'mutable objects', 'Something.new'
+
+    it_behaves_like 'immutable objects', '1'
+    it_behaves_like 'immutable objects', '1.5'
+    it_behaves_like 'immutable objects', ':sym'
+    it_behaves_like 'immutable objects', "ENV['foo']"
+    it_behaves_like 'immutable objects', 'OTHER_CONST'
+    it_behaves_like 'immutable objects', 'Namespace::OTHER_CONST'
+    it_behaves_like 'immutable objects', 'Struct.new'
+    it_behaves_like 'immutable objects', 'Struct.new(:a, :b)'
+
+    it 'allows calls to freeze' do
+      expect_no_offenses(<<~RUBY)
+        CONST = T.let([1].freeze, T::Array[Integer])
+      RUBY
+    end
+
+    context 'when assigning with an operator' do
+      shared_examples 'operator methods' do |o|
+        it 'registers an offense' do
+          inspect_source("CONST = T.let(FOO #{o} BAR, Numeric)")
+
+          expect(cop.offenses.size).to(eq(1))
+          expect(cop.highlights).to(eq(["FOO #{o} BAR"]))
+        end
+
+        it 'corrects by wrapping in parentheses and calling freeze' do
+          new_source = autocorrect_source(<<~RUBY)
+            CONST = T.let(FOO #{o} BAR, Numeric)
+          RUBY
+
+          expect(new_source).to(eq(<<~RUBY))
+            CONST = T.let((FOO #{o} BAR).freeze, Numeric)
+          RUBY
+        end
+      end
+
+      it_behaves_like 'operator methods', '+'
+      it_behaves_like 'operator methods', '-'
+      it_behaves_like 'operator methods', '*'
+      it_behaves_like 'operator methods', '/'
+      it_behaves_like 'operator methods', '%'
+      it_behaves_like 'operator methods', '**'
+    end
+
+    context 'when assigning with multiple operator calls' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          FOO = T.let([1].freeze, T::Array[Integer])
+          BAR = T.let([2].freeze, T::Array[Integer])
+          BAZ = T.let([3].freeze, T::Array[Integer])
+          CONST = T.let(FOO + BAR + BAZ, Object)
+                        ^^^^^^^^^^^^^^^ Freeze mutable objects in T.let expressions assigned to constants.
+        RUBY
+      end
+
+      it 'corrects by wrapping in parens and calling freeze' do
+        new_source = autocorrect_source(<<~RUBY)
+          FOO = T.let([1].freeze, T::Array[Integer])
+          BAR = T.let([2].freeze, T::Array[Integer])
+          BAZ = T.let([3].freeze, T::Array[Integer])
+          CONST = T.let(FOO + BAR + BAZ, Object)
+        RUBY
+
+        expect(new_source).to(eq(<<~RUBY))
+          FOO = T.let([1].freeze, T::Array[Integer])
+          BAR = T.let([2].freeze, T::Array[Integer])
+          BAZ = T.let([3].freeze, T::Array[Integer])
+          CONST = T.let((FOO + BAR + BAZ).freeze, Object)
+        RUBY
+      end
+    end
+
+    context 'methods and operators that produce frozen objects' do
+      it 'accepts assigning to an environment variable with a fallback' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(ENV['foo'] || 'foo', String)
+        RUBY
+      end
+
+      it 'accepts operating on a constant and an interger' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(FOO + 2, Integer)
+        RUBY
+      end
+
+      it 'accepts operating on multiple integers' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(1 + 2, Integer)
+        RUBY
+      end
+
+      it 'accepts operating on a constant and a float' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(FOO + 2.1, Float)
+        RUBY
+      end
+
+      it 'accepts operating on multiple floats' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(1.2 + 2.1, Float)
+        RUBY
+      end
+
+      it 'accepts comparison operators' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let(FOO == BAR, T::Boolean)
+        RUBY
+      end
+
+      it 'accepts checking fixed size' do
+        expect_no_offenses(<<~RUBY)
+          CONST = T.let([1, 2, 3].count, Integer)
+          CONST = T.let('foo'.count('f'), Integer)
+          CONST = T.let([1, 2, 3].count { |n| n > 2 }, Integer)
+          CONST = T.let([1, 2, 3].count(2) { |n| n > 2 }, Integer)
+          CONST = T.let('foo'.length, Integer)
+          CONST = T.let('foo'.size, Integger)
+        RUBY
+      end
+    end
+
+    context 'operators that produce unfrozen objects' do
+      it 'registers an offense when operating on a constant and a string' do
+        expect_offense(<<~RUBY)
+          CONST = T.let(FOO + 'bar', String)
+                        ^^^^^^^^^^^ Freeze mutable objects in T.let expressions assigned to constants.
+        RUBY
+      end
+
+      it 'registers an offense when operating on multiple strings' do
+        expect_offense(<<~RUBY)
+          CONST = T.let('foo' + 'bar' + 'baz', String)
+                        ^^^^^^^^^^^^^^^^^^^^^ Freeze mutable objects in T.let expressions assigned to constants.
+        RUBY
+      end
+    end
+
+    context 'when assigning a word array' do
+      it 'auto-corrects by adding .freeze' do
+        new_source = autocorrect_source('XXX = T.let(%w(YYY ZZZ), T::Array[String])')
+        expect(new_source).to(eq('XXX = T.let(%w(YYY ZZZ).freeze, T::Array[String])'))
+      end
+    end
+
+    context 'when the frozen string literal comment is missing' do
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
+
+    context 'when the frozen string literal comment is true' do
+      let(:prefix) { '# frozen_string_literal: true' }
+
+      it_behaves_like 'immutable objects', '"#{a}"'
+    end
+
+    context 'when the frozen string literal comment is false' do
+      let(:prefix) { '# frozen_string_literal: false' }
+
+      it_behaves_like 'mutable objects', '"#{a}"'
+    end
+  end
+end


### PR DESCRIPTION
Implements https://github.com/Shopify/rubocop-sorbet/issues/35

This is mostly a copy pasta of https://github.com/rubocop-hq/rubocop/blob/v0.85.1/lib/rubocop/cop/style/mutable_constant.rb (differing by adding a node matcher and making slight changes to the `on_casgn` and `on_or_asgn` impls)

The output of `bundle exec rake new_cop` requests adding an entry to `CHANGELOG.md`, which did not exist. I have taken the liberty of creating one in a second commit, modeled on https://github.com/rubocop-hq/rubocop/blob/v0.85.1/CHANGELOG.md