### PR TITLE
Add ForbidTUnsafe cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -86,6 +86,12 @@ Sorbet/ForbidSuperclassConstLiteral:
   Exclude:
   - db/migrate/*.rb
 
+Sorbet/ForbidTUnsafe:
+  Description: 'Forbid usage of T.unsafe.'
+  Enabled: false
+  VersionAdded: 0.7.0
+  VersionChanged: 0.7.0
+
 Sorbet/ForbidUntypedStructProps:
   Description: >-
                   Disallows use of `T.untyped` or `T.nilable(T.untyped)` as a

--- a/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop disallows using `T.unsafe` anywhere.
+      #
+      # @example
+      #
+      #   # bad
+      #   T.unsafe(foo)
+      #
+      #   # good
+      #   foo
+      class ForbidTUnsafe < RuboCop::Cop::Cop
+        def_node_matcher(:t_unsafe?, '(send (const nil? :T) :unsafe _)')
+
+        def on_send(node)
+          add_offense(node, message: "Do not use `T.unsafe`.") if t_unsafe?(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -6,6 +6,7 @@ require_relative 'sorbet/forbid_include_const_literal'
 require_relative 'sorbet/forbid_untyped_struct_props'
 require_relative 'sorbet/one_ancestor_per_line'
 require_relative 'sorbet/callback_conditionals_binding'
+require_relative 'sorbet/forbid_t_unsafe'
 
 require_relative 'sorbet/rbi/forbid_extend_t_sig_helpers_in_shims'
 require_relative 'sorbet/rbi/forbid_rbi_outside_of_sorbet_dir'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -17,6 +17,7 @@ In the following section you find all available cops:
 * [Sorbet/ForbidIncludeConstLiteral](cops_sorbet.md#sorbetforbidincludeconstliteral)
 * [Sorbet/ForbidRBIOutsideOfSorbetDir](cops_sorbet.md#sorbetforbidrbioutsideofsorbetdir)
 * [Sorbet/ForbidSuperclassConstLiteral](cops_sorbet.md#sorbetforbidsuperclassconstliteral)
+* [Sorbet/ForbidTUnsafe](cops_sorbet.md#sorbetforbidtunsafe)
 * [Sorbet/ForbidUntypedStructProps](cops_sorbet.md#sorbetforbiduntypedstructprops)
 * [Sorbet/HasSigil](cops_sorbet.md#sorbethassigil)
 * [Sorbet/IgnoreSigil](cops_sorbet.md#sorbetignoresigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -284,6 +284,24 @@ Name | Default value | Configurable values
 --- | --- | ---
 Exclude | `db/migrate/*.rb` | Array
 
+## Sorbet/ForbidTUnsafe
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | No | 0.7.0 | 0.7.0
+
+This cop disallows using `T.unsafe` anywhere.
+
+### Examples
+
+```ruby
+# bad
+T.unsafe(foo)
+
+# good
+foo
+```
+
 ## Sorbet/ForbidUntypedStructProps
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/sorbet/forbid_t_unsafe_spec.rb
+++ b/spec/rubocop/cop/sorbet/forbid_t_unsafe_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUnsafe, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  it 'adds offense when using T.unsafe' do
+    expect_offense(<<~RUBY)
+      T.unsafe(foo)
+      ^^^^^^^^^^^^^ Do not use `T.unsafe`.
+    RUBY
+  end
+end


### PR DESCRIPTION
I don't think this cop should be enabled by default, as it's a very common and convenient way to bail out of type checks when Sorbet can't figure out what's going on. However, there are times when you want to find all usage of `T.unsafe` in your codebase. For example, when tapioca releases new DSLs that make it so that more things can be typed, a lot of the time that means we can get rid of things that we previously called `T.unsafe`. So this cop is mostly to find and document those usages so that they don't get lost.