### PR TITLE
Fix Lint/Syntax cop name

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -188,7 +188,7 @@ Lint/EmptyFile:
   Enabled: true
   AllowComments: false
 
-Lint/SyntaxError:
+Lint/Syntax:
   Enabled: true
 
 ## Sorbet


### PR DESCRIPTION
As described here: https://msp-greg.github.io/rubocop/RuboCop/Cop/Lint/Syntax.html.