### PR TITLE
Remove `github_user` from `new_cop` generator task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,10 +22,7 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  github_user = %x(git config github.user).chop
-  github_user = "Shopify" if github_user.empty?
-
-  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+  generator = RuboCop::Cop::Generator.new(cop_name)
 
   generator.write_source
   generator.write_spec


### PR DESCRIPTION
This was removed upstream in rubocop/rubocop#10109 and no longer works.

```
ArgumentError: wrong number of arguments (given 2, expected 1)
/Users/sambostock/.gem/ruby/2.5.5/gems/rubocop-1.24.1/lib/rubocop/cop/generator.rb:114:in `initialize'
```