### PR TITLE
Add callback conditionals cop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rubocop-sorbet.gemspec
 gemspec
 
+gem "byebug"
 gem "rake", ">= 12.3.3"
 gem "rspec"
 gem "rubocop-shopify", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       ice_nine (~> 0.11.0)
       memoizable (~> 0.4.0)
     ast (2.4.0)
+    byebug (11.1.3)
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
@@ -71,6 +72,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   rake (>= 12.3.3)
   rspec
   rubocop-shopify

--- a/config/default.yml
+++ b/config/default.yml
@@ -14,6 +14,11 @@ Sorbet/BindingConstantWithoutTypeAlias:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/CallbackConditionalsBinding:
+  Description: 'Ensures callback conditionals are bound to the right type.'
+  Enabled: true
+  VersionAdded: 0.7.0
+
 Sorbet/CheckedTrueInSignature:
   Description: 'Disallows the usage of `checked(true)` in signatures.'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
+++ b/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
@@ -26,8 +26,46 @@ module RuboCop
       #     end
       #   end
       class CallbackConditionalsBinding < RuboCop::Cop::Cop
-        CALLBACKS = %i(before_create).freeze
-        include RangeHelp
+        CALLBACKS = %i(
+          before_create
+          before_save
+          before_destroy
+          before_update
+
+          after_create
+          after_save
+          after_destroy
+          after_update
+          after_touch
+          after_initialize
+          after_find
+
+          around_create
+          around_save
+          around_destroy
+          around_update
+
+          before_commit
+
+          after_commit
+          after_create_commit
+          after_destroy_commit
+          after_rollback
+          after_save_commit
+          after_update_commit
+
+          before_action
+          prepend_before_action
+          append_before_action
+
+          around_action
+          prepend_around_action
+          append_around_action
+
+          after_action
+          prepend_after_action
+          append_after_action
+        ).freeze
 
         def autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
