### PR TITLE
WIP: Add a cop that compacts classes/modules with more than one child 

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,11 @@ Sorbet/CheckedTrueInSignature:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/ClassAndModuleChildren:
+  Description: 'Checks style of children classes and modules.'
+  Enabled: true
+  VersionAdded: 0.2.0
+
 Sorbet/ConstantsFromStrings:
   Description: >-
                   Forbids constant access through meta-programming.

--- a/lib/rubocop/cop/sorbet/rbi/class_and_module_children.rb
+++ b/lib/rubocop/cop/sorbet/rbi/class_and_module_children.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      class ClassAndModuleChildren < RuboCop::Cop::Style::ClassAndModuleChildren
+        def style
+          :compact
+        end
+
+        def on_class(node)
+          return if node.parent_class && style != :nested
+
+          check_style(node, node.body)
+        end
+
+        def check_compact_style(node, body)
+          if body&.begin_type?
+            body.children.each do |child|
+              check_compact_style(node, child) if %i[module class].include?(child.type)
+            end
+          else
+            super
+          end
+        end
+
+        # def needs_compacting?(body)
+        #   body && %i[begin module class].include?(body.type)
+        # end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -10,6 +10,7 @@ require_relative "sorbet/forbid_t_unsafe"
 require_relative "sorbet/forbid_t_untyped"
 require_relative "sorbet/type_alias_name"
 
+require_relative "sorbet/rbi/class_and_module_children"
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"
 require_relative "sorbet/rbi/forbid_rbi_outside_of_allowed_paths"
 require_relative "sorbet/rbi/single_line_rbi_class_module_definitions"

--- a/spec/rubocop/cop/sorbet/rbi/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/sorbet/rbi/class_and_module_children_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ClassAndModuleChildren, :config) do
+  subject(:cop) { described_class.new(config) }
+  describe("autocorrect") do
+    let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
+
+    it("autocorrects one nested child") do
+      source = <<~RUBY
+        # typed: true
+        # frozen_string_literal: true
+        module Foo
+          class Bar
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          # typed: true
+          # frozen_string_literal: true
+          class Foo::Bar
+          end
+      RUBY
+    end
+
+    it("autocorrects two nested children") do
+      source = <<~RUBY
+        # typed: true
+        # frozen_string_literal: true
+        module Foo
+          class Bar
+          end
+
+          class Baz
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          # typed: true
+          # frozen_string_literal: true
+          class Foo::Bar
+          end
+          class Foo::Baz
+          end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
# Goal 

Create a cop like [RuboCop::Cop::Style::ClassAndModuleChildren](https://www.rubydoc.info/gems/rubocop/0.45.0/RuboCop/Cop/Style/ClassAndModuleChildren#:~:text=The%20compact%20style%20is%20only%20forced%20for%20classes/modules%20with%20one%20child) that is able to compact multiple children rather than just one child so we can use it on RBIs

# WIP 

July 28th - group pairing  
We were trying to make 2 nested classes compaction work, and there's a test for it. A nested module with two class returns an AST with a different format, i.e. it now has a `begin` node containing the two nested classes. We need to figure out how to iterate through the AST past the `begin` node.

Next time, we decided should consider creating a brand new cop instead of inheriting from `RuboCop::Cop::Style::ClassAndModuleChildren` 