### PR TITLE
Extract new `BuggyObsoleteStrictMemoization` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -171,6 +171,23 @@ Sorbet/ObsoleteStrictMemoization:
   Safe: true
   SafeAutoCorrect: true
 
+Sorbet/BuggyObsoleteStrictMemoization:
+  Description: >-
+    Checks for the a mistaken variant of the "obsolete memoization pattern" that used to be required
+    for older Sorbet versions in `#typed: strict` files. The mistaken variant would overwrite the ivar with `nil`
+    on every call, causing the memoized value to be discarded and recomputed on every call.
+    
+    This cop will correct it to read from the ivar instead of `nil`, which will memoize it correctly.
+    
+    The result of this correction will be the "obsolete memoization pattern", which can further be corrected by
+    the `Sorbet/ObsoleteStrictMemoization` cop.
+    
+    See `Sorbet/ObsoleteStrictMemoization` for more details.
+  Enabled: true
+  VersionAdded: '0.7.3'
+  Safe: true
+  SafeAutoCorrect: false
+
 Sorbet/OneAncestorPerLine:
   Description: 'Enforces one ancestor per call to requires_ancestor'
   Enabled: false

--- a/lib/rubocop/cop/sorbet/buggy_obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/buggy_obsolete_strict_memoization.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Checks for the obsolete pattern for initializing instance variables that was required for older Sorbet
+      # versions in `#typed: strict` files.
+      #
+      # It's no longer required, as of Sorbet 0.5.10210
+      # See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { returns(Foo) }
+      #   def foo
+      #     @foo = T.let(@foo, T.nilable(Foo))
+      #     @foo ||= Foo.new
+      #   end
+      #
+      #   # bad
+      #   sig { returns(Foo) }
+      #   def foo
+      #     # This would have been a mistake, causing the memoized value to be discarded and recomputed on every call.
+      #     @foo = T.let(nil, T.nilable(Foo))
+      #     @foo ||= Foo.new
+      #   end
+      #
+      #   # good
+      #   sig { returns(Foo) }
+      #   def foo
+      #     @foo ||= T.let(Foo.new, T.nilable(Foo))
+      #   end
+      #
+      class ObsoleteStrictMemoization < RuboCop::Cop::Base
+        include RuboCop::Cop::MatchRange
+        include RuboCop::Cop::Alignment
+        include RuboCop::Cop::LineLengthHelp
+        include RuboCop::Cop::RangeHelp
+        extend AutoCorrector
+
+        include TargetSorbetVersion
+        minimum_target_sorbet_static_version "0.5.10210"
+
+        MSG = "This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. " \
+          "See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
+
+        # @!method legacy_memoization_pattern?(node)
+        def_node_matcher :legacy_memoization_pattern?, <<~PATTERN
+          (begin
+            ...                                                       # Ignore any other lines that come first.
+            $(ivasgn $_ivar                                           # First line: @_ivar = ...
+              (send                                                   # T.let(_ivar, T.nilable(_ivar_type))
+                $(const {nil? cbase} :T) :let
+                {(ivar _ivar) nil}
+                (send (const {nil? cbase} :T) :nilable $_ivar_type))) # T.nilable(_ivar_type)
+            $(or-asgn (ivasgn _ivar) $_initialization_expr))          # Second line: @_ivar ||= _initialization_expr
+        PATTERN
+
+        def on_begin(node)
+          legacy_memoization_pattern?(node) do |first_asgn_node, ivar, t, ivar_type, second_or_asgn_node, init_expr| # rubocop:disable Metrics/ParameterLists
+            add_offense(first_asgn_node) do |corrector|
+              indent = offset(node)
+              correction = "#{ivar} ||= #{t.source}.let(#{init_expr.source}, #{t.source}.nilable(#{ivar_type.source}))"
+
+              # We know good places to put line breaks, if required.
+              if line_length(indent + correction) > max_line_length || correction.include?("\n")
+                correction = <<~RUBY.chomp
+                  #{ivar} ||= #{t.source}.let(
+                  #{indent}  #{init_expr.source.gsub("\n", "\n#{indent}")},
+                  #{indent}  #{t.source}.nilable(#{ivar_type.source.gsub("\n", "\n#{indent}")}),
+                  #{indent})
+                RUBY
+              end
+
+              corrector.replace(
+                range_between(first_asgn_node.source_range.begin_pos, second_or_asgn_node.source_range.end_pos),
+                correction,
+              )
+            end
+          end
+        end
+
+        def relevant_file?(file)
+          super && enabled_for_sorbet_static_version?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/buggy_obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/buggy_obsolete_strict_memoization.rb
@@ -5,36 +5,41 @@ require "rubocop"
 module RuboCop
   module Cop
     module Sorbet
