### PR TITLE
Generate cops docs, disable Sorbet/ForbidTUntyped by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -97,6 +97,12 @@ Sorbet/ForbidTUnsafe:
   VersionAdded: 0.7.0
   VersionChanged: 0.7.0
 
+Sorbet/ForbidTUntyped:
+  Description: 'Forbid usage of T.untyped'
+  Enabled: false
+  VersionAdded: 0.6.9
+  VersionChanged: 0.7.0
+
 Sorbet/ForbidUntypedStructProps:
   Description: >-
                   Disallows use of `T.untyped` or `T.nilable(T.untyped)` as a

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -19,6 +19,7 @@ In the following section you find all available cops:
 * [Sorbet/ForbidRBIOutsideOfAllowedPaths](cops_sorbet.md#sorbetforbidrbioutsideofallowedpaths)
 * [Sorbet/ForbidSuperclassConstLiteral](cops_sorbet.md#sorbetforbidsuperclassconstliteral)
 * [Sorbet/ForbidTUnsafe](cops_sorbet.md#sorbetforbidtunsafe)
+* [Sorbet/ForbidTUntyped](cops_sorbet.md#sorbetforbidtuntyped)
 * [Sorbet/ForbidUntypedStructProps](cops_sorbet.md#sorbetforbiduntypedstructprops)
 * [Sorbet/HasSigil](cops_sorbet.md#sorbethassigil)
 * [Sorbet/IgnoreSigil](cops_sorbet.md#sorbetignoresigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -274,7 +274,7 @@ Include | `**/*.rbi` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.2.0 | 0.5.0
+Disabled | Yes | Yes  | 0.2.0 | 0.5.0
 
 No documentation
 
@@ -284,7 +284,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 0.6.1 | -
 
-This cop makes sure that RBI files are always located under the defined allowed paths
+This cop makes sure that RBI files are always located under the defined allowed paths.
 
 Options:
 
@@ -339,6 +339,26 @@ T.unsafe(foo)
 
 # good
 foo
+```
+
+## Sorbet/ForbidTUntyped
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | No | 0.6.9 | 0.7.0
+
+This cop disallows using `T.untyped` anywhere.
+
+### Examples
+
+```ruby
+# bad
+sig { params(my_argument: T.untyped).void }
+def foo(my_argument); end
+
+# good
+sig { params(my_argument: String).void }
+def foo(my_argument); end
 ```
 
 ## Sorbet/ForbidUntypedStructProps


### PR DESCRIPTION
The `Sorbet/ForbidTUntyped` cop is enabled by default which makes gradual typing hard. Let's disable it by default and also regenerate the docs for the cops with `bundle exec rake generate_cops_documentation`