### PR TITLE
Add more lint cops to RBI config

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -181,9 +181,15 @@ Layout/TrailingWhitespace:
 
 ## Lint
 
+Lint/DuplicateMethods:
+  Enabled: true
+
 Lint/EmptyFile:
   Enabled: true
   AllowComments: false
+
+Lint/SyntaxError:
+  Enabled: true
 
 ## Sorbet
 


### PR DESCRIPTION
Enable `Lint/DuplicateMethods` and `Lint/SyntaxError` when checking RBI files.