### PR TITLE
Update documentation for sigil order cop

### DIFF
--- a/lib/rubocop/cop/sorbet/sigils/enforce_sigil_order.rb
+++ b/lib/rubocop/cop/sorbet/sigils/enforce_sigil_order.rb
@@ -7,7 +7,7 @@ module RuboCop
     module Sorbet
       # This cop checks that the Sorbet sigil comes as the first magic comment in the file.
       #
-      # The expected order for magic comments is: typed, (en)?coding, warn_indent then frozen_string_literal.
+      # The expected order for magic comments is: (en)?coding, typed, warn_indent then frozen_string_literal.
       #
       # For example, the following bad ordering:
       #
@@ -25,7 +25,7 @@ module RuboCop
       # class Foo; end
       # ```
       #
-      # Only `typed`, `(en)?coding`, `warn_indent` and `frozen_string_literal` magic comments are considered,
+      # Only `(en)?coding`, `typed`, `warn_indent` and `frozen_string_literal` magic comments are considered,
       # other comments or magic comments are left in the same place.
       class EnforceSigilOrder < ValidSigil
         include RangeHelp

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -146,7 +146,7 @@ Enabled | Yes | Yes  | 0.3.4 | -
 
 This cop checks that the Sorbet sigil comes as the first magic comment in the file.
 
-The expected order for magic comments is: typed, (en)?coding, warn_indent then frozen_string_literal.
+The expected order for magic comments is: (en)?coding, typed, warn_indent then frozen_string_literal.
 
 For example, the following bad ordering:
 
@@ -164,7 +164,7 @@ Will be corrected as:
 class Foo; end
 ```
 
-Only `typed`, `(en)?coding`, `warn_indent` and `frozen_string_literal` magic comments are considered,
+Only `(en)?coding`, `typed`, `warn_indent` and `frozen_string_literal` magic comments are considered,
 other comments or magic comments are left in the same place.
 
 ## Sorbet/EnforceSignatures


### PR DESCRIPTION
The EnforceSigilOrder cop originally preferred to put the `typed` sigil
first, above the `encoding` sigil, which caused Ruby to ignore the
`encoding` sigil if present. This was corrected in:

66b2d6f48b88d7f290727c7745584ca830ab3316

but the documentation was not updated in that same commit.

This change updates the documentation in the cop to reflect the correct
ordering of the sigils enforced by the cop.