### PR TITLE
Refactor `SingleLineRbiClassModuleDefinitions`

### DIFF
--- a/lib/rubocop/cop/sorbet/rbi/single_line_rbi_class_module_definitions.rb
+++ b/lib/rubocop/cop/sorbet/rbi/single_line_rbi_class_module_definitions.rb
@@ -14,31 +14,25 @@ module RuboCop
       #
       #   # good
       #   module SomeModule; end
-      class SingleLineRbiClassModuleDefinitions < RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+      class SingleLineRbiClassModuleDefinitions < RuboCop::Cop::Base
+        extend AutoCorrector
+
         MSG = "Empty class/module definitions in RBI files should be on a single line."
 
         def on_module(node)
-          process_node(node)
-        end
-
-        def on_class(node)
-          process_node(node)
-        end
-
-        def autocorrect(node)
-          -> (corrector) { corrector.replace(node, convert_newlines(node.source)) }
-        end
-
-        protected
-
-        def convert_newlines(source)
-          source.sub(/[\r\n]+\s*[\r\n]*/, "; ")
-        end
-
-        def process_node(node)
           return if node.body
           return if node.single_line?
-          add_offense(node)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, convert_newlines_to_semicolons(node.source))
+          end
+        end
+        alias_method :on_class, :on_module
+
+        private
+
+        def convert_newlines_to_semicolons(source)
+          source.sub(/[\r\n]+\s*[\r\n]*/, "; ")
         end
       end
     end

--- a/spec/rubocop/cop/sorbet/rbi/single_line_rbi_class_module_definitions_spec.rb
+++ b/spec/rubocop/cop/sorbet/rbi/single_line_rbi_class_module_definitions_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe(RuboCop::Cop::Sorbet::SingleLineRbiClassModuleDefinitions, :confi
 
         module SecondModule
         ^^^^^^^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
+
+
+        end
+
+        module ThirdModule
+          def some_method
+          end
+        end
+      RBI
+
+      expect_correction(<<~RBI)
+        module MyModule; end
+
+        module SecondModule; end
+
+        module ThirdModule
+          def some_method
+          end
         end
       RBI
     end
@@ -25,6 +43,12 @@ RSpec.describe(RuboCop::Cop::Sorbet::SingleLineRbiClassModuleDefinitions, :confi
         class AnotherClass < SomeParentClass
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty class/module definitions in RBI files should be on a single line.
         end
+      RBI
+
+      expect_correction(<<~RBI)
+        class MyClass; end
+
+        class AnotherClass < SomeParentClass; end
       RBI
     end
   end
@@ -57,69 +81,6 @@ RSpec.describe(RuboCop::Cop::Sorbet::SingleLineRbiClassModuleDefinitions, :confi
           end
         end
       RBI
-    end
-  end
-
-  describe("autocorrect") do
-    it "autocorrects multi-line module definitions to a single line" do
-      source = <<~RBI
-        module MyModule
-        end
-
-        module AnotherModule
-
-
-        end
-      RBI
-      expect(autocorrect_source(source))
-        .to(eq(<<~RBI))
-          module MyModule; end
-
-          module AnotherModule; end
-        RBI
-    end
-
-    it "autocorrects multi-line class definitions to a single line" do
-      source = <<~RBI
-        class MyClass
-
-
-
-
-        end
-
-        class AnotherClass < SomeClass
-        end
-      RBI
-      expect(autocorrect_source(source))
-        .to(eq(<<~RBI))
-          class MyClass; end
-
-          class AnotherClass < SomeClass; end
-        RBI
-    end
-
-    it "autocorrects multi-line definitions and ignores non-empty modules" do
-      source = <<~RBI
-        module MyModule
-          def hello_world
-          end
-        end
-
-        module ModuleWithWhitespace
-
-
-        end
-      RBI
-      expect(autocorrect_source(source))
-        .to(eq(<<~RBI))
-          module MyModule
-            def hello_world
-            end
-          end
-
-          module ModuleWithWhitespace; end
-        RBI
     end
   end
 end


### PR DESCRIPTION
This makes the following changes:

- Migrates from deprecated `Cop` parent class to `Base`
- Inlines `process_node` helper method
- Uses `alias_method` to consolidate `on_module` and `on_class`
- Renames the `convert_newlines` helper to explain the conversion
- Simplifies the tests using `expect_correction` helper