### PR TITLE
Preserve generic formatting by using index send nodes

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -55,10 +55,9 @@ module RuboCop
           return nil unless can_autocorrect?
 
           lambda do |corrector|
-            rich_node = node_with_index_sends(node)
-            nodes = call_chain(rich_node).sort_by { |call| ORDER[call.method_name] }
-            tree =
-              nodes.reduce(nil) do |receiver, caller|
+            tree = call_chain(node_with_index_sends(node))
+              .sort_by { |call| ORDER[call.method_name] }
+              .reduce(nil) do |receiver, caller|
                 caller.updated(nil, [receiver] + caller.children.drop(1))
               end
 

--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -55,7 +55,8 @@ module RuboCop
           return nil unless can_autocorrect?
 
           lambda do |corrector|
-            nodes = call_chain(node).sort_by { |call| ORDER[call.method_name] }
+            rich_node = node_with_index_sends(node)
+            nodes = call_chain(rich_node).sort_by { |call| ORDER[call.method_name] }
             tree =
               nodes.reduce(nil) do |receiver, caller|
                 caller.updated(nil, [receiver] + caller.children.drop(1))
@@ -69,6 +70,16 @@ module RuboCop
         end
 
         private
+
+        def node_with_index_sends(node)
+          # This is really dirty hack to reparse the current node with index send
+          # emitting enabled, which is necessary to unparse them back as index accessors.
+          emit_index_value = RuboCop::AST::Builder.emit_index
+          RuboCop::AST::Builder.emit_index = true
+          RuboCop::AST::ProcessedSource.new(node.source, target_ruby_version, processed_source.path).ast
+        ensure
+          RuboCop::AST::Builder.emit_index = emit_index_value
+        end
 
         def can_autocorrect?
           defined?(::Unparser)

--- a/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
           sig { type_parameters(:U).params(x: T.type_parameter(:U)).void }
         RUBY
     end
+
+    it('autocorrects sigs with generic types properly') do
+      source = <<~RUBY
+        sig { void.type_parameters(:U).params(x: T.type_parameter(:U), y: T::Hash[String, Integer]) }
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          sig { type_parameters(:U).params(x: T.type_parameter(:U), y: T::Hash[String, Integer]).void }
+        RUBY
+    end
   end
 
   describe('without the unparser gem') do


### PR DESCRIPTION
Fixes: #40

By default RuboCop does not enable the more modern AST syntax that users of whitequark parser can opt-in to by turning on various `emit_xxx` flags on `Parser::Builders::Default`. One of those modern Ruby AST syntax is the `index` nodes that can be emitted for index accessors, which is necessary for us to properly roundtrip generic types back to expected Ruby code.

The "fix" is an ugly hack that re-parses the given node source with `emit_index` turned on and applies `unparse` on the returned node set instead of the original one.