### PR TITLE
Fix default config for `RedundantExtendTSig`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -156,7 +156,7 @@ Sorbet/OneAncestorPerLine:
   Enabled: false
   VersionAdded: '0.6.0'
 
-Sorbet/ForbidExtendTSig:
+Sorbet/RedundantExtendTSig:
   Description: >-
     Forbid the usage of redundant `extend T::Sig`.
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -501,7 +501,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Disabled | No | Yes  | <<next>> | -
 
 Forbids the use of redundant `extend T::Sig`. Only for use in
 applications that monkey patch `Module.include(T::Sig)` globally,


### PR DESCRIPTION
In the original draft, the cop was called `ForbidExtendTSig`. It was later renamed, and the config was moved to what would be the correct location alphabetically, but the actual config key was not updated.

This cause the cop to have no default config, so it was enabled by default, which would have been problematic for consumers.