### PR TITLE
Skip `bundle exec rake changelog:new` `new_cop` TODO

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,5 +32,8 @@ task :new_cop, [:cop] do |_task, args|
   generator.inject_require(root_file_path: "lib/rubocop/cop/sorbet_cops.rb")
   generator.inject_config(config_file_path: "config/default.yml")
 
-  puts generator.todo
+  # We don't use Rubocop's changelog automation workflow
+  todo_without_changelog_instruction = generator.todo
+    .sub(/$\s+4\. Run.*changelog.*for your new cop\.$/m, "")
+  puts todo_without_changelog_instruction
 end


### PR DESCRIPTION
We don't use Rubocop's changelog automation workflow, so we should drop [this line](https://github.com/rubocop/rubocop/blob/5230ef2238a7c88c96ee512251d248f987d49f74/lib/rubocop/cop/generator.rb#L153C21-L154) from the todo instructions.