### PR TITLE
Add scope helper position cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -111,6 +111,11 @@ Sorbet/ParametersOrderingInSignature:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/ScopeHelperPosition:
+  Description: 'Enforces that helpers such as abstract!, interface! and final! appear before method definitions.'
+  Enabled: true
+  VersionAdded: 0.7.0
+
 Sorbet/SignatureBuildOrder:
   Description: >-
                   Enforces the order of parts in a signature.

--- a/lib/rubocop/cop/sorbet/scope_helper_position.rb
+++ b/lib/rubocop/cop/sorbet/scope_helper_position.rb
@@ -31,7 +31,7 @@ module RuboCop
       #   end
       class ScopeHelperPosition < RuboCop::Cop::Cop
         include RangeHelp
-        HELPERS = %i(interface! abstract! final!).freeze
+        HELPERS = %i(interface! abstract! final! sealed!).freeze
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/sorbet/scope_helper_position.rb
+++ b/lib/rubocop/cop/sorbet/scope_helper_position.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop ensures that helpers such as abstract!, interface! and final!
+      # are invoke before any method definitions
+      #
+      # @example
+      #
+      #   # bad
+      #   module Interface
+      #     extend T::Sig
+      #     extend T::Helpers
+      #
+      #     sig { returns(String) }
+      #     def foo; end
+      #
+      #     interface!
+      #   end
+      #
+      #   # good
+      #   module Interface
+      #     extend T::Sig
+      #     extend T::Helpers
+      #
+      #     interface!
+      #
+      #     sig { returns(String) }
+      #     def foo; end
+      #   end
+      class ScopeHelperPosition < RuboCop::Cop::Cop
+        include RangeHelp
+        HELPERS = %i(interface! abstract! final!).freeze
+
+        def autocorrect(node)
+          lambda do |corrector|
+            end_pos = if processed_source[node.source_range.line].blank? &&
+              processed_source[node.source_range.line - 2].blank?
+              node.source_range.end_pos + 1
+            else
+              node.source_range.end_pos
+            end
+
+            range = range_between(node.source_range.begin_pos, end_pos)
+            corrector.remove(range_by_whole_lines(range, include_final_newline: true))
+
+            first_def = node.parent.each_child_node.find(&:def_type?)
+            first_sig = node.parent.each_child_node.find { |child| child.method_name == :sig }
+            before_node = first_sig && first_sig.first_line < first_def.first_line ? first_sig : first_def
+            indentation = " " * before_node.loc.column
+
+            corrector.insert_before(before_node, "#{node.source}\n\n#{indentation}")
+          end
+        end
+
+        def on_send(node)
+          return unless HELPERS.include?(node.method_name)
+
+          node.parent.each_child_node do |child_node|
+            if child_node.def_type? && child_node.first_line < node.first_line
+              add_offense(node, message: "Cannot invoke #{node.method_name} after method definitions")
+              break
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/scope_helper_position.rb
+++ b/lib/rubocop/cop/sorbet/scope_helper_position.rb
@@ -55,7 +55,16 @@ module RuboCop
 
             indentation = " " * before_node.loc.column
 
+            t_helpers_node = node.parent.each_child_node.find do |child_node|
+              child_node.method_name == :extend && child_node.source == "extend T::Helpers"
+            end
+
             corrector.insert_before(before_node, "#{node.source}\n\n#{indentation}")
+
+            if t_helpers_node.first_line > before_node.first_line
+              corrector.remove(range_by_whole_lines(t_helpers_node.source_range, include_final_newline: true))
+              corrector.insert_before(before_node, "#{t_helpers_node.source}\n#{indentation}")
+            end
           end
         end
 

--- a/lib/rubocop/cop/sorbet/scope_helper_position.rb
+++ b/lib/rubocop/cop/sorbet/scope_helper_position.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Sorbet
       # This cop ensures that helpers such as abstract!, interface! and final!
-      # are invoke before any method definitions
+      # are invoke before any method definitions or invocations
       #
       # @example
       #
