### PR TITLE
Use mixin instead of superclass for signature cops

### DIFF
--- a/lib/rubocop/cop/sorbet/mixin/signature_help.rb
+++ b/lib/rubocop/cop/sorbet/mixin/signature_help.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require "rubocop"
-
 module RuboCop
   module Cop
     module Sorbet
-      # Abstract cop specific to Sorbet signatures
-      #
-      # You can subclass it to use the `on_signature` trigger and the `signature?` node matcher.
-      class SignatureCop < RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
-        @registry = Cop.registry # So we can properly subclass this cop
+      # Mixin for writing cops for signatures, providing a `signature?` node matcher and an `on_signature` trigger.
+      module SignatureHelp
+        extend RuboCop::NodePattern::Macros
 
         # @!method signature?(node)
         def_node_matcher(:signature?, <<~PATTERN)
@@ -22,12 +18,12 @@ module RuboCop
 
         # @!method with_runtime?(node)
         def_node_matcher(:with_runtime?, <<~PATTERN)
-          (const (const nil? :T) :Sig)
+          (const (const {nil? cbase} :T) :Sig)
         PATTERN
 
         # @!method without_runtime?(node)
         def_node_matcher(:without_runtime?, <<~PATTERN)
-          (const (const (const nil? :T) :Sig) :WithoutRuntime)
+          (const (const (const {nil? cbase} :T) :Sig) :WithoutRuntime)
         PATTERN
 
         def on_block(node)
@@ -36,8 +32,8 @@ module RuboCop
 
         alias_method :on_numblock, :on_block
 
-        def on_signature(_)
-          # To be defined in subclasses
+        def on_signature(_node)
+          # To be defined by cop class as needed
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/signatures/checked_true_in_signature.rb
+++ b/lib/rubocop/cop/sorbet/signatures/checked_true_in_signature.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "rubocop"
-require_relative "signature_cop"
-
 module RuboCop
   module Cop
     module Sorbet
@@ -19,8 +16,9 @@ module RuboCop
       #
       #   # good
       #   sig { void }
-      class CheckedTrueInSignature < SignatureCop
+      class CheckedTrueInSignature < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
         include(RuboCop::Cop::RangeHelp)
+        include(RuboCop::Cop::Sorbet::SignatureHelp)
 
         # @!method offending_node(node)
         def_node_search(:offending_node, <<~PATTERN)

--- a/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
+++ b/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "signature_cop"
-
 module RuboCop
   module Cop
     module Sorbet
@@ -20,8 +18,9 @@ module RuboCop
       #   sig { void }
       #   def foo; end
       #
-      class EmptyLineAfterSig < SignatureCop
+      class EmptyLineAfterSig < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
         include RangeHelp
+        include SignatureHelp
 
         def on_signature(node)
           if (next_method(node).line - node.last_line) > 1

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "rubocop"
 require "stringio"
-require_relative "signature_cop"
 
 module RuboCop
   module Cop
@@ -26,7 +24,9 @@ module RuboCop
       #
       # * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
       # * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
-      class EnforceSignatures < SignatureCop
+      class EnforceSignatures < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+        include SignatureHelp
+
         def initialize(config = nil, options = nil)
           super(config, options)
           @last_sig_for_scope = {}

--- a/lib/rubocop/cop/sorbet/signatures/keyword_argument_ordering.rb
+++ b/lib/rubocop/cop/sorbet/signatures/keyword_argument_ordering.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "rubocop"
-require_relative "signature_cop"
-
 module RuboCop
   module Cop
     module Sorbet
@@ -20,7 +17,9 @@ module RuboCop
       #   # good
       #   sig { params(b: String, a: Integer).void }
       #   def foo(b:, a: 1); end
-      class KeywordArgumentOrdering < SignatureCop
+      class KeywordArgumentOrdering < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+        include SignatureHelp
+
         def on_signature(node)
           method_node = node.parent.children[node.sibling_index + 1]
           return if method_node.nil?

--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "rubocop"
-require_relative "signature_cop"
-
 begin
   require "unparser"
 rescue LoadError
@@ -31,7 +28,9 @@ module RuboCop
       #
       #  # good
       #  sig { params(x: Integer).returns(Integer) }
-      class SignatureBuildOrder < SignatureCop
+      class SignatureBuildOrder < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+        include SignatureHelp
+
         ORDER =
           [
             :abstract,

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "sorbet/mixin/target_sorbet_version.rb"
+require_relative "sorbet/mixin/signature_help.rb"
 
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/constants_from_strings"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -32,7 +32,6 @@ In the following section you find all available cops:
 * [Sorbet/OneAncestorPerLine](cops_sorbet.md#sorbetoneancestorperline)
 * [Sorbet/RedundantExtendTSig](cops_sorbet.md#sorbetredundantextendtsig)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
-* [Sorbet/SignatureCop](cops_sorbet.md#sorbetsignaturecop)
 * [Sorbet/SingleLineRbiClassModuleDefinitions](cops_sorbet.md#sorbetsinglelinerbiclassmoduledefinitions)
 * [Sorbet/StrictSigil](cops_sorbet.md#sorbetstrictsigil)
 * [Sorbet/StrongSigil](cops_sorbet.md#sorbetstrongsigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -733,16 +733,6 @@ sig { void.abstract }
 sig { abstract.void }
 ```
 
-## Sorbet/SignatureCop
-
-Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
---- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
-
-Abstract cop specific to Sorbet signatures
-
-You can subclass it to use the `on_signature` trigger and the `signature?` node matcher.
-
 ## Sorbet/SingleLineRbiClassModuleDefinitions
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged


### PR DESCRIPTION
This replaces the `SignatureCop` parent class with a `SignatureHelp` mixin module. Since `SignatureCop` was inheriting from the deprecated `RuboCop::Cop::Cop`, the cops that were inheriting from `SignatureCop` are updated to inherit directly from `Cop` instead.

This approach
- matches what RuboCop does internally,
- avoids the need to override the registry (?), and
- allows granularly migrating from the deprecated `Cop` class to `Base`.

### Before Merging
- [x] Rebase after #186 is merged