### PR TITLE
Fix signature order cop when we have an incomplete call

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -36,6 +36,10 @@ module RuboCop
           calls = call_chain(node.children[2]).map(&:method_name)
           return unless calls.any?
 
+          # While the developer is typing, we may have an incomplete call statement, which means `ORDER[call]` will
+          # return `nil`. In that case, invoking `sort_by` will raise
+          return if calls.any? { |call| ORDER[call].nil? }
+
           expected_order = calls.sort_by { |call| ORDER[call] }
           return if expected_order == calls
 

--- a/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
       expect_no_offenses(<<~RUBY)
         sig { abstract }
       RUBY
+
+      expect_no_offenses(<<~RUBY)
+        sig { params(a: Integer).v }
+      RUBY
     end
 
     it("enforces orders of builder calls") do


### PR DESCRIPTION
While the developer is typing, we might have no syntax errors, but an incomplete signature still (e.g.: `sig { params(a: Integer).voi }`).

This causes the cop to break, which is surfaced by the Ruby LSP basically every single time someone is typing a signature.