### PR TITLE
Allow signatures declared with `T::Sig(::WithoutRuntime)`

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -48,8 +48,8 @@ module RuboCop
           check_node(node) if accessor?(node)
         end
 
-        def on_block(node)
-          @last_sig_for_scope[scope(node)] = node if signature?(node)
+        def on_signature(node)
+          @last_sig_for_scope[scope(node)] = node
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/sorbet/signatures/signature_cop.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_cop.rb
@@ -12,8 +12,23 @@ module RuboCop
         @registry = Cop.registry # So we can properly subclass this cop
 
         def_node_matcher(:signature?, <<~PATTERN)
-          (block (send nil? :sig) (args) ...)
+          (block (send #allowed_recv :sig) (args) ...)
         PATTERN
+
+        def_node_matcher(:with_runtime?, <<~PATTERN)
+          (const (const nil? :T) :Sig)
+        PATTERN
+
+        def_node_matcher(:without_runtime?, <<~PATTERN)
+          (const (const (const nil? :T) :Sig) :WithoutRuntime)
+        PATTERN
+
+        def allowed_recv(recv)
+          return true unless recv
+          return true if with_runtime?(recv)
+          return true if without_runtime?(recv)
+          false
+        end
 
         def on_block(node)
           on_signature(node) if signature?(node)

--- a/spec/rubocop/cop/sorbet/signatures/enforce_signatures_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/enforce_signatures_spec.rb
@@ -149,6 +149,42 @@ RSpec.describe(RuboCop::Cop::Sorbet::EnforceSignatures, :config) do
       RUBY
     end
 
+    it "makes no offense if the signature is declared with T::Sig::WithoutRuntime.sig" do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          T::Sig::WithoutRuntime.sig { void }
+          def foo; end
+        end
+      RUBY
+    end
+
+    it "makes no offense if the signature is declared with T::Sig.sig" do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          T::Sig.sig { void }
+          def foo; end
+        end
+      RUBY
+    end
+
+    it "makes offense if the signature on an unknown receiver" do
+      expect_offense(<<~RUBY)
+        class Foo
+          T::Sig::WithRuntime.sig { void }
+          def foo; end
+          ^^^^^^^^^^^^ Each method is required to have a signature.
+
+          T::SomeSig.sig { void }
+          def foo; end
+          ^^^^^^^^^^^^ Each method is required to have a signature.
+
+          Sig.sig { void }
+          def foo; end
+          ^^^^^^^^^^^^ Each method is required to have a signature.
+        end
+      RUBY
+    end
+
     it "does not check the signature for accessors" do # Validity will be checked by Sorbet
       expect_no_offenses(<<~RUBY)
         class Foo


### PR DESCRIPTION
So this doesn't raise any offense:

```rb
class Foo
  T::Sig::WithoutRuntime.sig { void }
  def foo; end
end
```

Neither does this:

```rb
class Foo
  T::Sig.sig { void }
  def foo; end
end
```

Closes https://github.com/Shopify/rubocop-sorbet/issues/82.