### PR TITLE
Do not search for sigils in the middle of comments

### DIFF
--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -49,7 +49,7 @@ module RuboCop
         protected
 
         STRICTNESS_LEVELS = ["ignore", "false", "true", "strict", "strong"]
-        SIGIL_REGEX = /#\s+typed:(?:\s+([\w]+))?/
+        SIGIL_REGEX = /^\s*#\s+typed:(?:\s+([\w]+))?/
 
         # extraction
 

--- a/spec/rubocop/cop/sorbet/sigils/enforce_single_sigil_spec.rb
+++ b/spec/rubocop/cop/sorbet/sigils/enforce_single_sigil_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe(RuboCop::Cop::Sorbet::EnforceSingleSigil, :config) do
         class Foo; end
       RUBY
     end
+
+    it("makes no offense with only one sigil and other sigil in the middle of a comment") do
+      expect_no_offenses(<<~RUBY)
+        # typed: true
+        #
+        # Something something `# typed: true`
+        class Foo; end
+      RUBY
+    end
   end
 
   describe("offenses") do


### PR DESCRIPTION
If you have a comment mentioning a sigil, the EnforceSingleSigil cop was failing. This should not happen.