@@ -32,22 +32,23 @@ module RuboCop
       class ScopeHelperPosition < RuboCop::Cop::Cop
         include RangeHelp
         HELPERS = %i(interface! abstract! final! sealed!).freeze
+        ALLOWED_METHODS = %i(extend include).freeze
 
         def autocorrect(node)
           lambda do |corrector|
-            end_pos = if processed_source[node.source_range.line].blank? &&
-              processed_source[node.source_range.line - 2].blank?
-              node.source_range.end_pos + 1
-            else
-              node.source_range.end_pos
+            corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
+
+            if processed_source[node.source_range.line - 2].empty? &&
+              (processed_source[node.source_range.line].empty? || processed_source[node.source_range.line] == "end")
+              corrector.remove(
+                range_by_whole_lines(source_range(processed_source.buffer, node.source_range.line - 1, 0))
+              )
             end
 
-            range = range_between(node.source_range.begin_pos, end_pos)
-            corrector.remove(range_by_whole_lines(range, include_final_newline: true))
+            before_node = node.parent.each_child_node.find do |child_node|
+              !ALLOWED_METHODS.include?(child_node.method_name)
+            end
 
-            first_def = node.parent.each_child_node.find(&:def_type?)
-            first_sig = node.parent.each_child_node.find { |child| child.method_name == :sig }
-            before_node = first_sig && first_sig.first_line < first_def.first_line ? first_sig : first_def
             indentation = " " * before_node.loc.column
 
             corrector.insert_before(before_node, "#{node.source}\n\n#{indentation}")
@@ -58,8 +59,8 @@ module RuboCop
           return unless HELPERS.include?(node.method_name)
 
           node.parent.each_child_node do |child_node|
-            if child_node.def_type? && child_node.first_line < node.first_line
-              add_offense(node, message: "Cannot invoke #{node.method_name} after method definitions")
+            if !ALLOWED_METHODS.include?(child_node.method_name) && child_node.first_line < node.first_line
+              add_offense(node, message: "Cannot invoke #{node.method_name} after method definitions or invocations")
               break
             end
           end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -7,6 +7,7 @@ require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
 require_relative 'sorbet/single_line_rbi_class_module_definitions'
 require_relative 'sorbet/one_ancestor_per_line'
