### PR TITLE
Add cop to rewrite obsolete memoization pattern

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -159,6 +159,18 @@ Sorbet/KeywordArgumentOrdering:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/ObsoleteStrictMemoization:
+  Description: >-
+    This cop checks for the obsolete pattern for initializing instance variables that was required for older Sorbet
+    versions in `#typed: strict` files.
+
+    It's no longer required, as of Sorbet 0.5.10210
+    See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
+  Enabled: true
+  VersionAdded: '0.7.1'
+  Safe: true
+  SafeAutoCorrect: true
+
 Sorbet/OneAncestorPerLine:
   Description: 'Enforces one ancestor per call to requires_ancestor'
   Enabled: false

--- a/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
+++ b/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      module TargetSorbetVersion
+        class << self
+          def included(target)
+            target.extend(ClassMethods)
+          end
+        end
+
+        module ClassMethods
+          # The version of the Sorbet static type checker required by this cop
+          def minimum_target_sorbet_static_version(version)
+            @minimum_target_sorbet_static_version = Gem::Version.new(version)
+          end
+
+          def support_target_sorbet_static_version?(version)
+            @minimum_target_sorbet_static_version <= Gem::Version.new(version)
+          end
+        end
+
+        def enabled_for_sorbet_static_version?
+          sorbet_static_version = target_sorbet_static_version_from_bundler_lock_file
+          return false unless sorbet_static_version
+
+          self.class.support_target_sorbet_static_version?(sorbet_static_version)
+        end
+
+        def target_sorbet_static_version_from_bundler_lock_file
+          @target_sorbet_static_version_from_bundler_lock_file ||= read_sorbet_static_version_from_bundler_lock_file
+        end
+
+        # Adapted from https://github.com/rubocop/rubocop/blob/1181d4ebad5f71c586f9514d9c341cdfffc1957d/lib/rubocop/config.rb#L293-L308
+        def read_sorbet_static_version_from_bundler_lock_file
+          lock_file_path = config.bundler_lock_file_path
+
+          return nil unless lock_file_path
+
+          File.foreach(lock_file_path) do |line|
+            # If Sorbet (or one of its frameworks) is in Gemfile.lock or gems.lock, there should be
+            # a line like:
+            #         sorbet-static (X.X.X-some_arch)
+            result = line.match(/^\s+sorbet-static\s+\((\d+\.\d+\.\d+)/)
+            return Gem::Version.new(result.captures.first) if result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Checks for the obsolete pattern for initializing instance variables that was required for older Sorbet
+      # versions in `#typed: strict` files.
+      #
+      # It's no longer required, as of Sorbet 0.5.10210
+      # See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { returns(Foo) }
+      #   def foo
+      #     @foo = T.let(@foo, T.nilable(Foo))
+      #     @foo ||= Foo.new
+      #   end
+      #
+      #   # good
+      #   sig { returns(Foo) }
+      #   def foo
+      #     @foo ||= T.let(Foo.new, T.nilable(Foo))
+      #   end
+      #
+      # TODO: disable this cop when the Sorbet version is older than `0.5.10210`.
+      class ObsoleteStrictMemoization < RuboCop::Cop::Cop
+        include RuboCop::Cop::MatchRange
+        include RuboCop::Cop::Alignment
+
+        MESSAGE = "This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. " \
+          "See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
+
+        # @!method legacy_memoization_pattern?(node)
+        def_node_matcher :legacy_memoization_pattern?, <<~PATTERN
+          (begin
+            (ivasgn $_ivar                                # @_ivar = ...
+              (send                                       # T.let(_ivar, T.nilable(_ivar_type))
+                (const nil? :T) :let
+                (ivar _ivar)
+                (send                                     # T.nilable(_ivar_type)
+                  (const nil? :T) :nilable $_ivar_type)))
+            (or-asgn                                      # @_ivar ||= _initialization_expr
+              (ivasgn _ivar)
+              $_initialization_expr))
+        PATTERN
+
+        def on_begin(node)
+          return unless legacy_memoization_pattern?(node)
+
+          add_offense(node, message: MESSAGE)
+        end
+
+        def autocorrect(node)
+          ->(corrector) {
+            expression = legacy_memoization_pattern?(node)
+            ivar, ivar_type, initialization_expr = expression
+
+            base_indent = offset(node)
+
+            is_multiline_init_expr = initialization_expr.line_count != 1
+
+            correction = if is_multiline_init_expr
+              render_multi_line_correction(ivar, ivar_type, initialization_expr, base_indent)
+            else
+              single_line_correction =
+                "#{ivar} ||= T.let(#{initialization_expr.source}, T.nilable(#{ivar_type.source}))"
+
+              if (base_indent.length + single_line_correction.length) <= max_line_length
+                single_line_correction
+              else # The single-line correction was too long. Re-render it as a multi-line correction.
+                render_multi_line_correction(ivar, ivar_type, initialization_expr, base_indent)
+              end
+            end
+
+            corrector.replace(node, correction)
+          }
+        end
+
+        private
+
+        def single_indent
+          @single_indent ||= case config.for_cop("Layout/IndentationStyle")["EnforcedStyle"]
+          when "tabs" then "\t"
+          when "spaces", nil then " " * configured_indentation_width
+          end
+        end
+
+        def render_multi_line_correction(ivar, ivar_type, initialization_expr, base_indent)
+          indent = single_indent
+          initialization_expr_source = initialization_expr.source.lines.map { |line| indent + line }.join
+
+          <<~RUBY.chomp
+            #{ivar} ||= T.let(
+            #{base_indent}#{initialization_expr_source},
+            #{base_indent}#{indent}T.nilable(#{ivar_type.source}),
+            #{base_indent})
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
@@ -20,6 +20,14 @@ module RuboCop
       #     @foo ||= Foo.new
       #   end
       #
+      #   # bad
+      #   sig { returns(Foo) }
+      #   def foo
+      #     # This would have been a mistake, causing the memoized value to be discarded and recomputed on every call.
+      #     @foo = T.let(nil, T.nilable(Foo))
+      #     @foo ||= Foo.new
+      #   end
+      #
       #   # good
       #   sig { returns(Foo) }
       #   def foo
@@ -46,7 +54,7 @@ module RuboCop
             $(ivasgn $_ivar                                           # First line: @_ivar = ...
               (send                                                   # T.let(_ivar, T.nilable(_ivar_type))
                 $(const {nil? cbase} :T) :let
-                (ivar _ivar)
+                {(ivar _ivar) nil}
                 (send (const {nil? cbase} :T) :nilable $_ivar_type))) # T.nilable(_ivar_type)
             $(or-asgn (ivasgn _ivar) $_initialization_expr))          # Second line: @_ivar ||= _initialization_expr
         PATTERN

