### PR TITLE
Add more rules for blocks

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -232,6 +232,9 @@ Sorbet/ValidSigil:
 
 ## Style
 
+Style/BlockDelimiters:
+  Enabled: true
+
 Style/ClassAndModuleChildren:
   Enabled: true
   EnforcedStyle: compact

--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -129,6 +129,7 @@ Layout/ParameterAlignment:
 
 Layout/RedundantLineBreak:
   Enabled: true
+  InspectBlocks: true
 
 Layout/SpaceAfterColon:
   Enabled: true


### PR DESCRIPTION
* Change `Layout/RedundantLineBreak` config to `InspectBlocks: true` so this:

   ```rb
   sig do
     void
   end
   ```

   will be corrected into this:

   ```rb
   sig { void }
   ```

* Enable `Style/BlockDelimiters` by default so this:

   ```rb
   sig do void end
   ```

   will be corrected into this:

   ```rb
   sig { void }
   ```