### PR TITLE
Update RedundantExtendTSig to trim whole line

### DIFF
--- a/lib/rubocop/cop/sorbet/redundant_extend_t_sig.rb
+++ b/lib/rubocop/cop/sorbet/redundant_extend_t_sig.rb
@@ -26,6 +26,7 @@ module RuboCop
       #   end
       #
       class RedundantExtendTSig < RuboCop::Cop::Base
+        include RangeHelp
         extend AutoCorrector
 
         MSG = "Do not redundantly `extend T::Sig` when it is already included in all modules."
@@ -40,7 +41,7 @@ module RuboCop
           return unless extend_t_sig?(node)
 
           add_offense(node) do |corrector|
-            corrector.remove(node)
+            corrector.remove(range_by_whole_lines(node.source_range, include_final_newline: true))
           end
         end
       end

--- a/spec/rubocop/cop/sorbet/redundant_extend_t_sig_spec.rb
+++ b/spec/rubocop/cop/sorbet/redundant_extend_t_sig_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe(RuboCop::Cop::Sorbet::RedundantExtendTSig, :config) do
 
       expect_correction(<<~RUBY)
         #{header}
-          #{trailing_whitespace}
         end
       RUBY
     end
@@ -43,7 +42,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::RedundantExtendTSig, :config) do
       ^^^^^^^^^^^^^ #{message}
     RUBY
 
-    expect_correction(a_blank_line)
+    expect_correction("")
   end
 
   it "registers an offense when using `extend ::T::Sig` (fully qualified)" do
@@ -52,7 +51,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::RedundantExtendTSig, :config) do
       ^^^^^^^^^^^^^^^ #{message}
     RUBY
 
-    expect_correction(a_blank_line)
+    expect_correction("")
   end
 
   it "registers an offense when using `extend T::Sig` with an explicit receiver" do
@@ -61,7 +60,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::RedundantExtendTSig, :config) do
       ^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
     RUBY
 
-    expect_correction(a_blank_line)
+    expect_correction("")
   end
 
   it "does not register an offense when extending other modules in the T namespace" do
@@ -70,11 +69,5 @@ RSpec.describe(RuboCop::Cop::Sorbet::RedundantExtendTSig, :config) do
         extend T::Helpers
       end
     RUBY
-  end
-
-  private
-
-  def a_blank_line
-    "\n"
   end
 end


### PR DESCRIPTION
### Description 

When running this cop it will leave whatever whitespace occurred at the start of the line, which means that if run in isolation may cause other violations. 

This approach is in line with what occurs in [ForbidExtendTSigHelpersInShims](https://github.com/Shopify/rubocop-sorbet/blob/main/lib/rubocop/cop/sorbet/rbi/forbid_extend_t_sig_helpers_in_shims.rb#L40), replacing the whole line and removing any new line. 

The thing to consider is that it will also remove any comment on the line, but this feels like a fine tradeoff since it would likely be to do with the extend in the first place and would need to be cleaned up. 