### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1 ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Also quoted 3.0 in the CI config because an unquoted 3.0 is truncated to 3.  This loads the latest Ruby 3 version - at this time 3.1.0.  By quoting the 3.0 we ensure that a 3.0.x Ruby is tested for this case.