+require_relative 'sorbet/scope_helper_position'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -21,6 +21,7 @@ In the following section you find all available cops:
 * [Sorbet/KeywordArgumentOrdering](cops_sorbet.md#sorbetkeywordargumentordering)
 * [Sorbet/OneAncestorPerLine](cops_sorbet.md#sorbetoneancestorperline)
 * [Sorbet/ParametersOrderingInSignature](cops_sorbet.md#sorbetparametersorderinginsignature)
+* [Sorbet/ScopeHelperPosition](cops_sorbet.md#sorbetscopehelperposition)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
 * [Sorbet/SignatureCop](cops_sorbet.md#sorbetsignaturecop)
 * [Sorbet/SingleLineRbiClassModuleDefinitions](cops_sorbet.md#sorbetsinglelinerbiclassmoduledefinitions)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -344,6 +344,41 @@ sig { params(a: Integer, b: String).void }
 def foo(a:, b:); end
 ```
 
+## Sorbet/ScopeHelperPosition
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.0 | -
+
+This cop ensures that helpers such as abstract!, interface! and final!
+are invoke before any method definitions
+
+### Examples
+
+```ruby
+# bad
+module Interface
+  extend T::Sig
+  extend T::Helpers
+
+  sig { returns(String) }
+  def foo; end
+
+  interface!
+end
+
+# good
+module Interface
+  extend T::Sig
+  extend T::Helpers
+
+  interface!
+
+  sig { returns(String) }
+  def foo; end
+end
+```
+
 ## Sorbet/SignatureBuildOrder
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -351,7 +351,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.7.0 | -
 
 This cop ensures that helpers such as abstract!, interface! and final!
-are invoke before any method definitions
+are invoke before any method definitions or invocations
 
 ### Examples
 

--- a/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
+++ b/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
@@ -89,7 +89,35 @@ RSpec.describe(RuboCop::Cop::Sorbet::ScopeHelperPosition, :config) do
         end
       RUBY
     end
+  end
 
+  describe("no offenses") do
+    it("allows scope helpers after constants") do
+      expect_no_offenses(<<~RUBY)
+        class Abstract
+          extend T::Helpers
+
+          SOME_CONSTANT = "VALUE"
+
+          abstract!
+        end
+      RUBY
+    end
+
+    it("allows scope helpers after requires_ancestor") do
+      expect_no_offenses(<<~RUBY)
+        module Interface
+          extend(T::Sig)
+          extend(T::Helpers)
+          requires_ancestor(Kernel)
+
+          interface!
+        end
+      RUBY
+    end
+  end
+
+  describe("autocorrect") do
     it("autocorrects moving the invocation to the right spot") do
       source = <<~RUBY
         module Interface

--- a/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
+++ b/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
@@ -307,5 +307,27 @@ RSpec.describe(RuboCop::Cop::Sorbet::ScopeHelperPosition, :config) do
 
       expect(autocorrect_source(source)).to(eq(corrected_source))
     end
+
+    it("autocorrects the extend T::Helpers if necessary") do
+      source = <<~RUBY
+        class Foo
+          self.table_name = "foos"
+          extend T::Helpers
+        
+          abstract!
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Foo
+          extend T::Helpers
+          abstract!
+
+          self.table_name = "foos"
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
   end
 end

--- a/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
+++ b/spec/rubocop/cop/sorbet/scope_helper_position_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ScopeHelperPosition, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe("offenses") do
+    it("disallows using interface! after method definitions") do
+      expect_offense(<<~RUBY)
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+
+          interface!
+          ^^^^^^^^^^ Cannot invoke interface! after method definitions
+
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+    end
+
+    it("disallows abstract! after method definitions") do
+      expect_offense(<<~RUBY)
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+
+          abstract!
+          ^^^^^^^^^ Cannot invoke abstract! after method definitions
+
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+    end
+
+    it("disallows final! after method definitions") do
+      expect_offense(<<~RUBY)
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+
+          final!
+          ^^^^^^ Cannot invoke final! after method definitions
+
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+    end
+
+    it("autocorrects moving the invocation to the right spot") do
+      source = <<~RUBY
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+
+          final!
+
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          final!
+
+          sig { abstract.void }
+          def foo; end
+
+          sig { abstract.void }
+          def bar; end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects when there are no spaces after method definition") do
+      source = <<~RUBY
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+          final!
+
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          final!
+
+          sig { abstract.void }
+          def foo; end
+
+          sig { abstract.void }
+          def bar; end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects when there are no spaces before method definition") do
+      source = <<~RUBY
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          sig { abstract.void }
+          def foo; end
+
+          final!
+          sig { abstract.void }
+          def bar; end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        module Interface
+          extend T::Sig
+          extend T::Helpers
+
+          final!
+
+          sig { abstract.void }
+          def foo; end
+
+          sig { abstract.void }
+          def bar; end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects when there are no signatures") do
+      source = <<~RUBY
+        class Final
+          extend T::Sig
+          extend T::Helpers
+
+          def foo; end
+
+          final!
+
+          def bar; end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Final
+          extend T::Sig
+          extend T::Helpers
+
+          final!
+
+          def foo; end
+
+          def bar; end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+  end
+end


### PR DESCRIPTION
Add the new cop to enforce that no method definitions appear before invoking `interface!`, `abstract!` or `final!`.

There are two things in particular I'd appreciate feedback.
1. Is there a cleaner way of removing surrounding blank lines from the matched node? Basically, if there is an empty line before and after the scope helper, I want to remove both and still leave a space between method definitions. I was able to get that functionality, but it's a bit messy
2. Is the way I matched the send_node to `abstract!`, `interface!` or `final!` okay or is there a nicer way of defining that?