-      # Checks for the obsolete pattern for initializing instance variables that was required for older Sorbet
-      # versions in `#typed: strict` files.
+      # Checks for the a mistaken variant of the "obsolete memoization pattern" that used to be required
+      # for older Sorbet versions in `#typed: strict` files. The mistaken variant would overwrite the ivar with `nil`
+      # on every call, causing the memoized value to be discarded and recomputed on every call.
       #
-      # It's no longer required, as of Sorbet 0.5.10210
-      # See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization
+      # This cop will correct it to read from the ivar instead of `nil`, which will memoize it correctly.
+      #
+      # The result of this correction will be the "obsolete memoization pattern", which can further be corrected by
+      # the `Sorbet/ObsoleteStrictMemoization` cop.
+      #
+      # See `Sorbet/ObsoleteStrictMemoization` for more details.
+      #
+      # @safety
+      #   If the computation being memoized had side effects, calling it only once (instead of once on every call
+      #   to the affected method) can be observed, and might be a breaking change.
       #
       # @example
-      #
       #   # bad
       #   sig { returns(Foo) }
       #   def foo
-      #     @foo = T.let(@foo, T.nilable(Foo))
-      #     @foo ||= Foo.new
-      #   end
-      #
-      #   # bad
-      #   sig { returns(Foo) }
-      #   def foo
-      #     # This would have been a mistake, causing the memoized value to be discarded and recomputed on every call.
+      #     # This `nil` is likely a mistake, causing the memoized value to be discarded and recomputed on every call.
       #     @foo = T.let(nil, T.nilable(Foo))
-      #     @foo ||= Foo.new
+      #     @foo ||= some_computation
       #   end
       #
       #   # good
       #   sig { returns(Foo) }
       #   def foo
-      #     @foo ||= T.let(Foo.new, T.nilable(Foo))
+      #     # This will now memoize the value as was likely intended, so `some_computation` is only ever called once.
+      #     # ⚠️If `some_computation` has side effects, this might be a breaking change!
+      #     @foo = T.let(@foo, T.nilable(Foo))
+      #     @foo ||= some_computation
       #   end
       #
-      class ObsoleteStrictMemoization < RuboCop::Cop::Base
+      # @see Sorbet/ObsoleteStrictMemoization
+      class BuggyObsoleteStrictMemoization < RuboCop::Cop::Base
         include RuboCop::Cop::MatchRange
         include RuboCop::Cop::Alignment
         include RuboCop::Cop::LineLengthHelp
@@ -42,49 +47,35 @@ module RuboCop
         extend AutoCorrector
 
         include TargetSorbetVersion
-        minimum_target_sorbet_static_version "0.5.10210"
 
-        MSG = "This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. " \
-          "See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
+        MSG = "This might be a mistaken variant of the two-stage workaround that used to be needed for memoization in "\
+          "`#typed: strict` files. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization."
 
-        # @!method legacy_memoization_pattern?(node)
-        def_node_matcher :legacy_memoization_pattern?, <<~PATTERN
+        # @!method buggy_legacy_memoization_pattern?(node)
+        def_node_matcher :buggy_legacy_memoization_pattern?, <<~PATTERN
           (begin
             ...                                                       # Ignore any other lines that come first.
-            $(ivasgn $_ivar                                           # First line: @_ivar = ...
+            (ivasgn $_ivar                                           # First line: @_ivar = ...
               (send                                                   # T.let(_ivar, T.nilable(_ivar_type))
-                $(const {nil? cbase} :T) :let
-                {(ivar _ivar) nil}
-                (send (const {nil? cbase} :T) :nilable $_ivar_type))) # T.nilable(_ivar_type)
-            $(or-asgn (ivasgn _ivar) $_initialization_expr))          # Second line: @_ivar ||= _initialization_expr
+                (const {nil? cbase} :T) :let
+                $nil
+                (send (const {nil? cbase} :T) :nilable _ivar_type))) # T.nilable(_ivar_type)
+            (or-asgn (ivasgn _ivar) _initialization_expr))          # Second line: @_ivar ||= _initialization_expr
         PATTERN
 
         def on_begin(node)
