### PR TITLE
Fix BindingConstantWithoutTypeAlias for type members with arguments

### DIFF
--- a/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
+++ b/lib/rubocop/cop/sorbet/binding_constants_without_type_alias.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         def_node_matcher(:generic_parameter_decl_block_call?, <<-PATTERN)
           (block
-            (send nil? {:type_template :type_member}) ...
+            (send nil? {:type_template :type_member} ...) ...
           )
         PATTERN
 

--- a/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
+++ b/spec/rubocop/cop/sorbet/binding_constant_without_type_alias_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
       expect_no_offenses(<<~RUBY)
         A = type_member(fixed: T.untyped)
         A = type_member { { fixed: T.class_of(::ActiveRecord::Base) } }
+        A = type_member(:in) { { fixed: T.untyped } }
       RUBY
     end
 
@@ -70,6 +71,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::BindingConstantWithoutTypeAlias, :config) d
       expect_no_offenses(<<~RUBY)
         A = type_template(fixed: T.untyped)
         A = type_template { { fixed: T.class_of(::ActiveRecord::Base) } }
+        A = type_template(:in) { { fixed: T.untyped } }
       RUBY
     end
 


### PR DESCRIPTION
This shouldn't be an offense:

```
Sorbet/BindingConstantWithoutTypeAlias: It looks like you're trying to bind a type to a constant.
To do this, you must alias the type using T.type_alias.
--
  | A = type_member(:in) { { fixed: T.untyped } }
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```