### PR TITLE
Add a cop to detect extra lines after signatures

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,11 @@ Sorbet/CheckedTrueInSignature:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/EmptyLineAfterSig:
+  Description: 'Ensures that there are no blank lines after signatures'
+  Enabled: true
+  VersionAdded: 0.7.0
+
 Sorbet/ConstantsFromStrings:
   Description: >-
                   Forbids constant access through meta-programming.

--- a/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
+++ b/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "signature_cop"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # This cop checks for blank lines after signatures.
+      #
+      # It also suggests an autocorrect
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { void }
+      #
+      #   def foo; end
+      #
+      #   # good
+      #   sig { void }
+      #   def foo; end
+      #
+      class EmptyLineAfterSig < SignatureCop
+        include RangeHelp
+
+        def on_signature(node)
+          if (next_method(node).line - node.last_line) > 1
+            location = source_range(processed_source.buffer, next_method(node).line - 1, 0)
+            add_offense(node, location: location, message: "Extra empty line or comment detected")
+          end
+        end
+
+        def autocorrect(node)
+          -> (corrector) do
+            offending_range = node.source_range.with(
+              begin_pos: node.source_range.end_pos + 1,
+              end_pos: processed_source.buffer.line_range(next_method(node).line).begin_pos
+            )
+            corrector.remove(offending_range)
+            clean_range = offending_range.source.split("\n").reject(&:empty?).join("\n")
+            offending_line = processed_source.buffer.line_range(node.source_range.first_line)
+            corrector.insert_before(offending_line, "#{clean_range}\n") unless clean_range.empty?
+          end
+        end
+
+        private
+
+        def next_method(node)
+          processed_source.tokens.find do |t|
+            t.line >= node.last_line &&
+              (t.type == :kDEF || t.text.start_with?("attr_"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -19,6 +19,7 @@ require_relative "sorbet/signatures/checked_true_in_signature"
 require_relative "sorbet/signatures/keyword_argument_ordering"
 require_relative "sorbet/signatures/signature_build_order"
 require_relative "sorbet/signatures/enforce_signatures"
+require_relative "sorbet/signatures/empty_line_after_sig"
 
 require_relative "sorbet/sigils/valid_sigil"
 require_relative "sorbet/sigils/has_sigil"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -10,6 +10,7 @@ In the following section you find all available cops:
 * [Sorbet/CallbackConditionalsBinding](cops_sorbet.md#sorbetcallbackconditionalsbinding)
 * [Sorbet/CheckedTrueInSignature](cops_sorbet.md#sorbetcheckedtrueinsignature)
 * [Sorbet/ConstantsFromStrings](cops_sorbet.md#sorbetconstantsfromstrings)
+* [Sorbet/EmptyLineAfterSig](cops_sorbet.md#sorbetemptylineaftersig)
 * [Sorbet/EnforceSigilOrder](cops_sorbet.md#sorbetenforcesigilorder)
 * [Sorbet/EnforceSignatures](cops_sorbet.md#sorbetenforcesignatures)
 * [Sorbet/EnforceSingleSigil](cops_sorbet.md#sorbetenforcesinglesigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -138,6 +138,29 @@ end
 { "User" => User }.fetch(class_name)
 ```
 
+## Sorbet/EmptyLineAfterSig
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.0 | -
+
+This cop checks for blank lines after signatures.
+
+It also suggests an autocorrect
+
+### Examples
+
+```ruby
+# bad
+sig { void }
+
+def foo; end
+
+# good
+sig { void }
+def foo; end
+```
+
 ## Sorbet/EnforceSigilOrder
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/sorbet/signatures/empty_line_after_sig_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/empty_line_after_sig_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::EmptyLineAfterSig, :config) do
+  subject(:cop) { described_class.new(config) }
+
+  describe("no offenses") do
+    it "makes no offense when signarure and method are next to eachother" do
+      expect_no_offenses(<<~RUBY)
+        sig { void }
+        def foo; end
+      RUBY
+    end
+  end
+  describe("with offences") do
+    it "makes offense there is a line between a method and a signature" do
+      expect_offense(<<~RUBY)
+        sig { void }
+
+        ^{} Extra empty line or comment detected
+        def foo; end
+      RUBY
+    end
+
+    it "supports various method defs" do
+      expect_offense(<<~RUBY)
+        sig { void }
+
+        ^{} Extra empty line or comment detected
+        def self.foo; end
+
+        sig { void }
+
+        ^{} Extra empty line or comment detected
+        attr_reader :bar
+      RUBY
+    end
+  end
+  describe("autocorrect") do
+    it("removes the empty line for single-line sigs") do
+      source = <<~RUBY
+        module Example
+          extend T::Sig
+
+          sig { params(session: String).void }
+
+          def initialize(session:)
+            @session = session
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module Example
+            extend T::Sig
+
+            sig { params(session: String).void }
+            def initialize(session:)
+              @session = session
+            end
+          end
+        RUBY
+    end
+
+    it("removes the empty line for multiline sigs with identation") do
+      source = <<~RUBY
+        module Example
+          extend T::Sig
+
+          sig do
+            params(
+              session: String,
+            ).void
+          end
+
+          def initialize(
+            session:
+          )
+            @session = session
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module Example
+            extend T::Sig
+
+            sig do
+              params(
+                session: String,
+              ).void
+            end
+            def initialize(
+              session:
+            )
+              @session = session
+            end
+          end
+        RUBY
+    end
+
+    it("moves comments above the sig") do
+      source = <<~RUBY
+        module Example
+          extend T::Sig
+
+          sig do
+            params(
+              session: String,
+            ).void
+          end
+          # Session: string
+          def initialize(
+            session:
+          )
+            @session = session
+          end
+        end
+      RUBY
+      expect(autocorrect_source(source))
+        .to(eq(<<~RUBY))
+          module Example
+            extend T::Sig
+
+            # Session: string
+            sig do
+              params(
+                session: String,
+              ).void
+            end
+            def initialize(
+              session:
+            )
+              @session = session
+            end
+          end
+        RUBY
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/Shopify/rubocop-sorbet/issues/124

 This cop checks for blank lines after signatures.

It also suggest an autocorrect

```
sig { void }

def foo; end
```

Will be corrected as:

```
sig { void }
def foo; end
```