-          legacy_memoization_pattern?(node) do |first_asgn_node, ivar, t, ivar_type, second_or_asgn_node, init_expr| # rubocop:disable Metrics/ParameterLists
-            add_offense(first_asgn_node) do |corrector|
-              indent = offset(node)
-              correction = "#{ivar} ||= #{t.source}.let(#{init_expr.source}, #{t.source}.nilable(#{ivar_type.source}))"
-
-              # We know good places to put line breaks, if required.
-              if line_length(indent + correction) > max_line_length || correction.include?("\n")
-                correction = <<~RUBY.chomp
-                  #{ivar} ||= #{t.source}.let(
-                  #{indent}  #{init_expr.source.gsub("\n", "\n#{indent}")},
-                  #{indent}  #{t.source}.nilable(#{ivar_type.source.gsub("\n", "\n#{indent}")}),
-                  #{indent})
-                RUBY
-              end
-
+          buggy_legacy_memoization_pattern?(node) do |ivar, nil_node|
+            add_offense(nil_node) do |corrector|
               corrector.replace(
-                range_between(first_asgn_node.source_range.begin_pos, second_or_asgn_node.source_range.end_pos),
-                correction,
+                range_between(nil_node.source_range.begin_pos, nil_node.source_range.end_pos),
+                ivar,
               )
             end
           end
         end
 
         def relevant_file?(file)
-          super && enabled_for_sorbet_static_version?
+          super && sorbet_enabled?
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
+++ b/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
@@ -11,21 +11,25 @@ module RuboCop
         end
 
         module ClassMethods
-          # The version of the Sorbet static type checker required by this cop
+          # Sets the version of the Sorbet static type checker required by this cop
           def minimum_target_sorbet_static_version(version)
             @minimum_target_sorbet_static_version = Gem::Version.new(version)
           end
 
-          def support_target_sorbet_static_version?(version)
+          def supports_target_sorbet_static_version?(version)
             @minimum_target_sorbet_static_version <= Gem::Version.new(version)
           end
+        end
+
+        def sorbet_enabled?
+          !target_sorbet_static_version_from_bundler_lock_file.nil?
         end
 
         def enabled_for_sorbet_static_version?
           sorbet_static_version = target_sorbet_static_version_from_bundler_lock_file
           return false unless sorbet_static_version
 
-          self.class.support_target_sorbet_static_version?(sorbet_static_version)
+          self.class.supports_target_sorbet_static_version?(sorbet_static_version)
         end
 
         def target_sorbet_static_version_from_bundler_lock_file

--- a/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
+++ b/lib/rubocop/cop/sorbet/obsolete_strict_memoization.rb
@@ -54,7 +54,7 @@ module RuboCop
             $(ivasgn $_ivar                                           # First line: @_ivar = ...
               (send                                                   # T.let(_ivar, T.nilable(_ivar_type))
                 $(const {nil? cbase} :T) :let
-                {(ivar _ivar) nil}
+                (ivar _ivar)
                 (send (const {nil? cbase} :T) :nilable $_ivar_type))) # T.nilable(_ivar_type)
             $(or-asgn (ivasgn _ivar) $_initialization_expr))          # Second line: @_ivar ||= _initialization_expr
         PATTERN

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -15,6 +15,7 @@ require_relative "sorbet/forbid_t_untyped"
 require_relative "sorbet/redundant_extend_t_sig"
 require_relative "sorbet/type_alias_name"
 require_relative "sorbet/obsolete_strict_memoization"
