### PR TITLE
Place constants right after the includes

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -25,6 +25,7 @@ Layout/ClassStructure:
   Enabled: true
   ExpectedOrder:
     - module_inclusion
+    - constants
     - macros
     - public_attribute_macros
     - protected_attribute_macros
@@ -34,7 +35,6 @@ Layout/ClassStructure:
     - protected_methods
     - private_methods
     - public_class_methods
-    - constants
 
 Layout/ClosingParenthesisIndentation:
   Enabled: true


### PR DESCRIPTION
So type_member and type_template are at the top.

I feel like having:

```rb
class Foo
  extend T::Generics

  def foo; end

  Elem = type_member

  SOME_OTHER_CONST = 42
end
```

is worse than having:

```rb
class Foo
  extend T::Generics

  Elem = type_member

  SOME_OTHER_CONST = 42

  def foo; end
end
```