### PR TITLE
Improve `ForbidTUn{safe,typed}`

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
@@ -15,11 +15,14 @@ module RuboCop
       #   # good
       #   foo
       class ForbidTUnsafe < RuboCop::Cop::Base
+        MSG = "Do not use `T.unsafe`."
+        RESTRICT_ON_SEND = [:unsafe].freeze
+
         # @!method t_unsafe?(node)
         def_node_matcher(:t_unsafe?, "(send (const nil? :T) :unsafe _)")
 
         def on_send(node)
-          add_offense(node, message: "Do not use `T.unsafe`.") if t_unsafe?(node)
+          add_offense(node) if t_unsafe?(node)
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
@@ -18,11 +18,14 @@ module RuboCop
       #   def foo(my_argument); end
       #
       class ForbidTUntyped < RuboCop::Cop::Base
+        MSG = "Do not use `T.untyped`."
+        RESTRICT_ON_SEND = [:untyped].freeze
+
         # @!method t_untyped?(node)
         def_node_matcher(:t_untyped?, "(send (const nil? :T) :untyped)")
 
         def on_send(node)
-          add_offense(node, message: "Do not use `T.untyped`.") if t_untyped?(node)
+          add_offense(node) if t_untyped?(node)
         end
       end
     end


### PR DESCRIPTION
This makes the following changes to the `Sorbet/ForbidTUnsafe` & `Sorbet/ForbidTUntyped` cops:

- Switches to the idiomatic `MSG` constant
- Specifies `RESTRICT_ON_SEND`, which optimizes `on_send` to only be called on relevant method sends.