### PR TITLE
Refactor `TypeAliasName`

### DIFF
--- a/lib/rubocop/cop/sorbet/type_alias_name.rb
+++ b/lib/rubocop/cop/sorbet/type_alias_name.rb
@@ -14,31 +14,23 @@ module RuboCop
       #
       #   # good
       #   FooOrBar = T.type_alias { T.any(Foo, Bar) }
-      class TypeAliasName < RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+      class TypeAliasName < RuboCop::Cop::Base
         MSG = "Type alias constant name should be in CamelCase"
 
-        # @!method casgn_type_alias?(node)
-        def_node_matcher(:casgn_type_alias?, <<-PATTERN)
+        # @!method underscored_type_alias?(node)
+        def_node_matcher(:underscored_type_alias?, <<-PATTERN)
           (casgn
             _
-            _
+            /_/                                  # Name matches underscore
             (block
-              (send
-                (const nil? :T) :type_alias)
-                _
-                _
-            ))
+              (send (const nil? :T) :type_alias)
+              ...
+            )
+          )
         PATTERN
 
         def on_casgn(node)
-          return unless casgn_type_alias?(node)
-
-          name = node.children[1]
-
-          # From https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/naming/class_and_module_camel_case.rb
-          return unless /_/.match?(name)
-
-          add_offense(node)
+          add_offense(node) if underscored_type_alias?(node)
         end
       end
     end

--- a/spec/rubocop/cop/sorbet/type_alias_name_spec.rb
+++ b/spec/rubocop/cop/sorbet/type_alias_name_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe(RuboCop::Cop::Sorbet::TypeAliasName, :config) do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
         CONSTANT_NAME = T.type_alias { T.any(A, B) }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+        PARENT::CONSTANT_NAME = T.type_alias { T.any(A, B) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
       RB
     end
 
@@ -26,6 +28,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::TypeAliasName, :config) do
         Constant = T.type_alias { Foo }
         ConstantName = T.type_alias { T.any(A, B) }
         HTTP = T.type_alias { Foo }
+        PARENT_NAME::ConstantName = T.type_alias { Foo }
       RB
     end
 


### PR DESCRIPTION
This makes the following changes:

- Changes from the deprecated `Cop` parent class to `Base`.
- Updates the node matcher to only match offending constant names.
- Use a node matcher capture, instead of indexing into children.
- Rename the matcher accordingly.
- Add tests to ensure qualified constants are handled correctly.