### PR TITLE
Mark callback binding cop as unsafe and disable it by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -16,7 +16,8 @@ Sorbet/BindingConstantWithoutTypeAlias:
 
 Sorbet/CallbackConditionalsBinding:
   Description: 'Ensures callback conditionals are bound to the right type.'
-  Enabled: true
+  Enabled: false
+  Safe: false
   VersionAdded: 0.7.0
 
 Sorbet/CheckedTrueInSignature:

--- a/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
+++ b/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
@@ -7,7 +7,7 @@ module RuboCop
       # so that they are type checked properly.
       #
       # Auto-correction is unsafe because other libraries define similar style callbacks as Rails, but don't always need
-      # binding to the attached class. Auto-correcting those usages can lead to false positives and auto-corretion
+      # binding to the attached class. Auto-correcting those usages can lead to false positives and auto-correction
       # introduces new typing errors.
       #
       # @example

--- a/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
+++ b/lib/rubocop/cop/sorbet/callback_conditionals_binding.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop ensures that callback conditionals are bound to the right type
       # so that they are type checked properly.
       #
+      # Auto-correction is unsafe because other libraries define similar style callbacks as Rails, but don't always need
+      # binding to the attached class. Auto-correcting those usages can lead to false positives and auto-corretion
+      # introduces new typing errors.
+      #
       # @example
       #
       #   # bad

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -45,10 +45,14 @@ FooOrBar = T.type_alias { T.any(Foo, Bar) }
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.7.0 | -
+Disabled | No | Yes  | 0.7.0 | -
 
 This cop ensures that callback conditionals are bound to the right type
 so that they are type checked properly.
+
+Auto-correction is unsafe because other libraries define similar style callbacks as Rails, but don't always need
+binding to the attached class. Auto-correcting those usages can lead to false positives and auto-corretion
+introduces new typing errors.
 
 ### Examples
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -51,7 +51,7 @@ This cop ensures that callback conditionals are bound to the right type
 so that they are type checked properly.
 
 Auto-correction is unsafe because other libraries define similar style callbacks as Rails, but don't always need
-binding to the attached class. Auto-correcting those usages can lead to false positives and auto-corretion
+binding to the attached class. Auto-correcting those usages can lead to false positives and auto-correction
 introduces new typing errors.
 
 ### Examples


### PR DESCRIPTION
The callback binding cop has an unsafe auto-correct, since some libraries define similar style callbacks using the same names as Rails, but that need different types of bindings. This can lead to false positives and introduce typing errors when running auto-correct.

This PR just disables the cop by default, marks it as unsafe and adds a note about why in the documentation.