### PR TITLE
Add `Sorbet/FetchWhenMust` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -66,6 +66,17 @@ Sorbet/FalseSigil:
   - db/**/*.rb
   - script/**/*
 
+Sorbet/FetchWhenMust:
+  Description: >-
+    Checks for `T.must(object[key])` and recommends `object.fetch(key)` instead.
+
+    While usually safe, false positives are possible if `object` does not respond to `fetch`,
+    or if `Hash#default_proc` (or similar) is being used.
+  Enabled: pending
+  VersionAdded: '<<next>>'
+  Safe: false
+  SafeAutoCorrect: false
+
 Sorbet/ForbidExtendTSigHelpersInShims:
   Description: 'Forbid the use of `extend T::Sig` and `extend T::Helpers` in RBI shims'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/fetch_when_must.rb
+++ b/lib/rubocop/cop/sorbet/fetch_when_must.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # rubocop:disable Lint/RedundantCopDisableDirective
+
+      # Checks for `T.must(object[key])` and recommends `object.fetch(key)` instead.
+      #
+      # @safety
+      #   False positives are possible if `object` does not respond to `fetch`,
+      #   or if `Hash#default_proc` (or similar) is being used.
+      #
+      # @example
+      #   # bad
+      #   T.must(object[key])
+      #
+      #   # good
+      #   object.fetch(key)
+      #
+      #   # good
+      #   object[key]
+      #
+      #   # good
+      #   # If `object` does not `respond_to? :fetch`, or if using `Hash` `default_proc`
+      #   T.must(object[key]) # rubocop:disable Sorbet/FetchWhenMust
+      #
+      class FetchWhenMust < RuboCop::Cop::Base
+        # rubocop:enable Lint/RedundantCopDisableDirective
+
+        extend AutoCorrector
+        include IgnoredNode
+
+        MSG = "Use `%<expected>s` instead of `%<actual>s` when value must always be found, and receiver supports it."
+        RESTRICT_ON_SEND = [:must].freeze
+
+        # @!method t_must_on_index_result(node)
+        def_node_matcher :t_must_on_index_result, <<~PATTERN
+          (send
+            (const { nil? cbase } :T) :must
+            {
+              (index $_ $_)
+              (send $_ :[] $_)
+            }
+          )
+        PATTERN
+
+        def on_send(node)
+          t_must_on_index_result(node) do |receiver, key|
+            expected = "#{receiver.source}.fetch(#{key.source})"
+            message = format(MSG, expected: expected, actual: node.source)
+
+            add_offense(node, message: message) do |corrector|
+              corrector.replace(node, expected) unless part_of_ignored_node?(node)
+            end
+
+            ignore_node(node)
+          end
+        end
+
+        private
+
+        def expected(receiver, key)
+          "#{receiver.source}.fetch(#{key.source})"
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/constants_from_strings"
+require_relative "sorbet/fetch_when_must"
 require_relative "sorbet/forbid_superclass_const_literal"
 require_relative "sorbet/forbid_include_const_literal"
 require_relative "sorbet/forbid_untyped_struct_props"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -15,6 +15,7 @@ In the following section you find all available cops:
 * [Sorbet/EnforceSignatures](cops_sorbet.md#sorbetenforcesignatures)
 * [Sorbet/EnforceSingleSigil](cops_sorbet.md#sorbetenforcesinglesigil)
 * [Sorbet/FalseSigil](cops_sorbet.md#sorbetfalsesigil)
+* [Sorbet/FetchWhenMust](cops_sorbet.md#sorbetfetchwhenmust)
 * [Sorbet/ForbidExtendTSigHelpersInShims](cops_sorbet.md#sorbetforbidextendtsighelpersinshims)
 * [Sorbet/ForbidIncludeConstLiteral](cops_sorbet.md#sorbetforbidincludeconstliteral)
 * [Sorbet/ForbidRBIOutsideOfAllowedPaths](cops_sorbet.md#sorbetforbidrbioutsideofallowedpaths)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -259,6 +259,31 @@ SuggestedStrictness | `false` | String
 Include | `**/*.{rb,rbi,rake,ru}` | Array
 Exclude | `bin/**/*`, `db/**/*.rb`, `script/**/*` | Array
 
+## Sorbet/FetchWhenMust
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | No | Yes (Unsafe) | <<next>> | -
+
+Checks for `T.must(object[key])` and recommends `object.fetch(key)` instead.
+
+### Examples
+
+```ruby
+# bad
+T.must(object[key])
+
+# good
+object.fetch(key)
+
+# good
+object[key]
+
+# good
+# If `object` does not `respond_to? :fetch`, or if using `Hash` `default_proc`
+T.must(object[key]) # rubocop:disable Sorbet/FetchWhenMust
+```
+
 ## Sorbet/ForbidExtendTSigHelpersInShims
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/documentation_spec.rb
+++ b/spec/documentation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe("generated documentation") do
     context(Pathname.new(path).relative_path_from(root_directory)) do
       it "does not contain any rogue `rubocop:___` comments" do
         contents = File.read(path)
-        expect(contents).not_to(match(/rubocop:(?:todo|disable)/))
+        expect(contents).not_to(match(/^(?:#?\s*)rubocop:(?:todo|disable)/))
       end
     end
   end

--- a/spec/rubocop/cop/sorbet/fetch_when_must_spec.rb
+++ b/spec/rubocop/cop/sorbet/fetch_when_must_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe(RuboCop::Cop::Sorbet::FetchWhenMust, :config) do
+  it "registers an offense when using `T.must(object[key])`" do
+    expect_offense(<<~RUBY)
+      T.must(object[key])
+      ^^^^^^^^^^^^^^^^^^^ Use `object.fetch(key)` instead of `T.must(object[key])` when value must always be found, and receiver supports it.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      object.fetch(key)
+    RUBY
+  end
+
+  it "does not register an offense when using `object[key]` without `T.must`" do
+    expect_no_offenses(<<~RUBY)
+      object[key]
+    RUBY
+  end
+
+  it "does not register an offense when using `object[key]` without `T.must`" do
+    expect_no_offenses(<<~RUBY)
+      T.must(object.fetch(key))
+    RUBY
+  end
+
+  it "does not register an offense when using `T.must(object[key1, key2])`" do
+    expect_no_offenses(<<~RUBY)
+      T.must(object[key1, key2])
+    RUBY
+  end
+
+  context "when nested" do
+    # Correcting nested nodes must be done in multiple passes: one per node.
+    # Attempting to correct nested nodes in a single pass will result in clobbering.
+    # Cop specs only perform the first correction pass, however the Corrector loops until no more corrections are made.
+    # These specs ensure we don't cause the clobbering error.
+
+    it "performs the first pass of two pass correction" do
+      # Finds both offenses
+      expect_offense(<<~RUBY)
+        T.must(T.must(object[key1])[key2])
+               ^^^^^^^^^^^^^^^^^^^^ Use `object.fetch(key1)` instead of `T.must(object[key1])` when value must always be found, and receiver supports it.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `T.must(object[key1]).fetch(key2)` instead of `T.must(T.must(object[key1])[key2])` when value must always be found, and receiver supports it.
+      RUBY
+
+      # Only corrects outer node on this pass, avoiding clobbering error
+      expect_correction(<<~RUBY)
+        T.must(object[key1]).fetch(key2)
+      RUBY
+    end
+
+    it "performs the second pass of two pass correction" do
+      # Finds remaining offense
+      expect_offense(<<~RUBY)
+        T.must(object[key1]).fetch(key2)
+        ^^^^^^^^^^^^^^^^^^^^ Use `object.fetch(key1)` instead of `T.must(object[key1])` when value must always be found, and receiver supports it.
+      RUBY
+
+      # Corrects inner node on this pass
+      expect_correction(<<~RUBY)
+        object.fetch(key1).fetch(key2)
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Checks for `T.must(object[key])` and recommends `object.fetch(key)` instead.

While usually safe, false positives are possible if `object` does not respond to `fetch`, or if `Hash#default_proc` (or similar) is being used.