### PR TITLE
Exclude files in `db/migrate` from `ForbidSuperclassConstLiteral`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -101,7 +101,7 @@ Sorbet/KeywordArgumentOrdering:
   Enabled: true
   VersionAdded: 0.2.0
 
-Sorbet/OnedAncestorPerLine:
+Sorbet/OneAncestorPerLine:
   Description: 'Enforces one ancestor per call to requires_ancestor'
   Enabled: false
   VersionAdded: '0.6.0'

--- a/config/default.yml
+++ b/config/default.yml
@@ -70,7 +70,9 @@ Sorbet/ForbidSuperclassConstLiteral:
   Description: 'Forbid superclasses which are non-literal constants.'
   Enabled: false
   VersionAdded: 0.2.0
-  VersionChanged: 0.5.0
+  VersionChanged: 0.6.1
+  Exclude:
+  - db/migrate/*.rb
 
 Sorbet/ForbidUntypedStructProps:
   Description: >-

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -217,9 +217,15 @@ No documentation
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.2.0 | 0.5.0
+Disabled | Yes | No | 0.2.0 | 0.6.1
 
 No documentation
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Exclude | `db/migrate/*.rb` | Array
 
 ## Sorbet/ForbidUntypedStructProps
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -302,7 +302,7 @@ def foo(b:, a: 1); end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Disabled | Yes | Yes  | 0.6.0 | -
 
 This cop ensures one ancestor per requires_ancestor line
 rather than chaining them as a comma-separated list.


### PR DESCRIPTION
Resolves https://github.com/Shopify/rubocop-sorbet/issues/52

Also fixes a typo that I had previously introduced.