### PR TITLE
Support new type_member / type_template syntax

### DIFF
--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -57,9 +57,15 @@ module RuboCop
           )
         PATTERN
 
-        def_node_matcher(:generic_parameter_decl?, <<-PATTERN)
+        def_node_matcher(:generic_parameter_decl_call?, <<-PATTERN)
           (
             send nil? {:type_template :type_member} ...
+          )
+        PATTERN
+
+        def_node_matcher(:generic_parameter_decl_block_call?, <<-PATTERN)
+          (block
+            (send nil? {:type_template :type_member}) ...
           )
         PATTERN
 
@@ -81,7 +87,7 @@ module RuboCop
         end
 
         def not_generic_parameter_decl?(node)
-          !generic_parameter_decl?(node)
+          !generic_parameter_decl_call?(node) && !generic_parameter_decl_block_call?(node)
         end
 
         def not_nil?(node)

--- a/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -62,12 +62,14 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
     it("allows assigning type_member to a constant") do
       expect_no_offenses(<<~RUBY)
         A = type_member(fixed: T.untyped)
+        A = type_member { { fixed: T.class_of(::ActiveRecord::Base) } }
       RUBY
     end
 
     it("allows assigning type_template to a constant") do
       expect_no_offenses(<<~RUBY)
         A = type_template(fixed: T.untyped)
+        A = type_template { { fixed: T.class_of(::ActiveRecord::Base) } }
       RUBY
     end
 


### PR DESCRIPTION
Fixes #104.

Since https://github.com/sorbet/sorbet/pull/5639, type members and templates must be declared using a block:

```rb
A = type_member { { fixed: T.class_of(::ActiveRecord::Base) } }
B = type_template { { fixed: T.class_of(::ActiveRecord::Base) } }
```

This PR provides support for both the old way and the new way of declaring them.