### PR TITLE
Update documentation

### DIFF
--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -368,19 +368,19 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | No | 0.4.0 | -
 
 This cop disallows use of `T.untyped` or `T.nilable(T.untyped)`
-as a prop type for `T::Struct`.
+as a prop type for `T::Struct` or `T::ImmutableStruct`.
 
 ### Examples
 
 ```ruby
 # bad
-class SomeClass
+class SomeClass < T::Struct
   const :foo, T.untyped
   prop :bar, T.nilable(T.untyped)
 end
 
 # good
-class SomeClass
+class SomeClass < T::Struct
   const :foo, Integer
   prop :bar, T.nilable(String)
 end


### PR DESCRIPTION
The documentation for the cop that forbids untyped struct props was updated in:

3456b3e72adc431373cd1a0fec684b39711780e5

but the associated generated documentation wasn't updated at the same time.

This change includes the documentation changes in the documents that get generated via `bundle exec rake generate_cops_documentation`.