### PR TITLE
Disable ForbidIncludeConstLiteral & ForbidSuperClassConstLiteral by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -55,12 +55,12 @@ Sorbet/FalseSigil:
 
 Sorbet/ForbidIncludeConstLiteral:
   Description: 'Forbids include of non-literal constants.'
-  Enabled: true
+  Enabled: false
   VersionAdded: 0.2.0
 
 Sorbet/ForbidSuperclassConstLiteral:
   Description: 'Forbid superclasses which are non-literal constants.'
-  Enabled: true
+  Enabled: false
   VersionAdded: 0.2.0
 
 Sorbet/ForbidUntypedStructProps:

--- a/config/default.yml
+++ b/config/default.yml
@@ -57,11 +57,13 @@ Sorbet/ForbidIncludeConstLiteral:
   Description: 'Forbids include of non-literal constants.'
   Enabled: false
   VersionAdded: 0.2.0
+  VersionChanged: 0.5.0
 
 Sorbet/ForbidSuperclassConstLiteral:
   Description: 'Forbid superclasses which are non-literal constants.'
   Enabled: false
   VersionAdded: 0.2.0
+  VersionChanged: 0.5.0
 
 Sorbet/ForbidUntypedStructProps:
   Description: >-

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -175,7 +175,7 @@ Exclude | `bin/**/*`, `db/**/*.rb`, `script/**/*` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.2.0 | -
+Disabled | Yes | Yes  | 0.2.0 | 0.5.0
 
 No documentation
 
@@ -183,7 +183,7 @@ No documentation
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.2.0 | -
+Disabled | Yes | Yes  | 0.2.0 | 0.5.0
 
 No documentation
 


### PR DESCRIPTION
Since the 0.4.0 release we have a set of cops that are enabled by default. Upon a failure in shopify core we noticed that the autocorrect is also faulty. I will remove it's autocorrect in another PR. This one just disables the cops by default, they are "aggressive" and will cause failures for people. Makes sense to tell users to "opt in" rather than "opt out".