### PR TITLE
Add one ancestor per requires_ancestor cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -92,6 +92,11 @@ Sorbet/KeywordArgumentOrdering:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/OnedAncestorPerLine:
+  Description: 'Enforces one ancestor per call to requires_ancestor'
+  Enabled: false
+  VersionAdded: '0.86'
+
 Sorbet/ParametersOrderingInSignature:
   Description: 'Enforces same parameter order between a method and its signature.'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/one_ancestor_per_line.rb
+++ b/lib/rubocop/cop/sorbet/one_ancestor_per_line.rb
@@ -1,0 +1,75 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop ensures one ancestor per requires_ancestor line
+      # rather than chaining them as a comma-separated list.
+      #
+      # @example
+      #
+      #   # bad
+      #   module SomeModule
+      #     requires_ancestor Kernel, Minitest::Assertions
+      #   end
+      #
+      #   # good
+      #   module SomeModule
+      #     requires_ancestor Kernel
+      #     requires_ancestor Minitest::Assertions
+      #   end
+      class OneAncestorPerLine < RuboCop::Cop::Cop
+        MSG = 'Cannot require more than one ancestor per line'
+
+        def_node_search :requires_ancestors, <<~PATTERN
+          (send nil? :requires_ancestor ...)
+        PATTERN
+
+        def_node_matcher :more_than_one_ancestor, <<~PATTERN
+          (send nil? :requires_ancestor const const+)
+        PATTERN
+
+        def_node_search :abstract?, <<~PATTERN
+          (send nil? :abstract!)
+        PATTERN
+
+        def on_module(node)
+          return unless node.body
+          return unless requires_ancestors(node)
+          process_node(node)
+        end
+
+        def on_class(node)
+          return unless abstract?(node)
+          return unless requires_ancestors(node)
+          process_node(node)
+        end
+
+        def autocorrect(node)
+          -> (corrector) do
+            ra_call = node.parent
+            split_ra_calls = ra_call.source.gsub(/,\s+/, new_ra_line(ra_call.loc.column))
+            corrector.replace(ra_call, split_ra_calls)
+          end
+        end
+
+        private
+
+        def process_node(node)
+          requires_ancestors(node).each do |ra|
+            add_offense(ra.child_nodes[1]) if more_than_one_ancestor(ra)
+          end
+        end
+
+        def new_ra_line(indent_count)
+          indents = " " * indent_count
+          indented_ra_call = "#{indents}requires_ancestor "
+          "\n#{indented_ra_call}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -5,6 +5,7 @@ require_relative 'sorbet/forbid_superclass_const_literal'
 require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
 require_relative 'sorbet/single_line_rbi_class_module_definitions'
