### PR TITLE
Add `ExactStrictness` to `Sorbet/ValidSigil` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -120,7 +120,8 @@ Sorbet/HasSigil:
   Description: 'Makes the Sorbet typed sigil mandatory in all files.'
   Enabled: false
   SuggestedStrictness: "false"
-  MinimumStrictness: "false"
+  MinimumStrictness: nil
+  ExactStrictness: nil
   VersionAdded: 0.3.3
   Include:
   - "**/*.{rb,rbi,rake,ru}"
@@ -242,7 +243,8 @@ Sorbet/ValidSigil:
   Enabled: true
   RequireSigilOnAllFiles: false
   SuggestedStrictness: "false"
-  MinimumStrictness: "false"
+  MinimumStrictness: nil
+  ExactStrictness: nil
   VersionAdded: 0.3.3
   Include:
   - "**/*.{rb,rbi,rake,ru}"

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -466,7 +466,8 @@ If a `MinimumStrictness` level is specified, it will be used in offense messages
 Name | Default value | Configurable values
 --- | --- | ---
 SuggestedStrictness | `false` | String
-MinimumStrictness | `false` | String
+MinimumStrictness | `nil` | String
+ExactStrictness | `nil` | String
 Include | `**/*.{rb,rbi,rake,ru}` | Array
 Exclude | `bin/**/*`, `db/**/*.rb`, `script/**/*` | Array
 
@@ -720,8 +721,10 @@ Options:
 * `RequireSigilOnAllFiles`: make offense if the Sorbet typed is not found in the file (default: false)
 * `SuggestedStrictness`: Sorbet strictness level suggested in offense messages (default: 'false')
 * `MinimumStrictness`: If set, make offense if the strictness level in the file is below this one
+* `ExactStrictness`: If set, make offense if the strictness level in the file is different than this one
 
-If a `MinimumStrictness` level is specified, it will be used in offense messages and autocorrect.
+If an `ExactStrictness` level is specified, it will be used in offense messages and autocorrect.
+Otherwise, if a `MinimumStrictness` level is specified, it will be used in offense messages and autocorrect.
 
 ### Configurable attributes
 
@@ -729,6 +732,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 RequireSigilOnAllFiles | `false` | Boolean
 SuggestedStrictness | `false` | String
-MinimumStrictness | `false` | String
+MinimumStrictness | `nil` | String
+ExactStrictness | `nil` | String
 Include | `**/*.{rb,rbi,rake,ru}` | Array
 Exclude | `bin/**/*`, `db/**/*.rb`, `script/**/*` | Array


### PR DESCRIPTION
This is useful for cases when a project wants to enforce a particular strictness for some part of its codebase, but nothing above or below that strictness for those files.