### PR TITLE
Prevent SignatureBuildOrder from breaking on empty signatures

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -94,6 +94,8 @@ module RuboCop
         end
 
         def call_chain(sig_child_node)
+          return [] if sig_child_node.nil?
+
           call_node = root_call(sig_child_node).first
           return [] unless call_node
 

--- a/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
       RUBY
     end
 
+    it("doesn't break on incomplete signatures") do
+      expect_no_offenses(<<~RUBY)
+        sig {}
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        sig { params(a: Integer) }
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        sig { abstract }
+      RUBY
+    end
+
     it("enforces orders of builder calls") do
       message = "Sig builders must be invoked in the following order: type_parameters, params, void."
       expect_offense(<<~RUBY)


### PR DESCRIPTION
When using the Ruby LSP, this cop keeps breaking while developers are still typing their signatures.