### PR TITLE
Add cop forbidding use of T.untyped

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop disallows using `T.untyped` anywhere.
+      #
+      # @example
+      #
+      #   # bad
+      #   T.untyped(foo)
+      #
+      #   # good
+      #   foo
+      class ForbidTUntyped < RuboCop::Cop::Cop
+        def_node_matcher(:t_untyped?, "(send (const nil? :T) :untyped)")
+
+        def on_send(node)
+          add_offense(node, message: "Do not use `T.untyped`.") if t_untyped?(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
@@ -10,10 +10,13 @@ module RuboCop
       # @example
       #
       #   # bad
-      #   T.untyped(foo)
+      #   sig { params(my_argument: T.untyped).void }
+      #   def foo(my_argument); end
       #
       #   # good
-      #   foo
+      #   sig { params(my_argument: String).void }
+      #   def foo(my_argument); end
+      #
       class ForbidTUntyped < RuboCop::Cop::Cop
         def_node_matcher(:t_untyped?, "(send (const nil? :T) :untyped)")
 

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -7,6 +7,7 @@ require_relative "sorbet/forbid_untyped_struct_props"
 require_relative "sorbet/one_ancestor_per_line"
 require_relative "sorbet/callback_conditionals_binding"
 require_relative "sorbet/forbid_t_unsafe"
+require_relative "sorbet/forbid_t_untyped"
 require_relative "sorbet/type_alias_name"
 
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"

--- a/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
+++ b/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
@@ -5,10 +5,44 @@ require "spec_helper"
 RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
   subject(:cop) { described_class.new(config) }
 
-  it "adds offense when using T.untyped" do
-    expect_offense(<<~RUBY)
-      T.untyped
-      ^^^^^^^^^ Do not use `T.untyped`.
-    RUBY
+  context 'a simple usage' do
+    it 'adds an offense' do
+      expect_offense(<<~RUBY)
+        T.untyped
+        ^^^^^^^^^ Do not use `T.untyped`.
+      RUBY
+    end
+  end
+
+  context 'used within a type alias' do
+    it 'adds offense' do
+      expect_offense(<<~RUBY)
+        FOO = T.type_alias { T.untyped }
+                             ^^^^^^^^^ Do not use `T.untyped`.
+      RUBY
+    end
+  end
+
+  context 'used within a type signature' do
+    it 'adds offense' do
+      expect_offense(<<~RUBY)
+        sig { params(x: T.untyped).returns(T.untyped) }
+                                           ^^^^^^^^^ Do not use `T.untyped`.
+                        ^^^^^^^^^ Do not use `T.untyped`.
+        def foo(x)
+        end
+      RUBY
+    end
+  end
+
+  context 'used within T.bind' do
+    it 'adds offense' do
+      expect_offense(<<~RUBY)
+        def foo(x)
+          T.bind(self, Y::Array[T.untyped])
+                                ^^^^^^^^^ Do not use `T.untyped`.
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
+++ b/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
     it "adds offense" do
       expect_offense(<<~RUBY)
         def foo(x)
-          T.bind(self, Y::Array[T.untyped])
+          T.bind(self, T::Array[T.untyped])
                                 ^^^^^^^^^ Do not use `T.untyped`.
         end
       RUBY

--- a/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
+++ b/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
   subject(:cop) { described_class.new(config) }
 
-  context 'a simple usage' do
-    it 'adds an offense' do
+  context "a simple usage" do
+    it "adds an offense" do
       expect_offense(<<~RUBY)
         T.untyped
         ^^^^^^^^^ Do not use `T.untyped`.
@@ -14,8 +14,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
     end
   end
 
-  context 'used within a type alias' do
-    it 'adds offense' do
+  context "used within a type alias" do
+    it "adds offense" do
       expect_offense(<<~RUBY)
         FOO = T.type_alias { T.untyped }
                              ^^^^^^^^^ Do not use `T.untyped`.
@@ -23,8 +23,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
     end
   end
 
-  context 'used within a type signature' do
-    it 'adds offense' do
+  context "used within a type signature" do
+    it "adds offense" do
       expect_offense(<<~RUBY)
         sig { params(x: T.untyped).returns(T.untyped) }
                                            ^^^^^^^^^ Do not use `T.untyped`.
@@ -35,8 +35,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
     end
   end
 
-  context 'used within T.bind' do
-    it 'adds offense' do
+  context "used within T.bind" do
+    it "adds offense" do
       expect_offense(<<~RUBY)
         def foo(x)
           T.bind(self, Y::Array[T.untyped])

--- a/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
+++ b/spec/rubocop/cop/sorbet/forbid_t_untyped_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ForbidTUntyped, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  it "adds offense when using T.untyped" do
+    expect_offense(<<~RUBY)
+      T.untyped
+      ^^^^^^^^^ Do not use `T.untyped`.
+    RUBY
+  end
+end


### PR DESCRIPTION
Modeled after Sorbet/ForbidTUnsafe. This cop is intended to discourage use of T.untyped and encourage thoughtful typing of input and output parameters.

Question: Should I bump the version or should maintainers? If I should, shall we go from `v0.6.8` to `v0.7.0` since this is a new feature (minor version release)?