### PR TITLE
Add version bounds to unparser dependency

### DIFF
--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency("rspec", "~> 3.7")
-  spec.add_development_dependency("unparser")
+  spec.add_development_dependency("unparser", "~> 0.6")
 
   spec.add_runtime_dependency("rubocop")
 end


### PR DESCRIPTION
Unparser `0.5` is not compatible with recent ruby releases. And to avoid frustration we should pin to the latest stable version.