+require_relative 'sorbet/one_ancestor_per_line'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -18,6 +18,7 @@ In the following section you find all available cops:
 * [Sorbet/HasSigil](cops_sorbet.md#sorbethassigil)
 * [Sorbet/IgnoreSigil](cops_sorbet.md#sorbetignoresigil)
 * [Sorbet/KeywordArgumentOrdering](cops_sorbet.md#sorbetkeywordargumentordering)
+* [Sorbet/OneAncestorPerLine](cops_sorbet.md#sorbetoneancestorperline)
 * [Sorbet/ParametersOrderingInSignature](cops_sorbet.md#sorbetparametersorderinginsignature)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
 * [Sorbet/SignatureCop](cops_sorbet.md#sorbetsignaturecop)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -258,6 +258,30 @@ sig { params(b: String, a: Integer).void }
 def foo(b:, a: 1); end
 ```
 
+## Sorbet/OneAncestorPerLine
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | - | -
+
+This cop ensures one ancestor per requires_ancestor line
+rather than chaining them as a comma-separated list.
+
+### Examples
+
+```ruby
+# bad
+module SomeModule
+  requires_ancestor Kernel, Minitest::Assertions
+end
+
+# good
+module SomeModule
+  requires_ancestor Kernel
+  requires_ancestor Minitest::Assertions
+end
+```
+
 ## Sorbet/ParametersOrderingInSignature
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -302,7 +326,7 @@ You can subclass it to use the `on_signature` trigger and the `signature?` node 
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.86 | -
+Disabled | Yes | Yes  | 0.86 | -
 
 This cop ensures empty class/module definitions in RBI files are
 done on a single line rather than being split across multiple lines.
@@ -315,7 +339,7 @@ module SomeModule
 end
 
 # good
-module SomeModule;end
+module SomeModule; end
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/sorbet/one_ancestor_per_line_spec.rb
+++ b/spec/rubocop/cop/sorbet/one_ancestor_per_line_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(RuboCop::Cop::Sorbet::OneAncestorPerLine, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe('no offences') do
+    it 'adds no offences when there are no requires_ancestor calls' do
+      expect_no_offenses(<<~RUBY)
+        module MyModule
+          def hello_world; end
+        end
+      RUBY
+    end
+
+    it 'adds no offences when just one ancestor is required per line' do
+      expect_no_offenses(<<~RUBY)
+        module MyModule
+          requires_ancestor Kernel
+          requires_ancestor Minitest::Assertions
+          requires_ancestor Foo::Bar
+        end
+      RUBY
+    end
+
+    it 'adds no offences when an abstract class does not require any ancestors' do
+      expect_no_offenses(<<~RUBY)
+        class MyClass
+          extend T::Sig
+          extend T::Helpers
+          abstract!
+
+          sig {abstract.void}
+          def self.foo; end
+        end
+      RUBY
+    end
+
+    it 'adds no offences when an abstract class has just one required ancestor per line' do
+      expect_no_offenses(<<~RUBY)
+        class MyClass
+          extend T::Sig
+          extend T::Helpers
+          requires_ancestor Kernel
+          requires_ancestor Minitest::Assertions
+          requires_ancestor Foo::Bar
+
+          abstract!
+
+          sig {abstract.void}
+          def self.foo; end
+        end
+      RUBY
+    end
+  end
+
+  describe('offenses') do
+    it 'adds offences when more than one ancestor is required on a line' do
+      expect_offense(<<~RUBY)
+        module MyModule
+          requires_ancestor Kernel, Minitest::Assertions, SomeOtherModule, Foo::Bar
+                                    ^^^^^^^^^^^^^^^^^^^^ Cannot require more than one ancestor per line
+        end
+      RUBY
+    end
+
+    it 'adds offences when a number of ancestors are formatted across multiple lines' do
+      expect_offense(<<~RUBY)
+        module MyModule
+          requires_ancestor Kernel, Minitest::Assertions,
+                                    ^^^^^^^^^^^^^^^^^^^^ Cannot require more than one ancestor per line
+            SomeOtherModule, Foo::Bar
+        end
+      RUBY
+    end
+
+    it 'adds offences to abstract classes that use more than one ancestor per line' do
+      expect_offense(<<~RUBY)
+        class MyClass
+          extend T::Sig
+          extend T::Helpers
+          requires_ancestor Kernel, Minitest::Assertions, Foo::Bar
+                                    ^^^^^^^^^^^^^^^^^^^^ Cannot require more than one ancestor per line
+          abstract!
+
+          sig {abstract.void}
+          def self.foo; end
+        end
+      RUBY
+    end
+
+    it 'adds an offence to a module inside a not-abstract class' do
+      expect_offense(<<~RUBY)
+        class Foo
+          # not abstract
+
+          module Bar
+            requires_ancestor Kernel, Minitest::Assertions
+                                      ^^^^^^^^^^^^^^^^^^^^ Cannot require more than one ancestor per line
+          end
+        end
+      RUBY
+    end
+
+    it 'adds an offence to a module inside a not-abstract class' do
+      expect_offense(<<~RUBY)
+        class Foo
+          extend T::Helpers
+
+          abstract!
+
+          module Bar
+            requires_ancestor Kernel, Minitest::Assertions
+                                      ^^^^^^^^^^^^^^^^^^^^ Cannot require more than one ancestor per line
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe('Autocorrect') do
+    it 'autocorrects the source to have requires_ancestor only call one ancestor per line' do
+      source = <<~RUBY
+        module MyModule
+          requires_ancestor Kernel, Minitest::Assertions, SomeOtherModule, Foo::Bar
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module MyModule
+            requires_ancestor Kernel
+            requires_ancestor Minitest::Assertions
+            requires_ancestor SomeOtherModule
+            requires_ancestor Foo::Bar
+          end
+        RUBY
+    end
+
+    it 'autocorrects when a large number of calls are formatted across multiple lines' do
+      source = <<~RUBY
+        module MyModule
+          requires_ancestor Kernel, Minitest::Assertions,
+            SomeOtherModule, Foo::Bar
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module MyModule
+            requires_ancestor Kernel
+            requires_ancestor Minitest::Assertions
+            requires_ancestor SomeOtherModule
+            requires_ancestor Foo::Bar
+          end
+        RUBY
+    end
+
+    it 'does not try to autocorrect otherwise valid code' do
+      source = <<~RUBY
+        module MyModule
+          requires_ancestor Kernel, Minitest::Assertions,
+            SomeOtherModule, Foo::Bar
+
+          def foo(one, two)
+            # Method body
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module MyModule
+            requires_ancestor Kernel
+            requires_ancestor Minitest::Assertions
+            requires_ancestor SomeOtherModule
+            requires_ancestor Foo::Bar
+
+            def foo(one, two)
+              # Method body
+            end
+          end
+        RUBY
+    end
+
+    it 'autocorrects abstract classes correctly' do
+      source = <<~RUBY
+        class MyClass
+          extend T::Sig
+          extend T::Helpers
+          requires_ancestor Kernel, Minitest::Assertions, Foo::Bar
+
+          abstract!
+
+          sig {abstract.void}
+          def self.foo; end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          class MyClass
+            extend T::Sig
+            extend T::Helpers
+            requires_ancestor Kernel
+            requires_ancestor Minitest::Assertions
+            requires_ancestor Foo::Bar
+
+            abstract!
+
+            sig {abstract.void}
+            def self.foo; end
+          end
+        RUBY
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to enforce that each requires_ancestor call is on a separate line, rather than chained together.

```ruby
# bad
module SomeModule
  requires_ancestor Kernel, Minitest::Assertions
end

# good
module SomeModule
  requires_ancestor Kernel
  requires_ancestor Minitest::Assertions
end
```