--- a/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
@@ -26,11 +26,13 @@ module RuboCop
       #     @foo ||= T.let(Foo.new, T.nilable(Foo))
       #   end
       #
-      # TODO: disable this cop when the Sorbet version is older than `0.5.10210`.
       class ObsoleteStrictMemoization < RuboCop::Cop::Base
         include RuboCop::Cop::MatchRange
         include RuboCop::Cop::Alignment
         extend AutoCorrector
+
+        include TargetSorbetVersion
+        minimum_target_sorbet_static_version "0.5.10210"
 
         MESSAGE = "This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. " \
           "See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
@@ -75,6 +77,10 @@ module RuboCop
 
             corrector.replace(node, correction)
           end
+        end
+
+        def relevant_file?(file)
+          super && enabled_for_sorbet_static_version?
         end
 
         private

--- a/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
@@ -27,9 +27,10 @@ module RuboCop
       #   end
       #
       # TODO: disable this cop when the Sorbet version is older than `0.5.10210`.
-      class ObsoleteStrictMemoization < RuboCop::Cop::Cop
+      class ObsoleteStrictMemoization < RuboCop::Cop::Base
         include RuboCop::Cop::MatchRange
         include RuboCop::Cop::Alignment
+        extend AutoCorrector
 
         MESSAGE = "This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. " \
           "See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
@@ -49,14 +50,10 @@ module RuboCop
         PATTERN
 
         def on_begin(node)
-          return unless legacy_memoization_pattern?(node)
+          expression = legacy_memoization_pattern?(node)
+          return unless expression
 
-          add_offense(node, message: MESSAGE)
-        end
-
-        def autocorrect(node)
-          ->(corrector) {
-            expression = legacy_memoization_pattern?(node)
+          add_offense(node, message: MESSAGE) do |corrector|
             ivar, ivar_type, initialization_expr = expression
 
             base_indent = offset(node)
@@ -77,7 +74,7 @@ module RuboCop
             end
 
             corrector.replace(node, correction)
-          }
+          end
         end
 
         private

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "sorbet/mixin/target_sorbet_version.rb"
+
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/constants_from_strings"
 require_relative "sorbet/forbid_superclass_const_literal"

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -12,6 +12,7 @@ require_relative "sorbet/forbid_t_unsafe"
 require_relative "sorbet/forbid_t_untyped"
 require_relative "sorbet/redundant_extend_t_sig"
 require_relative "sorbet/type_alias_name"
