### PR TITLE
Add extend sig position cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -43,6 +43,11 @@ Sorbet/EnforceSignatures:
   Enabled: false
   VersionAdded: 0.3.4
 
+Sorbet/ExtendSigPosition:
+  Description: 'Ensures extend T::Sig is always invoked first in classes/modules.'
+  Enabled: true
+  VersionAdded: 0.7.0
+
 Sorbet/FalseSigil:
   Description: 'All files must be at least at strictness `false`.'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/extend_sig_position.rb
+++ b/lib/rubocop/cop/sorbet/extend_sig_position.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop ensures that, if extend T::Sig is used in a class/module, it
+      # is the first statement inside it.
+      #
+      # @example
+      #
+      #   # bad
+      #   module Interface
+      #     include Something
+      #     extend T::Sig
+      #   end
+      #
+      #   # good
+      #   module Interface
+      #     extend T::Sig
+      #     include Something
+      #   end
+      class ExtendSigPosition < RuboCop::Cop::Cop
+        include RangeHelp
+
+        def_node_matcher :extend_t_sig?, <<~PATTERN
+          (send nil? :extend (const (const nil? :T) :Sig))
+        PATTERN
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
+
+            first_node = node.parent.child_nodes.first
+            indentation = " " * first_node.loc.column
+            corrector.insert_before(first_node, "#{node.source}\n#{indentation}")
+
+            if processed_source[node.source_range.line - 2].empty? &&
+              (processed_source[node.source_range.line].empty? || processed_source[node.source_range.line] == "end")
+              corrector.remove(
+                range_by_whole_lines(source_range(processed_source.buffer, node.source_range.line - 1, 0))
+              )
+            end
+          end
+        end
+
+        def on_send(node)
+          return unless extend_t_sig?(node)
+
+          unless node.parent.child_nodes[0] == node
+            add_offense(node, message: "extend T::Sig should be the first statement of a class/module")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -8,6 +8,7 @@ require_relative 'sorbet/forbid_untyped_struct_props'
 require_relative 'sorbet/single_line_rbi_class_module_definitions'
 require_relative 'sorbet/one_ancestor_per_line'
 require_relative 'sorbet/callback_conditionals_binding'
+require_relative 'sorbet/extend_sig_position'
 
 require_relative 'sorbet/signatures/allow_incompatible_override'
 require_relative 'sorbet/signatures/checked_true_in_signature'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -12,6 +12,7 @@ In the following section you find all available cops:
 * [Sorbet/ConstantsFromStrings](cops_sorbet.md#sorbetconstantsfromstrings)
 * [Sorbet/EnforceSigilOrder](cops_sorbet.md#sorbetenforcesigilorder)
 * [Sorbet/EnforceSignatures](cops_sorbet.md#sorbetenforcesignatures)
+* [Sorbet/ExtendSigPosition](cops_sorbet.md#sorbetextendsigposition)
 * [Sorbet/FalseSigil](cops_sorbet.md#sorbetfalsesigil)
 * [Sorbet/ForbidExtendTSigHelpersInShims](cops_sorbet.md#sorbetforbidextendtsighelpersinshims)
 * [Sorbet/ForbidIncludeConstLiteral](cops_sorbet.md#sorbetforbidincludeconstliteral)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -186,6 +186,31 @@ You can configure the placeholders used by changing the following options:
 * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
 * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
 
+## Sorbet/ExtendSigPosition
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.0 | -
+
+This cop ensures that, if extend T::Sig is used in a class/module, it
+is the first statement inside it.
+
+### Examples
+
+```ruby
+# bad
+module Interface
+  include Something
+  extend T::Sig
+end
+
+# good
+module Interface
+  extend T::Sig
+  include Something
+end
+```
+
 ## Sorbet/FalseSigil
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/sorbet/extend_sig_position_spec.rb
+++ b/spec/rubocop/cop/sorbet/extend_sig_position_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ExtendSigPosition, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe("offenses") do
+    it("enforces that extend T::Sig is the first line in a class/module") do
+      expect_offense(<<~RUBY)
+        class Abstract
+          include Something
+          extend T::Sig
+          ^^^^^^^^^^^^^ extend T::Sig should be the first statement of a class/module
+        end
+      RUBY
+    end
+  end
+
+  describe("valid uses") do
+    it("respects usage of nested modules or classes") do
+      expect_no_offenses(<<~RUBY)
+        module Namespace
+          extend T::Sig
+
+          class First
+            extend T::Sig
+            include Something
+          end
+
+          class Second
+            extend T::Sig
+            include Something
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe("autocorrect") do
+    it("moves the extend to the first position inside class/module") do
+      source = <<~RUBY
+        class Abstract
+          include Something
+          extend T::Sig
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Abstract
+          extend T::Sig
+          include Something
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("handles empty lines before extend") do
+      source = <<~RUBY
+        class Abstract
+          include Something
+
+          extend T::Sig
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Abstract
+          extend T::Sig
+          include Something
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("handles empty lines after extend") do
+      source = <<~RUBY
+        class Abstract
+          include Something
+
+          extend T::Sig
+
+          def foo; end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        class Abstract
+          extend T::Sig
+          include Something
+
+          def foo; end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+
+    it("handles nested classes/modules") do
+      source = <<~RUBY
+        module Namespace
+          include Something
+          extend T::Sig
+
+          class First
+            include AnotherThing
+            extend T::Sig
+          end
+
+          class Second
+            include AnotherThing
+            extend T::Sig
+          end
+        end
+      RUBY
+
+      corrected_source = <<~CORRECTED
+        module Namespace
+          extend T::Sig
+          include Something
+
+          class First
+            extend T::Sig
+            include AnotherThing
+          end
+
+          class Second
+            extend T::Sig
+            include AnotherThing
+          end
+        end
+      CORRECTED
+
+      expect(autocorrect_source(source)).to(eq(corrected_source))
+    end
+  end
+end


### PR DESCRIPTION
This PR is the first of 3 cops related to #59

We realized that, in order to be able to safely autocorrect scope helpers, we need to make sure that the first line in classes/modules is `extend T::Sig`, the second `extend T::Helpers` and then the scope helper. Other attempts to autocorrect could lead to broken code after the correction.

Splitting this into 3 cops works better, since each cop is only responsible to autocorrect a single type of node.

This PR adds the cop to correct the position of `extend T::Sig` and always move it to the first thing inside a class or module.

The next PR will include the `extend T::Helpers` cop and finally we'll adapt #59 to only take care of the scope helpers.