### PR TITLE
Fix type alias cop mismatching class/module/struct creation

### DIFF
--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   FooOrBar = T.type_alias { T.any(Foo, Bar) }
       class BindingConstantWithoutTypeAlias < RuboCop::Cop::Cop
         def_node_matcher(:binding_unaliased_type?, <<-PATTERN)
-          (casgn _ _ [#not_nil? #not_t_let? #not_generic_parameter_decl? #method_needing_aliasing_on_t?])
+          (casgn _ _ [#not_nil? #not_t_let? #not_dynamic_type_creation_with_block? #not_generic_parameter_decl? #method_needing_aliasing_on_t?])
         PATTERN
 
         def_node_matcher(:using_type_alias?, <<-PATTERN)
@@ -48,6 +48,15 @@ module RuboCop
           )
         PATTERN
 
+        def_node_matcher(:dynamic_type_creation_with_block?, <<-PATTERN)
+          (block
+            (send
+              const :new ...)
+              _
+              _
+          )
+        PATTERN
+
         def_node_matcher(:generic_parameter_decl?, <<-PATTERN)
           (
             send nil? {:type_template :type_member} ...
@@ -65,6 +74,10 @@ module RuboCop
 
         def not_t_let?(node)
           !t_let?(node)
+        end
+
+        def not_dynamic_type_creation_with_block?(node)
+          !dynamic_type_creation_with_block?(node)
         end
 
         def not_generic_parameter_decl?(node)

--- a/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -71,6 +71,34 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
       RUBY
     end
 
+    it('allow using Class.new or Module.new with extend T::Sig') do
+      expect_no_offenses(<<~RUBY)
+        Foo = Class.new do
+          A = T.let(42, T.any(Integer, Float))
+        end
+
+        Foo2 = Class.new(String) do
+          A = T.let(42, T.any(Integer, Float))
+        end
+
+        Bar = Module.new do
+          A = T.let(42, T.any(Integer, Float))
+        end
+
+        Baz = Struct.new do
+          A = T.let(42, T.any(Integer, Float))
+        end
+
+        Baz2 = Struct.new(:baz) do
+          A = T.let(42, T.any(Integer, Float))
+        end
+
+        Baz3 = Struct.new(:baz, :bar, :foo) do
+          A = T.let(42, T.any(Integer, Float))
+        end
+      RUBY
+    end
+
     it('allows using the return value of T.any, T.all, etc in a signature definition') do
       expect_no_offenses(<<~RUBY)
         sig { params(foo: T.any(String, Integer)).void }


### PR DESCRIPTION
Our `BindingConstantWithoutTypeAlias` has started mismatching classes/modules/structs defined via `Class.new`, `Module.new` and `Struct.new`, etc with a block that contains `T.xxx` inside. 

We need to explicitly match those dynamic module creation calls and exclude them.