+require_relative "sorbet/buggy_obsolete_strict_memoization"
 
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"
 require_relative "sorbet/rbi/forbid_rbi_outside_of_allowed_paths"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -7,6 +7,7 @@ In the following section you find all available cops:
 
 * [Sorbet/AllowIncompatibleOverride](cops_sorbet.md#sorbetallowincompatibleoverride)
 * [Sorbet/BindingConstantWithoutTypeAlias](cops_sorbet.md#sorbetbindingconstantwithouttypealias)
+* [Sorbet/BuggyObsoleteStrictMemoization](cops_sorbet.md#sorbetbuggyobsoletestrictmemoization)
 * [Sorbet/CallbackConditionalsBinding](cops_sorbet.md#sorbetcallbackconditionalsbinding)
 * [Sorbet/CheckedTrueInSignature](cops_sorbet.md#sorbetcheckedtrueinsignature)
 * [Sorbet/ConstantsFromStrings](cops_sorbet.md#sorbetconstantsfromstrings)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -41,6 +41,44 @@ FooOrBar = T.any(Foo, Bar)
 FooOrBar = T.type_alias { T.any(Foo, Bar) }
 ```
 
+## Sorbet/BuggyObsoleteStrictMemoization
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes (Unsafe) | 0.7.3 | -
+
+Checks for the a mistaken variant of the "obsolete memoization pattern" that used to be required
+for older Sorbet versions in `#typed: strict` files. The mistaken variant would overwrite the ivar with `nil`
+on every call, causing the memoized value to be discarded and recomputed on every call.
+
+This cop will correct it to read from the ivar instead of `nil`, which will memoize it correctly.
+
+The result of this correction will be the "obsolete memoization pattern", which can further be corrected by
+the `Sorbet/ObsoleteStrictMemoization` cop.
+
+See `Sorbet/ObsoleteStrictMemoization` for more details.
+
+### Examples
+
+```ruby
+# bad
+sig { returns(Foo) }
+def foo
+  # This `nil` is likely a mistake, causing the memoized value to be discarded and recomputed on every call.
+  @foo = T.let(nil, T.nilable(Foo))
+  @foo ||= some_computation
+end
+
+# good
+sig { returns(Foo) }
+def foo
+  # This will now memoize the value as was likely intended, so `some_computation` is only ever called once.
+  # ⚠️If `some_computation` has side effects, this might be a breaking change!
+  @foo = T.let(@foo, T.nilable(Foo))
+  @foo ||= some_computation
+end
+```
+
 ## Sorbet/CallbackConditionalsBinding
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/sorbet/buggy_obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/buggy_obsolete_strict_memoization_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
+  let(:specs_without_sorbet) do
+    [
+      Gem::Specification.new("foo", "0.0.1"),
+      Gem::Specification.new("bar", "0.0.2"),
+    ]
+  end
+
+  before(:each) do
+    allow(Bundler).to(receive(:locked_gems)).and_return(
+      Struct.new(:specs).new([
+        *specs_without_sorbet,
+        Gem::Specification.new("sorbet-static", "0.5.10210"),
+      ]),
+    )
+
+    allow(cop).to(receive(:configured_indentation_width).and_return(2))
+  end
+
+  it "the new memoization pattern doesn't register any offense" do
+    expect_no_offenses(<<~RUBY)
+      def foo
+        @foo ||= T.let(Foo.new, T.nilable(Foo))
+      end
+    RUBY
+  end
+
+  describe "the obsolete memoization pattern" do
+    it "registers an offence and autocorrects" do
+      expect_offense(<<~RUBY)
+        def foo
+          @foo = T.let(@foo, T.nilable(Foo))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+          @foo ||= Foo.new
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          @foo ||= T.let(Foo.new, T.nilable(Foo))
+        end
+      RUBY
+    end
+
+    describe "with fully qualified ::T" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = ::T.let(@foo, ::T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= Foo.new
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= ::T.let(Foo.new, ::T.nilable(Foo))
+          end
+        RUBY
+      end
+    end
+
+    describe "with a complex type" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def client_info_hash
+            @client_info_hash = T.let(@client_info_hash, T.nilable(T::Hash[Symbol, T.untyped]))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @client_info_hash ||= client_info.to_hash
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def client_info_hash
+            @client_info_hash ||= T.let(client_info.to_hash, T.nilable(T::Hash[Symbol, T.untyped]))
+          end
+        RUBY
+      end
+    end
+
+    describe "with a long initialization expression" do
+      let(:max_line_length) { 90 }
+
+      let(:config) do
+        RuboCop::Config.new(
+          "Layout/LineLength" => { "Max" => max_line_length },
+          "Sorbet/ObsoleteStrictMemoization" => cop_config,
+        )
+      end
+
+      it "registers an offence and autocorrects into a multiline expression" do
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= some_really_long_initialization_expression______________________________________
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= T.let(
+              some_really_long_initialization_expression______________________________________,
+              T.nilable(SomeReallyLongTypeName______________________________________),
+            )
+          end
+        RUBY
+
+        autocorrected_source = autocorrect_source(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
+            @foo ||= some_really_long_initialization_expression______________________________________
+          end
+        RUBY
+
+        longest_line = autocorrected_source.lines.max_by(&:length)
+        expect(longest_line.length).to(be <= max_line_length)
+      end
+    end
+
+    describe "with multiline initialization expression" do
+      it "registers an offence and autocorrects into a multiline expression" do
+        # There's special auto-correct logic to handle a multiline initialization expression, so that it
+        # *doesn't* end up like this:
+        #
+        #   def foo
+        #     @foo = T.let(multiline_method_call(
+        #       foo,
+        #       bar,
+        #       baz,
+        #     ), T.nilable(Foo))
+        #   end
+
+        expect_offense(<<~RUBY)
+          def foo
+            @foo = T.let(@foo, T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= multiline_method_call(
+              foo,
+              bar,
+              baz,
+            )
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            @foo ||= T.let(
+              multiline_method_call(
+                foo,
+                bar,
+                baz,
+              ),
+              T.nilable(Foo),
+            )
+          end
+        RUBY
+      end
+
+      describe "with a gap between the two lines" do
+        it "registers an offence and autocorrects into a multiline expression" do
+          expect_offense(<<~RUBY)
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+
+              @foo ||= multiline_method_call(
+                foo,
+                bar,
+                baz,
+              )
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            def foo
+              @foo ||= T.let(
+                multiline_method_call(
+                  foo,
+                  bar,
+                  baz,
+                ),
+                T.nilable(Foo),
+              )
+            end
+          RUBY
+        end
+      end
+    end
+
+    context "when its not the first line in a method" do
+      it "registers an offence and autocorrects" do
+        expect_offense(<<~RUBY)
+          def foo
+            some
+            other
+            code
+            @foo = T.let(@foo, T.nilable(Foo))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo ||= Foo.new
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          def foo
+            some
+            other
+            code
+            @foo ||= T.let(Foo.new, T.nilable(Foo))
+          end
+        RUBY
+      end
+    end
+
+    context "using an old version of Sorbet" do
+      # For old versions, the obsolete memoization pattern isn't actually obsolete.
+
+      describe "the obsolete memoization pattern" do
+        it "does not register an offence" do
+          allow(Bundler).to(receive(:locked_gems)).and_return(
+            Struct.new(:specs).new([
+              *specs_without_sorbet,
+              Gem::Specification.new("sorbet-static", "0.5.10209"),
+            ]),
+          )
+
+          expect_no_offenses(<<~RUBY)
+            sig { returns(Foo) }
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+              @foo ||= Foo.new
+            end
+          RUBY
+        end
+      end
+    end
+
+    context "not using Sorbet" do
+      # If the project is not using Sorbet, the obsolete memoization pattern might be intentional.
+
+      describe "the obsolete memoization pattern" do
+        it "does not register an offence" do
+          allow(Bundler).to(receive(:locked_gems)).and_return(
+            Struct.new(:specs).new(specs_without_sorbet),
+          )
+
+          expect_no_offenses(<<~RUBY)
+            sig { returns(Foo) }
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+              @foo ||= Foo.new
+            end
+          RUBY
+        end
+      end
+    end
+  end
+
+  describe "a mistaken variant of the obsolete memoization pattern" do
+    it "registers an offence and autocorrects" do
+      # This variant would have been a mistake, which would have caused the memoized value to be discarded
+      # and recomputed on every call. We can fix it up into the working version.
+
+      expect_offense(<<~RUBY)
+        def foo
+          @foo = T.let(nil, T.nilable(Foo))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+          @foo ||= Foo.new
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        def foo
+          @foo ||= T.let(Foo.new, T.nilable(Foo))
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/sorbet/buggy_obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/buggy_obsolete_strict_memoization_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
+RSpec.describe(RuboCop::Cop::Sorbet::BuggyObsoleteStrictMemoization, :config) do
   let(:specs_without_sorbet) do
     [
       Gem::Specification.new("foo", "0.0.1"),
@@ -17,157 +17,55 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
         Gem::Specification.new("sorbet-static", "0.5.10210"),
       ]),
     )
-
     allow(cop).to(receive(:configured_indentation_width).and_return(2))
   end
 
-  it "the new memoization pattern doesn't register any offense" do
-    expect_no_offenses(<<~RUBY)
-      def foo
-        @foo ||= T.let(Foo.new, T.nilable(Foo))
-      end
-    RUBY
-  end
-
-  describe "the obsolete memoization pattern" do
-    it "registers an offence and autocorrects" do
-      expect_offense(<<~RUBY)
-        def foo
-          @foo = T.let(@foo, T.nilable(Foo))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-          @foo ||= Foo.new
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
+  describe "non-offending cases" do
+    it "the new memoization pattern doesn't register any offense" do
+      expect_no_offenses(<<~RUBY)
         def foo
           @foo ||= T.let(Foo.new, T.nilable(Foo))
         end
       RUBY
     end
 
-    describe "with fully qualified ::T" do
-      it "registers an offence and autocorrects" do
-        expect_offense(<<~RUBY)
+    describe "the correct obsolete memoization pattern" do
+      it " doesn't register any offense" do
+        expect_no_offenses(<<~RUBY)
           def foo
-            @foo = ::T.let(@foo, ::T.nilable(Foo))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+            @foo = T.let(@foo, T.nilable(Foo))
             @foo ||= Foo.new
           end
         RUBY
-
-        expect_correction(<<~RUBY)
-          def foo
-            @foo ||= ::T.let(Foo.new, ::T.nilable(Foo))
-          end
-        RUBY
-      end
-    end
-
-    describe "with a complex type" do
-      it "registers an offence and autocorrects" do
-        expect_offense(<<~RUBY)
-          def client_info_hash
-            @client_info_hash = T.let(@client_info_hash, T.nilable(T::Hash[Symbol, T.untyped]))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-            @client_info_hash ||= client_info.to_hash
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          def client_info_hash
-            @client_info_hash ||= T.let(client_info.to_hash, T.nilable(T::Hash[Symbol, T.untyped]))
-          end
-        RUBY
-      end
-    end
-
-    describe "with a long initialization expression" do
-      let(:max_line_length) { 90 }
-
-      let(:config) do
-        RuboCop::Config.new(
-          "Layout/LineLength" => { "Max" => max_line_length },
-          "Sorbet/ObsoleteStrictMemoization" => cop_config,
-        )
       end
 
-      it "registers an offence and autocorrects into a multiline expression" do
-        expect_offense(<<~RUBY)
-          def foo
-            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-            @foo ||= some_really_long_initialization_expression______________________________________
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          def foo
-            @foo ||= T.let(
-              some_really_long_initialization_expression______________________________________,
-              T.nilable(SomeReallyLongTypeName______________________________________),
-            )
-          end
-        RUBY
-
-        autocorrected_source = autocorrect_source(<<~RUBY)
-          def foo
-            @foo = T.let(@foo, T.nilable(SomeReallyLongTypeName______________________________________))
-            @foo ||= some_really_long_initialization_expression______________________________________
-          end
-        RUBY
-
-        longest_line = autocorrected_source.lines.max_by(&:length)
-        expect(longest_line.length).to(be <= max_line_length)
-      end
-    end
-
-    describe "with multiline initialization expression" do
-      it "registers an offence and autocorrects into a multiline expression" do
-        # There's special auto-correct logic to handle a multiline initialization expression, so that it
-        # *doesn't* end up like this:
-        #
-        #   def foo
-        #     @foo = T.let(multiline_method_call(
-        #       foo,
-        #       bar,
-        #       baz,
-        #     ), T.nilable(Foo))
-        #   end
-
-        expect_offense(<<~RUBY)
-          def foo
-            @foo = T.let(@foo, T.nilable(Foo))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-            @foo ||= multiline_method_call(
-              foo,
-              bar,
-              baz,
-            )
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          def foo
-            @foo ||= T.let(
-              multiline_method_call(
-                foo,
-                bar,
-                baz,
-              ),
-              T.nilable(Foo),
-            )
-          end
-        RUBY
+      describe "with fully qualified ::T" do
+        it " doesn't register any offense" do
+          expect_no_offenses(<<~RUBY)
+            def foo
+              @foo = ::T.let(@foo, ::T.nilable(Foo))
+              @foo ||= Foo.new
+            end
+          RUBY
+        end
       end
 
-      describe "with a gap between the two lines" do
-        it "registers an offence and autocorrects into a multiline expression" do
-          expect_offense(<<~RUBY)
+      describe "with a complex type" do
+        it "doesn't register any offense" do
+          expect_no_offenses(<<~RUBY)
+            def client_info_hash
+              @client_info_hash = T.let(@client_info_hash, T.nilable(T::Hash[Symbol, T.untyped]))
+              @client_info_hash ||= client_info.to_hash
+            end
+          RUBY
+        end
+      end
+
+      describe "with multiline initialization expression" do
+        it "doesn't register any offense" do
+          expect_no_offenses(<<~RUBY)
             def foo
               @foo = T.let(@foo, T.nilable(Foo))
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-
               @foo ||= multiline_method_call(
                 foo,
                 bar,
@@ -175,82 +73,48 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
               )
             end
           RUBY
+        end
 
-          expect_correction(<<~RUBY)
-            def foo
-              @foo ||= T.let(
-                multiline_method_call(
+        describe "with a gap between the two lines" do
+          it "doesn't register any offense" do
+            expect_no_offenses(<<~RUBY)
+              def foo
+                @foo = T.let(@foo, T.nilable(Foo))
+
+                @foo ||= multiline_method_call(
                   foo,
                   bar,
                   baz,
-                ),
-                T.nilable(Foo),
+                )
+              end
+            RUBY
+          end
+        end
+      end
+
+      describe "with non-empty lines between the two lines" do
+        it "doesn't register any offense" do
+          expect_no_offenses(<<~RUBY)
+            def foo
+              @foo = T.let(@foo, T.nilable(Foo))
+             some_other_computation
+              @foo ||= multiline_method_call(
+                foo,
+                bar,
+                baz,
               )
             end
           RUBY
         end
       end
-    end
 
-    context "when its not the first line in a method" do
-      it "registers an offence and autocorrects" do
-        expect_offense(<<~RUBY)
-          def foo
-            some
-            other
-            code
-            @foo = T.let(@foo, T.nilable(Foo))
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-            @foo ||= Foo.new
-          end
-        RUBY
-
-        expect_correction(<<~RUBY)
-          def foo
-            some
-            other
-            code
-            @foo ||= T.let(Foo.new, T.nilable(Foo))
-          end
-        RUBY
-      end
-    end
-
-    context "using an old version of Sorbet" do
-      # For old versions, the obsolete memoization pattern isn't actually obsolete.
-
-      describe "the obsolete memoization pattern" do
-        it "does not register an offence" do
-          allow(Bundler).to(receive(:locked_gems)).and_return(
-            Struct.new(:specs).new([
-              *specs_without_sorbet,
-              Gem::Specification.new("sorbet-static", "0.5.10209"),
-            ]),
-          )
-
+      context "when its not the first line in a method" do
+        it "doesn't register any offense" do
           expect_no_offenses(<<~RUBY)
-            sig { returns(Foo) }
             def foo
-              @foo = T.let(@foo, T.nilable(Foo))
-              @foo ||= Foo.new
-            end
-          RUBY
-        end
-      end
-    end
-
-    context "not using Sorbet" do
-      # If the project is not using Sorbet, the obsolete memoization pattern might be intentional.
-
-      describe "the obsolete memoization pattern" do
-        it "does not register an offence" do
-          allow(Bundler).to(receive(:locked_gems)).and_return(
-            Struct.new(:specs).new(specs_without_sorbet),
-          )
-
-          expect_no_offenses(<<~RUBY)
-            sig { returns(Foo) }
-            def foo
+              some
+              other
+              code
               @foo = T.let(@foo, T.nilable(Foo))
               @foo ||= Foo.new
             end
@@ -261,6 +125,23 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
   end
 
   describe "a mistaken variant of the obsolete memoization pattern" do
+    context "not using Sorbet" do
+      # If the project is not using Sorbet, the obsolete memoization pattern might be intentional.
+      it "does not register an offence" do
+        allow(Bundler).to(receive(:locked_gems)).and_return(
+          Struct.new(:specs).new(specs_without_sorbet),
+        )
+
+        expect_no_offenses(<<~RUBY)
+          sig { returns(Foo) }
+          def foo
+            @foo = T.let(@foo, T.nilable(Foo))
+            @foo ||= Foo.new
+          end
+        RUBY
+      end
+    end
+
     it "registers an offence and autocorrects" do
       # This variant would have been a mistake, which would have caused the memoized value to be discarded
       # and recomputed on every call. We can fix it up into the working version.
@@ -268,14 +149,15 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
       expect_offense(<<~RUBY)
         def foo
           @foo = T.let(nil, T.nilable(Foo))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
+                       ^^^ This might be a mistaken variant of the two-stage workaround that used to be needed for memoization in `#typed: strict` files. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
           @foo ||= Foo.new
         end
       RUBY
 
       expect_correction(<<~RUBY)
         def foo
-          @foo ||= T.let(Foo.new, T.nilable(Foo))
+          @foo = T.let(@foo, T.nilable(Foo))
+          @foo ||= Foo.new
         end
       RUBY
     end

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -259,25 +259,4 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
       end
     end
   end
-
-  describe "a mistaken variant of the obsolete memoization pattern" do
-    it "registers an offence and autocorrects" do
-      # This variant would have been a mistake, which would have caused the memoized value to be discarded
-      # and recomputed on every call. We can fix it up into the working version.
-
-      expect_offense(<<~RUBY)
-        def foo
-          @foo = T.let(nil, T.nilable(Foo))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This two-stage workaround for memoization in `#typed: strict` files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
-          @foo ||= Foo.new
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        def foo
-          @foo ||= T.let(Foo.new, T.nilable(Foo))
-        end
-      RUBY
-    end
-  end
 end

--- a/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
+++ b/spec/rubocop/cop/sorbet/obsolete_strict_memoization_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
-  let(:specs) do
+  let(:specs_without_sorbet) do
     [
       Gem::Specification.new("foo", "0.0.1"),
       Gem::Specification.new("bar", "0.0.2"),
@@ -13,7 +13,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
   before(:each) do
     allow(Bundler).to(receive(:locked_gems)).and_return(
       Struct.new(:specs).new([
-        *specs,
+        *specs_without_sorbet,
         Gem::Specification.new("sorbet-static", "0.5.10210"),
       ]),
     )
@@ -223,7 +223,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
         it "does not register an offence" do
           allow(Bundler).to(receive(:locked_gems)).and_return(
             Struct.new(:specs).new([
-              *specs,
+              *specs_without_sorbet,
               Gem::Specification.new("sorbet-static", "0.5.10209"),
             ]),
           )
@@ -245,9 +245,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ObsoleteStrictMemoization, :config) do
       describe "the obsolete memoization pattern" do
         it "does not register an offence" do
           allow(Bundler).to(receive(:locked_gems)).and_return(
-            Struct.new(:specs).new([
-              *specs,
-            ]),
+            Struct.new(:specs).new(specs_without_sorbet),
           )
 
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
The `Sorbet/ObsoleteStrictMemoization` cop introduced in #162 was initially meant to detect this kind of pattern:

```ruby
sig { returns(Foo) }
def foo
  @foo = T.let(@foo, T.nilable(Foo))
  @foo ||= Foo.new
end
```

@Morriar had [the fantastic idea](https://github.com/Shopify/rubocop-sorbet/pull/162#discussion_r1220133334) to also detect a mistaken variant:

```ruby
sig { returns(Foo) }
def foo
  # This would have been a mistake, causing the memoized value to be discarded and recomputed on every call.
  @foo = T.let(nil, T.nilable(Foo))
  #            !!!
  @foo ||= Foo.new
end
```

This was a great idea and found several such bugs in our program, but wasn't implemented quite right.

Auto-correcting this is dangerous. If the computation being memoized (`Foo.new`, in this case) had side effects, calling it only once (instead of once on every call to `foo`) can be observed, and might be a breaking change. This is problematic because `Sorbet/ObsoleteStrictMemoization` is marked `Safe: true` and `SafeAutoCorrect: true`.

This PR splits off this behaviour into a new `BuggyObsoleteStrictMemoization` cop. The output of this cop is the correct (but still obsolete) memoization pattern. From there, `ObsoleteStrictMemoization` can be applied to bring it to the modern standard. This cop is marked `Safe: true, SafeAutoCorrect: false`.