### PR TITLE
Add rbi/** to default AllowedPaths for ForbidRBIOutsideOfAllowedPaths

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -78,6 +78,7 @@ Sorbet/ForbidRBIOutsideOfAllowedPaths:
   Enabled: true
   VersionAdded: 0.6.1
   AllowedPaths:
+  - "rbi/**"
   - "sorbet/rbi/**"
   Include:
   - "**/*.rbi"

--- a/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
+++ b/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       # Options:
       #
-      # * `AllowedPaths`: A list of the paths where RBI files are allowed (default: ["sorbet/rbi/**"])
+      # * `AllowedPaths`: A list of the paths where RBI files are allowed (default: ["rbi/**", "sorbet/rbi/**"])
       #
       # @example
       #   # bad
@@ -17,6 +17,7 @@ module RuboCop
       #   # other_file.rbi
       #
       #   # good
+      #   # rbi/external_interface.rbi
       #   # sorbet/rbi/some_file.rbi
       #   # sorbet/rbi/any/path/for/file.rbi
       class ForbidRBIOutsideOfAllowedPaths < RuboCop::Cop::Cop

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -311,7 +311,7 @@ This cop makes sure that RBI files are always located under the defined allowed 
 
 Options:
 
-* `AllowedPaths`: A list of the paths where RBI files are allowed (default: ["sorbet/rbi/**"])
+* `AllowedPaths`: A list of the paths where RBI files are allowed (default: ["rbi/**", "sorbet/rbi/**"])
 
 ### Examples
 
@@ -321,6 +321,7 @@ Options:
 # other_file.rbi
 
 # good
+# rbi/external_interface.rbi
 # sorbet/rbi/some_file.rbi
 # sorbet/rbi/any/path/for/file.rbi
 ```
@@ -329,7 +330,7 @@ Options:
 
 Name | Default value | Configurable values
 --- | --- | ---
-AllowedPaths | `sorbet/rbi/**` | Array
+AllowedPaths | `rbi/**`, `sorbet/rbi/**` | Array
 Include | `**/*.rbi` | Array
 
 ## Sorbet/ForbidSuperclassConstLiteral

--- a/spec/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths_spec.rb
+++ b/spec/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths_spec.rb
@@ -14,12 +14,20 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
   end
 
   describe "with default configuration" do
-    context "with an .rbi file outside of sorbet/rbi/**" do
+    context "with an .rbi file outside of AllowedPaths" do
       let(:filename) { "some/dir/file.rbi" }
 
       it "makes an offense if an RBI file is outside of sorbet/rbi/**" do
         expect(cop.offenses.size).to(eq(1))
-        expect(cop.messages).to(eq(["RBI file path should match one of: sorbet/rbi/**"]))
+        expect(cop.messages).to(eq(["RBI file path should match one of: rbi/**, sorbet/rbi/**"]))
+      end
+    end
+
+    context "with an .rbi file inside of rbi/**" do
+      let(:filename) { "rbi/some/dir/file.rbi" }
+
+      it "makes no offense if an RBI file is inside the rbi/** directory" do
+        expect(cop.offenses.empty?).to(be(true))
       end
     end
 


### PR DESCRIPTION
The `ForbidRBIOutsideOfAllowedPaths` creates an offense when following the [official guidance](https://sorbet.org/docs/rbi#rbis-within-gems) on where to place `rbi` files within gem code:

> We expect that as adoption grows, gems will include their external interfaces RBI files in an `rbi/` directory. When they do this, Tapioca will automatically merge those definitions in the autogenerated RBIs. In the future, we anticipate this to be the preferred way to include RBI files into a project.

This was [confirmed](https://sorbet-ruby.slack.com/archives/C02VD06EQ3U/p1673923210096859?thread_ts=1673917916.215189&cid=C02VD06EQ3U) via the Sorbet Slack with a pointer to the tapioca [code](https://github.com/Shopify/tapioca/blob/1b485c6ce47fb840554fbb864d58ade1e2be20df/lib/tapioca/gemfile.rb#L217-L220).

Since it's confusing for end-users following the docs to trigger violations, I propose including this path in the default config. (Also, the cop message doesn't mention `AllowedPaths`, adding to the confusion.)