### PR TITLE
match SIGIL_REGEX behavior to sorbet sigil parsing

### DIFF
--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -51,7 +51,7 @@ module RuboCop
         protected
 
         STRICTNESS_LEVELS = ["ignore", "false", "true", "strict", "strong"]
-        SIGIL_REGEX = /^\s*#\s+typed:(?:\s+([\w]+))?/
+        SIGIL_REGEX = /^\s*#\s+typed:(?:\s+([\S]+))?/
 
         # extraction
 

--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -51,7 +51,7 @@ module RuboCop
         protected
 
         STRICTNESS_LEVELS = ["ignore", "false", "true", "strict", "strong"]
-        SIGIL_REGEX = /^\s*#\s+typed:(?:\s+([\S]+))?/
+        SIGIL_REGEX = /^[[:blank:]]*#[[:blank:]]+typed:(?:[[:blank:]]+([\S]+))?/
 
         # extraction
 

--- a/spec/rubocop/cop/sorbet/sigils/valid_sigil_spec.rb
+++ b/spec/rubocop/cop/sorbet/sigils/valid_sigil_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSigil, :config) do
         ^^^^^^^^^^^^^^^ Invalid Sorbet sigil `foobar`.
         class Foo; end
       RUBY
-    end 
+    end
 
     it "enforces whitespase surrounding valid strictness levels" do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sorbet/sigils/valid_sigil_spec.rb
+++ b/spec/rubocop/cop/sorbet/sigils/valid_sigil_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe(RuboCop::Cop::Sorbet::ValidSigil, :config) do
         ^^^^^^^^^^^^^^^ Invalid Sorbet sigil `foobar`.
         class Foo; end
       RUBY
+    end 
+
+    it "enforces whitespase surrounding valid strictness levels" do
+      expect_offense(<<~RUBY)
+        # Hello world!
+        # typed: true# rubocop:todo Sorbet/StrictSigil
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid Sorbet sigil `true#`.
+        class Foo; end
+      RUBY
     end
   end
 


### PR DESCRIPTION
closes https://github.com/Shopify/rubocop-sorbet/issues/169

This change makes the `ValidSigil` cop's sigil parsing match behavior more closely to the sorbet [implementation](https://github.com/sorbet/sorbet/blob/10541602dda21d749ffeb5ef6cb8401b26e4365f/core/Files.cc#L24-L96).