### PR TITLE
Teach YARD about `@safety` tag

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--tag safety:"Cop Safety Information"


### PR DESCRIPTION
See https://github.com/rubocop/rubocop/blob/38b4451e67a7b6ebebed0a6ea16a0218418591f7/.yardopts#L2

This fixes

```
[warn]: Unknown tag @safety in file `lib/rubocop/cop/sorbet/redundant_extend_t_sig.rb` near line 28
```

This tag is part of the RuboCop boilerplate, and is used to describe if the cop is safe or not.