+require_relative "sorbet/obsolete_strict_memoization"
 
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"
 require_relative "sorbet/rbi/forbid_rbi_outside_of_allowed_paths"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -26,6 +26,7 @@ In the following section you find all available cops:
 * [Sorbet/IgnoreSigil](cops_sorbet.md#sorbetignoresigil)
 * [Sorbet/ImplicitConversionMethod](cops_sorbet.md#sorbetimplicitconversionmethod)
 * [Sorbet/KeywordArgumentOrdering](cops_sorbet.md#sorbetkeywordargumentordering)
+* [Sorbet/ObsoleteStrictMemoization](cops_sorbet.md#sorbetobsoletestrictmemoization)
 * [Sorbet/OneAncestorPerLine](cops_sorbet.md#sorbetoneancestorperline)
 * [Sorbet/RedundantExtendTSig](cops_sorbet.md#sorbetredundantextendtsig)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -539,6 +539,37 @@ sig { params(b: String, a: Integer).void }
 def foo(b:, a: 1); end
 ```
 
+## Sorbet/ObsoleteStrictMemoization
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.7.1 | -
+
+Checks for the obsolete pattern for initializing instance variables that was required for older Sorbet
+versions in `#typed: strict` files.
+
+It's no longer required, as of Sorbet 0.5.10210
+See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
+
+TODO: disable this cop when the Sorbet version is older than `0.5.10210`.
+
+### Examples
+
+```ruby
+# bad
+sig { returns(Foo) }
+def foo
+  @foo = T.let(@foo, T.nilable(Foo))
+  @foo ||= Foo.new
+end
+
+# good
+sig { returns(Foo) }
+def foo
+  @foo ||= T.let(Foo.new, T.nilable(Foo))
+end
+```
+
 ## Sorbet/OneAncestorPerLine
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -561,6 +561,14 @@ def foo
   @foo ||= Foo.new
 end
 
+# bad
+sig { returns(Foo) }
+def foo
+  # This would have been a mistake, causing the memoized value to be discarded and recomputed on every call.
+  @foo = T.let(nil, T.nilable(Foo))
+  @foo ||= Foo.new
+end
+
 # good
 sig { returns(Foo) }
 def foo

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -551,8 +551,6 @@ versions in `#typed: strict` files.
 It's no longer required, as of Sorbet 0.5.10210
 See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
 
-TODO: disable this cop when the Sorbet version is older than `0.5.10210`.
-
 ### Examples
 
 ```ruby

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
       end
     end
 
-    context "when its not the first line in a method", pending: "Not implemented yet" do
+    context "when its not the first line in a method" do
       it "registers an offence and autocorrects" do
         expect_offense(<<~RUBY)
           def foo

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
   before(:each) do
+    allow(cop).to(receive(:target_sorbet_static_version_from_bundler_lock_file).and_return("0.5.10210"))
     allow(cop).to(receive(:configured_indentation_width).and_return(2))
   end
 
@@ -172,6 +173,24 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
             @foo ||= T.let(Foo.new, T.nilable(Foo))
           end
         RUBY
+      end
+    end
+
+    context "using an old version of Sorbet" do
+      # For old versions, the obsolete memoization pattern isn't actually obsolete.
+
+      describe "the obsolete memoization pattern" do
+        it "does not register an offence" do
+          allow(cop).to(receive(:target_sorbet_static_version_from_bundler_lock_file).and_return("0.5.10209"))
+
+          expect_no_offenses(<<~RUBY)
+            sig { returns(Foo) }
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+              @foo ||= Foo.new
+            end
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
+  before(:each) do
+    allow(cop).to(receive(:configured_indentation_width).and_return(2))
+  end
+
+  it "the new memoization pattern doesn't register any offense" do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        @foo ||= T.let(Foo.new, T.nilable(Foo))
+      end
+    RUBY
+  end
+
+  describe "the obsolete memoization pattern" do
+    it "registers an offence and autocorrects" do
+      expect_offense(<<~RUBY)
+        def foo
+          @foo = T.let(@foo, T.nilable(Foo))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+          @foo ||= Foo.new
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          @foo ||= T.let(Foo.new, T.nilable(Foo))
+        end
+      RUBY
+    end
+
+    describe "with a complex type" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def client_info_hash
+            @client_info_hash = T.let(@client_info_hash, T.nilable(T::Hash[Symbol, T.untyped]))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @client_info_hash ||= client_info.to_hash
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def client_info_hash
+            @client_info_hash ||= T.let(client_info.to_hash, T.nilable(T::Hash[Symbol, T.untyped]))
+          end
+        RUBY
+      end
+    end
+
+    describe "with a long initialization expression" do
+      it "registers an offence and autocorrects into a multiline expression" do
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= some_really_long_initialization_expression______________________________________
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= T.let(
+              some_really_long_initialization_expression______________________________________,
+              T.nilable(SomeReallyLongTypeName______________________________________),
+            )
+          end
+        RUBY
+
+        autocorrected_source = autocorrect_source(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
+            @foo ||= some_really_long_initialization_expression______________________________________
+          end
+        RUBY
+
+        longest_line = autocorrected_source.lines.max_by(&:length)
+        expect(longest_line.length).to(be <= 120) # FIXME: Unhardcode this 120
+      end
+    end
+
+    describe "with multiline initialization expression" do
+      it "registers an offence and autocorrects into a multiline expression" do
+        # There's special auto-correct logic to handle a multiline initialization expression, so that it
+        # *doesn't* end up like this:
+        #
+        #   def foo
+        #     @foo = T.let(multiline_method_call(
+        #       foo,
+        #       bar,
+        #       baz,
+        #     ), T.nilable(Foo))
+        #   end
+
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= multiline_method_call(
+              foo,
+              bar,
+              baz,
+            )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= T.let(
+              multiline_method_call(
+                foo,
+                bar,
+                baz,
+              ),
+              T.nilable(Foo),
+            )
+          end
+        RUBY
+      end
+
+      describe "with a gap between the two lines" do
+        it "registers an offence and autocorrects into a multiline expression" do
+          expect_offense(<<~RUBY)
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+
+              @foo ||= multiline_method_call(
+                foo,
+                bar,
+                baz,
+              )
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo
+              @foo ||= T.let(
+                multiline_method_call(
+                  foo,
+                  bar,
+                  baz,
+                ),
+                T.nilable(Foo),
+              )
+            end
+          RUBY
+        end
+      end
+    end
+
+    context "when its not the first line in a method", pending: "Not implemented yet" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def foo
+            some
+            other
+            code
+            @foo = T.let(@foo, T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= Foo.new
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            some
+            other
+            code
+            @foo ||= T.let(Foo.new, T.nilable(Foo))
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
     end
 
     describe "with a long initialization expression" do
+      let(:max_line_length) { 90 }
+
+      let(:config) do
+        RuboCop::Config.new(
+          "Layout/LineLength" => { "Max" => max_line_length },
+          "Sorbet/ObsoleteStrictMemoization" => cop_config,
+        )
+      end
+
       it "registers an offence and autocorrects into a multiline expression" do
         expect_offense(<<~RUBY)
           def foo
@@ -96,7 +105,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
         RUBY
 
         longest_line = autocorrected_source.lines.max_by(&:length)
-        expect(longest_line.length).to(be <= 120) # FIXME: Unhardcode this 120
+        expect(longest_line.length).to(be <= max_line_length)
       end
     end
 

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
       RUBY
     end
 
+    describe "with fully qualified ::T" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = ::T.let(@foo, ::T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= Foo.new
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= ::T.let(Foo.new, ::T.nilable(Foo))
+          end
+        RUBY
+      end
+    end
+
     describe "with a complex type" do
       it "registers an offence and autocorrects" do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Until recently, memoizing with instance variables in `#typed: strict` files required this cumbersome pattern:

```ruby
sig { returns(Foo) }
def foo
  @foo = T.let(@foo, T.nilable(Foo))
  @foo ||= Foo.new
end
```

This was fixed in Sorbet `0.5.10210.20220725105033-6e80c502e` (see https://github.com/sorbet/sorbet/issues/995)! 🥳 

This new `Sorbet/ObsoleteStrictMemoization` cop catches that obsolete memoization pattern, and rewrites it into:

```ruby
sig { returns(Foo) }
def foo
  @foo ||= T.let(Foo.new, T.nilable(Foo))
end
```

The rewriter also has some special logic to make sure that the resulting line isn't too long. If it is, it'll automatically split it into multiple lines. Look at the test cases for more details.

#### TODO

1. [x] Detect offences even if they're not in the first 2 lines of a method

    There's a limitation in this cop where it can't detect this pattern unless it's the first thing in a method body. Fixing this seemed pretty tricky, so I left it out for now.

    Some of these missed offences of this pattern can be found with this regex:

    ```regex
    \@([a-zAZ_]+) = T\.let\(@\1
    ```

2. [x] Improved the way indentation rules are detected and applied
3. [x] Only apply when the user's Sorbet version is greater than `0.5.10210.20220725105033-6e80c502e`