+++ b/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
@@ -27,6 +27,12 @@ module RuboCop
       #   end
       class CallbackConditionalsBinding < RuboCop::Cop::Cop
         CALLBACKS = %i(
+          validate
+          validates
+          validates_with
+          before_validation
+          around_validation
+
           before_create
           before_save
           before_destroy

--- a/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
+++ b/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop ensures that callback conditionals are bound to the right type
+      # so that they are type checked properly.
+      #
+      # @example
+      #
+      #   # bad
+      #   class Post < ApplicationRecord
+      #     before_create :do_it, if: -> { should_do_it? }
+      #
+      #     def should_do_it?
+      #       true
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Post < ApplicationRecord
+      #     before_create :do_it, if: -> { T.bind(self, Post).should_do_it? }
+      #
+      #     def should_do_it?
+      #       true
+      #     end
+      #   end
+      class CallbackConditionalsBinding < RuboCop::Cop::Cop
+        CALLBACKS = %i(before_create).freeze
+        include RangeHelp
+
+        def autocorrect(node)
+          lambda do |corrector|
+            options = node.each_child_node.find(&:hash_type?)
+
+            conditional = nil
+            options.each_pair do |keyword, block|
+              if keyword.value == :if || keyword.value == :unless
+                conditional = block
+                break
+              end
+            end
+
+            _, _, block = conditional.child_nodes
+            expected_class = node.parent.child_nodes.first.source
+
+            bind = if block.begin_type?
+              indentation = " " * block.child_nodes.first.loc.column
+              "T.bind(self, #{expected_class})\n#{indentation}"
+            elsif block.child_nodes.empty?
+              "T.bind(self, #{expected_class})."
+            else
+              "T.bind(self, #{expected_class}); "
+            end
+
+            corrector.insert_before(block, bind)
+          end
+        end
+
+        def on_send(node)
+          return unless CALLBACKS.include?(node.method_name)
+
+          options = node.each_child_node.find(&:hash_type?)
+
+          conditional = nil
+          options.each_pair do |keyword, block|
+            if keyword.value == :if || keyword.value == :unless
+              conditional = block
+              break
+            end
+          end
+
+          return if conditional.nil?
+
+          type, _, block = conditional.child_nodes
+          return unless type.lambda_or_proc?
+
+          expected_class = node.parent.child_nodes.first.source
+
+          unless block.source.include?("T.bind(self, #{expected_class})")
+            add_offense(
+              node,
+              message: "Callback conditionals should be bound to the right type. Use T.bind(self, #{expected_class})"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -7,6 +7,7 @@ require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
 require_relative 'sorbet/single_line_rbi_class_module_definitions'
 require_relative 'sorbet/one_ancestor_per_line'
+require_relative 'sorbet/callback_conditionals_binding'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -7,6 +7,7 @@ In the following section you find all available cops:
 
 * [Sorbet/AllowIncompatibleOverride](cops_sorbet.md#sorbetallowincompatibleoverride)
 * [Sorbet/BindingConstantWithoutTypeAlias](cops_sorbet.md#sorbetbindingconstantwithouttypealias)
+* [Sorbet/CallbackConditionalsBinding](cops_sorbet.md#sorbetcallbackconditionalsbinding)
 * [Sorbet/CheckedTrueInSignature](cops_sorbet.md#sorbetcheckedtrueinsignature)
 * [Sorbet/ConstantsFromStrings](cops_sorbet.md#sorbetconstantsfromstrings)
 * [Sorbet/EnforceSigilOrder](cops_sorbet.md#sorbetenforcesigilorder)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -41,6 +41,37 @@ FooOrBar = T.any(Foo, Bar)
 FooOrBar = T.type_alias { T.any(Foo, Bar) }
 ```
 
+## Sorbet/CallbackConditionalsBinding
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.0 | -
+
+This cop ensures that callback conditionals are bound to the right type
+so that they are type checked properly.
+
+### Examples
+
+```ruby
+# bad
+class Post < ApplicationRecord
+  before_create :do_it, if: -> { should_do_it? }
+
+  def should_do_it?
+    true
+  end
+end
+
+# good
+class Post < ApplicationRecord
+  before_create :do_it, if: -> { T.bind(self, Post).should_do_it? }
+
+  def should_do_it?
+    true
+  end
+end
+```
+
 ## Sorbet/CheckedTrueInSignature
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/callback_conditionals_binding_spec.rb
+++ b/spec/rubocop/cop/callback_conditionals_binding_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe(RuboCop::Cop::Sorbet::CallbackConditionalsBinding, :config) do
         end
       RUBY
     end
+
+    it("does not verify callbacks using validator classes") do
+      expect_no_offenses(<<~RUBY)
+        class Post < ApplicationRecord
+          validates_with PostValidator
+        end
+      RUBY
+    end
+
+    it("does not verify callbacks using validator instances") do
+      expect_no_offenses(<<~RUBY)
+        class Post < ApplicationRecord
+          validates_with PostValidator.new
+        end
+      RUBY
+    end
   end
 
   describe("offenses") do

--- a/spec/rubocop/cop/callback_conditionals_binding_spec.rb
+++ b/spec/rubocop/cop/callback_conditionals_binding_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::CallbackConditionalsBinding, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe("offenses") do
+    it("disallows having if callback conditionals without bindings") do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> { should? && ready? }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callback conditionals should be bound to the right type. Use T.bind(self, Post)
+        end
+      RUBY
+    end
+
+    it("disallows having unless callback conditionals without bindings") do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it, unless: -> { shouldnt? }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callback conditionals should be bound to the right type. Use T.bind(self, Post)
+        end
+      RUBY
+    end
+
+    it("disallows having callback conditionals without bindings in multi line blocks") do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it, unless: lambda {
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callback conditionals should be bound to the right type. Use T.bind(self, Post)
+             shouldnt?
+          }
+        end
+      RUBY
+    end
+
+    it("disallows having callback conditionals without bindings in multi line blocks using do end") do
+      expect_offense(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it, unless: -> do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Callback conditionals should be bound to the right type. Use T.bind(self, Post)
+             shouldnt?
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe("autocorrect") do
+    it("autocorrects by adding the missing binding") do
+      source = <<~RUBY
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> { should? && ready? }
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> { T.bind(self, Post); should? && ready? }
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects with chaining if the lambda includes a single statement") do
+      source = <<~RUBY
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> { should? }
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> { T.bind(self, Post).should? }
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects multi line blocks with a single statement") do
+      source = <<~RUBY
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> do
+            should?
+          end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> do
+            T.bind(self, Post).should?
+          end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects multi line blocks with multie statements") do
+      source = <<~RUBY
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> do
+            a = should?
+            a && ready?
+          end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post < ApplicationRecord
+          before_create :do_it, if: -> do
+            T.bind(self, Post)
+            a = should?
+            a && ready?
+          end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+  end
+end

--- a/spec/rubocop/cop/callback_conditionals_binding_spec.rb
+++ b/spec/rubocop/cop/callback_conditionals_binding_spec.rb
@@ -5,6 +5,42 @@ require "spec_helper"
 RSpec.describe(RuboCop::Cop::Sorbet::CallbackConditionalsBinding, :config) do
   subject(:cop) { described_class.new(config) }
 
+  describe("no offenses") do
+    it("allows callbacks with no options") do
+      expect_no_offenses(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it
+        end
+      RUBY
+    end
+
+    it("allows callbacks with symbol conditionals") do
+      expect_no_offenses(<<~RUBY)
+        class Post < ApplicationRecord
+          before_create :do_it, if: :should?
+        end
+      RUBY
+    end
+
+    it("does not verify hashes with unknown keys") do
+      expect_no_offenses(<<~RUBY)
+        Validator.new.validate(key => value)
+      RUBY
+    end
+
+    it("does not verify callbacks inside concerns included blocks") do
+      expect_no_offenses(<<~RUBY)
+        module SomeConcern
+          extend ActiveSupport::Concern
+
+          included do
+            before_create :do_it, if: -> { should? }
+          end
+        end
+      RUBY
+    end
+  end
+
   describe("offenses") do
     it("disallows having if callback conditionals without bindings") do
       expect_offense(<<~RUBY)
@@ -117,6 +153,42 @@ RSpec.describe(RuboCop::Cop::Sorbet::CallbackConditionalsBinding, :config) do
             a = should?
             a && ready?
           end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("autocorrects with the correct type when there are multiple parent levels") do
+      source = <<~RUBY
+        class Post
+          extend Something
+
+          validates :it, presence: true, if: -> { should? && ready? }
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post
+          extend Something
+
+          validates :it, presence: true, if: -> { T.bind(self, Post); should? && ready? }
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("does not try to chain if the condition is an instance variable") do
+      source = <<~RUBY
+        class Post
+          validates :it, presence: true, if: -> { @ready }
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Post
+          validates :it, presence: true, if: -> { T.bind(self, Post); @ready }
         end
       CORRECTED
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "rubocop-sorbet"
 require "rubocop/rspec/support"
+require "byebug"
 
 RSpec.configure do |config|
   config.include(RuboCop::RSpec::ExpectOffense)


### PR DESCRIPTION
This PR does two things in different commits

1. Add `byebug` to the project. It's hard to figure out small details without it 😅 
2. Add the callback conditionals binding cop, to ensure that blocks are type checked against the right types

E.g.:
```ruby
# Bad. Sorbet is not able to determine that the block will be executed in the context of an instance
# and then thinks `should?` is undefined
class Post < ApplicationRecord
  before_create :do_it, if: -> { should? }
end

# Good. By binding it to the right type, Sorbet is able to type check the block
class Post < ApplicationRecord
  before_create :do_it, if: -> { T.bind(self, Post).should? }
end
```