### PR TITLE
Add cop for empty class/module definitions in RBI files

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -107,6 +107,13 @@ Sorbet/SignatureBuildOrder:
   Enabled: true
   VersionAdded: 0.3.0
 
+Sorbet/SingleLineRbiClassModuleDefinitions:
+  Description: 'Empty class and module definitions in RBI must be on a single line.'
+  Enabled: false
+  VersionAdded: '0.86'
+  Include:
+  - "**/*.rbi"
+
 Sorbet/StrictSigil:
   Description: 'All files must be at least at strictness `strict`.'
   Enabled: false

--- a/lib/rubocop/cop/sorbet/single_line_rbi_class_module_definitions.rb
+++ b/lib/rubocop/cop/sorbet/single_line_rbi_class_module_definitions.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop ensures empty class/module definitions in RBI files are
+      # done on a single line rather than being split across multiple lines.
+      #
+      # @example
+      #
+      #   # bad
+      #   module SomeModule
+      #   end
+      #
+      #   # good
+      #   module SomeModule; end
+      class SingleLineRbiClassModuleDefinitions < RuboCop::Cop::Cop
+        MSG = 'Empty class/module definitions in RBI files should be on a single line.'
+
+        def on_module(node)
+          process_node(node)
+        end
+
+        def on_class(node)
+          process_node(node)
+        end
+
+        def autocorrect(node)
+          -> (corrector) { corrector.replace(node, convert_newlines(node.source)) }
+        end
+
+        protected
+
+        def convert_newlines(source)
+          source.sub(/[\r\n]+\s*[\r\n]*/, "; ")
+        end
+
+        def process_node(node)
+          return if node.body
+          return if node.single_line?
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -4,6 +4,7 @@ require_relative 'sorbet/constants_from_strings'
 require_relative 'sorbet/forbid_superclass_const_literal'
 require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
+require_relative 'sorbet/single_line_rbi_class_module_definitions'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -21,6 +21,7 @@ In the following section you find all available cops:
 * [Sorbet/ParametersOrderingInSignature](cops_sorbet.md#sorbetparametersorderinginsignature)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
 * [Sorbet/SignatureCop](cops_sorbet.md#sorbetsignaturecop)
+* [Sorbet/SingleLineRbiClassModuleDefinitions](cops_sorbet.md#sorbetsinglelinerbiclassmoduledefinitions)
 * [Sorbet/StrictSigil](cops_sorbet.md#sorbetstrictsigil)
 * [Sorbet/StrongSigil](cops_sorbet.md#sorbetstrongsigil)
 * [Sorbet/TrueSigil](cops_sorbet.md#sorbettruesigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -175,7 +175,7 @@ Exclude | `bin/**/*`, `db/**/*.rb`, `script/**/*` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No  | 0.2.0 | 0.5.0
+Disabled | Yes | No | 0.2.0 | 0.5.0
 
 No documentation
 
@@ -183,7 +183,7 @@ No documentation
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No  | 0.2.0 | 0.5.0
+Disabled | Yes | No | 0.2.0 | 0.5.0
 
 No documentation
 
@@ -191,7 +191,7 @@ No documentation
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.3.8 | -
+Enabled | Yes | No | 0.4.0 | -
 
 This cop disallows use of `T.untyped` or `T.nilable(T.untyped)`
 as a prop type for `T::Struct`.
@@ -297,6 +297,32 @@ Enabled | Yes | No | - | -
 Abstract cop specific to Sorbet signatures
 
 You can subclass it to use the `on_signature` trigger and the `signature?` node matcher.
+
+## Sorbet/SingleLineRbiClassModuleDefinitions
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.86 | -
+
+This cop ensures empty class/module definitions in RBI files are
+done on a single line rather than being split across multiple lines.
+
+### Examples
+
+```ruby
+# bad
+module SomeModule
+end
+
+# good
+module SomeModule;end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/*.rbi` | Array
 
 ## Sorbet/StrictSigil
 

--- a/spec/rubocop/cop/sorbet/single_line_rbi_class_module_definitions_spec.rb
+++ b/spec/rubocop/cop/sorbet/single_line_rbi_class_module_definitions_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(RuboCop::Cop::Sorbet::SingleLineRbiClassModuleDefinitions, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe('offences') do
+    it 'registers an offense when an empty module definition is split across multiple lines' do
+      expect_offense(<<~RBI)
+        module MyModule
+        ^^^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
+        end
+
+        module SecondModule
+        ^^^^^^^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
+        end
+      RBI
+    end
+
+    it 'registers an offence when an empty class definition is split across multiple lines' do
+      expect_offense(<<~RBI)
+        class MyClass
+        ^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
+        end
+
+        class AnotherClass < SomeParentClass
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
+        end
+      RBI
+    end
+  end
+
+  describe('no offences') do
+    it 'does not register an offense when empty module definition is done on a single line' do
+      expect_no_offenses(<<~RBI)
+        module MyModule; end
+
+        module AnotherModule; end
+      RBI
+    end
+
+    it 'does not register an offense when empty class definition is done on a single line' do
+      expect_no_offenses(<<~RBI)
+        class MyClass; end
+
+        class AnotherClass < SomeParentClass; end
+      RBI
+    end
+
+    it 'does not register an offence when a module is not empty' do
+      expect_no_offenses(<<~RBI)
+        module MyModule
+          def hello; end
+        end
+
+        module AnotherModule
+          def world
+          end
+        end
+      RBI
+    end
+  end
+
+  describe('autocorrect') do
+    it 'autocorrects multi-line module definitions to a single line' do
+      source = <<~RBI
+        module MyModule
+        end
+
+        module AnotherModule
+
+
+        end
+      RBI
+      expect(autocorrect_source(source))
+        .to(eq(<<~RBI))
+          module MyModule; end
+
+          module AnotherModule; end
+        RBI
+    end
+
+    it 'autocorrects multi-line class definitions to a single line' do
+      source = <<~RBI
+        class MyClass
+
+
+
+
+        end
+
+        class AnotherClass < SomeClass
+        end
+      RBI
+      expect(autocorrect_source(source))
+        .to(eq(<<~RBI))
+          class MyClass; end
+
+          class AnotherClass < SomeClass; end
+        RBI
+    end
+
+    it 'autocorrects multi-line definitions and ignores non-empty modules' do
+      source = <<~RBI
+        module MyModule
+          def hello_world
+          end
+        end
+
+        module ModuleWithWhitespace
+
+
+        end
+      RBI
+      expect(autocorrect_source(source))
+        .to(eq(<<~RBI))
+          module MyModule
+            def hello_world
+            end
+          end
+
+          module ModuleWithWhitespace; end
+        RBI
+    end
+  end
+end


### PR DESCRIPTION
Empty class/module definitions in RBI files should be expressed on a single line rather than multiple lines.

This is my first crack at writing one of these! Keen for any feedback.