### PR TITLE
Refactor `AllowIncompatibleOverride`

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/allow_incompatible_override.rb
+++ b/lib/rubocop/cop/sorbet/signatures/allow_incompatible_override.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This cop disallows using `.override(allow_incompatible: true)`.
       # Using `allow_incompatible` suggests a violation of the Liskov
       # Substitution Principle, meaning that a subclass is not a valid
-      # subtype of it's superclass. This Cop prevents these design smells
+      # subtype of its superclass. This Cop prevents these design smells
       # from occurring.
       #
       # @example
@@ -18,43 +18,29 @@ module RuboCop
       #
       #   # good
       #   sig.override
-      class AllowIncompatibleOverride < RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
-        # @!method sig?(node)
-        def_node_search(:sig?, <<-PATTERN)
-          (
-            send
-            nil?
-            :sig
-             ...
-          )
-        PATTERN
-
-        def not_nil?(node)
-          !node.nil?
-        end
-
-        # @!method allow_incompatible?(node)
-        def_node_search(:allow_incompatible?, <<-PATTERN)
-          (pair (sym :allow_incompatible) (true))
-        PATTERN
+      class AllowIncompatibleOverride < RuboCop::Cop::Base
+        MSG = "Usage of `allow_incompatible` suggests a violation of the Liskov Substitution Principle. " \
+          "Instead, strive to write interfaces which respect subtyping principles and remove `allow_incompatible`"
+        RESTRICT_ON_SEND = [:override].freeze
 
         # @!method allow_incompatible_override?(node)
-        def_node_matcher(:allow_incompatible_override?, <<-PATTERN)
-          (
-            send
-            [#not_nil? #sig?]
+        def_node_matcher(:allow_incompatible_override?, <<~PATTERN)
+          (send
+            #sig?
             :override
-            [#not_nil? #allow_incompatible?]
+            (hash <$(pair (sym :allow_incompatible) true) ...>)
           )
+        PATTERN
+
+        # @!method sig?(node)
+        def_node_search :sig?, <<~PATTERN
+          (send _ :sig ...)
         PATTERN
 
         def on_send(node)
-          return unless allow_incompatible_override?(node)
-          add_offense(
-            node.children[2],
-            message: "Usage of `allow_incompatible` suggests a violation of the Liskov Substitution Principle. "\
-            "Instead, strive to write interfaces which respect subtyping principles and remove `allow_incompatible`",
-          )
+          allow_incompatible_override?(node) do |allow_incompatible_pair|
+            add_offense(allow_incompatible_pair)
+          end
         end
       end
     end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -9,7 +9,7 @@ Enabled | Yes | No | 0.2.0 | -
 This cop disallows using `.override(allow_incompatible: true)`.
 Using `allow_incompatible` suggests a violation of the Liskov
 Substitution Principle, meaning that a subclass is not a valid
-subtype of it's superclass. This Cop prevents these design smells
+subtype of its superclass. This Cop prevents these design smells
 from occurring.
 
 ### Examples

--- a/spec/rubocop/cop/sorbet/signatures/allow_incompatible_override_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/allow_incompatible_override_spec.rb
@@ -3,10 +3,7 @@
 require "spec_helper"
 
 RSpec.describe(RuboCop::Cop::Sorbet::AllowIncompatibleOverride, :config) do
-  def message
-    "Usage of `allow_incompatible` suggests a violation of the Liskov Substitution Principle. "\
-    "Instead, strive to write interfaces which respect subtyping principles and remove `allow_incompatible`"
-  end
+  let(:message) { RuboCop::Cop::Sorbet::AllowIncompatibleOverride::MSG }
 
   it("disallows using override(allow_incompatible: true)") do
     expect_offense(<<~RUBY)
@@ -17,10 +14,28 @@ RSpec.describe(RuboCop::Cop::Sorbet::AllowIncompatibleOverride, :config) do
     RUBY
   end
 
+  it("disallows using override(allow_incompatible: true) even when other keywords are present") do
+    expect_offense(<<~RUBY)
+      class Foo
+        sig(a: Integer).override(allow_incompatible: true, something: :unrelated).void
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      end
+    RUBY
+  end
+
+  it("disallows using override(allow_incompatible: true) even when the sig is out of order") do
+    expect_offense(<<~RUBY)
+      class Foo
+        sig(a: Integer).void.override(allow_incompatible: true, something: :unrelated)
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      end
+    RUBY
+  end
+
   it("allows override without allow_incompatible") do
     expect_no_offenses(<<~RUBY)
       class Foo
-        sig(a: Integer).void.override
+        sig(a: Integer).override.void
       end
     RUBY
   end


### PR DESCRIPTION
This makes the following changes:

- Fixes a typo in the cop description.
- Switches from the deprecated `Cop` parent class to `Base`
- Removes the unneeded `not_nil?` matcher
- Switches from a node search to order independent matching for the
  `allow_incompatible` `pair`
- Uses the idiomatic `MSG` constant
- Uses `RESTRICT_ON_SEND` to optimize the `on_send` calls, avoiding
  irrelevant method calls
- Uses a capture in the node matcher instead of indexing into children
- Adds tests for edge cases