### PR TITLE
Declare strictness options in default configuration

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -89,6 +89,8 @@ Sorbet/ForbidUntypedStructProps:
 Sorbet/HasSigil:
   Description: 'Makes the Sorbet typed sigil mandatory in all files.'
   Enabled: false
+  SuggestedStrictness: "false"
+  MinimumStrictness: "false"
   VersionAdded: 0.3.3
 
 Sorbet/IgnoreSigil:

--- a/config/default.yml
+++ b/config/default.yml
@@ -47,7 +47,7 @@ Sorbet/FalseSigil:
   Description: 'All files must be at least at strictness `false`.'
   Enabled: true
   VersionAdded: 0.3.3
-  SuggestedStrictness: true
+  SuggestedStrictness: "true"
   Include:
   - "**/*.rb"
   - "**/*.rbi"
@@ -96,6 +96,7 @@ Sorbet/HasSigil:
 Sorbet/IgnoreSigil:
   Description: 'All files must be at least at strictness `ignore`.'
   Enabled: false
+  SuggestedStrictness: "ignore"
   VersionAdded: 0.3.3
 
 Sorbet/KeywordArgumentOrdering:
@@ -138,16 +139,19 @@ Sorbet/SingleLineRbiClassModuleDefinitions:
 Sorbet/StrictSigil:
   Description: 'All files must be at least at strictness `strict`.'
   Enabled: false
+  SuggestedStrictness: "strict"
   VersionAdded: 0.3.3
 
 Sorbet/StrongSigil:
   Description: 'All files must be at least at strictness `strong`.'
   Enabled: false
+  SuggestedStrictness: "strong"
   VersionAdded: 0.3.3
 
 Sorbet/TrueSigil:
   Description: 'All files must be at least at strictness `true`.'
   Enabled: false
+  SuggestedStrictness: "true"
   VersionAdded: 0.3.3
 
 Sorbet/ValidSigil:

--- a/config/default.yml
+++ b/config/default.yml
@@ -151,4 +151,7 @@ Sorbet/TrueSigil:
 Sorbet/ValidSigil:
   Description: 'All files must have a valid sigil.'
   Enabled: true
+  RequireSigilOnAllFiles: false
+  SuggestedStrictness: "false"
+  MinimumStrictness: "false"
   VersionAdded: 0.3.3

--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -147,12 +147,14 @@ module RuboCop
 
         # Default is `'false'`
         def suggested_strictness
-          STRICTNESS_LEVELS.include?(cop_config['SuggestedStrictness']) ? cop_config['SuggestedStrictness'] : 'false'
+          config = cop_config['SuggestedStrictness'].to_s
+          STRICTNESS_LEVELS.include?(config) ? config : 'false'
         end
 
         # Default is `nil`
         def minimum_strictness
-          cop_config['MinimumStrictness'] if STRICTNESS_LEVELS.include?(cop_config['MinimumStrictness'])
+          config = cop_config['MinimumStrictness'].to_s
+          config if STRICTNESS_LEVELS.include?(config)
         end
       end
     end


### PR DESCRIPTION
As noted by @bmulholland in #64, a few of the options expected by the `ValidSigil` and `HasSigil` cops are not declared properly resulting in warnings to the user:

```
Warning: Sorbet/HasSigil does not support SuggestedStrictness parameter.
Warning: Sorbet/ValidSigil does not support SuggestedStrictness parameter.
Warning: Sorbet/ValidSigil does not support MinimumStrictness parameter.
Warning: Sorbet/ValidSigil does not support RequireSigilOnAllFiles parameter.
```

This PR adds these options to the `config/default.yml` thus removing the warnings.

Another problem was that with this configuration:

```yml
Sorbet/ValidSigil:
  Enabled: true
  SuggestedStrictness: true
  MinimumStrictness: true
  RequireSigilOnAllFiles: true
```

Both `SuggestedStrictness` and `MinimumStrictness` were parsed as a boolean, resulting in inclusion tests [here](https://github.com/Shopify/rubocop-sorbet/blob/master/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb#L150) and [here](https://github.com/Shopify/rubocop-sorbet/blob/master/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb#L155) failing since we tried to match a string.

This PR also fixes this problem (see added tests).

Fixes #64.