### PR TITLE
Disable `InternalAffairs/UndefinedConfig` for now

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ Naming/FileName:
 
 Layout/LineLength:
   IgnoreCopDirectives: true
+
+InternalAffairs/UndefinedConfig:
+  Enabled: false # Bug in implementation fails to find our configs

--- a/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
+++ b/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
@@ -56,7 +56,7 @@ module RuboCop
         private
 
         def allowed_paths
-          paths = cop_config["AllowedPaths"] # rubocop:todo InternalAffairs/UndefinedConfig
+          paths = cop_config["AllowedPaths"]
           return unless paths.is_a?(Array)
 
           paths.compact

--- a/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
+++ b/lib/rubocop/cop/sorbet/sigils/valid_sigil.rb
@@ -90,7 +90,7 @@ module RuboCop
           return suggested_strictness unless minimum_strictness
 
           # special case: if you're using Sorbet/IgnoreSigil without config, we should recommend `ignore`
-          return "ignore" if minimum_strictness == "ignore" && cop_config["SuggestedStrictness"].nil? # rubocop:todo InternalAffairs/UndefinedConfig
+          return "ignore" if minimum_strictness == "ignore" && cop_config["SuggestedStrictness"].nil?
 
           # if a minimum strictness is set (eg. you're using Sorbet/FalseSigil)
           # we want to compare the minimum strictness and suggested strictness. this is because
@@ -161,24 +161,24 @@ module RuboCop
 
         # Default is `false`
         def require_sigil_on_all_files?
-          !!cop_config["RequireSigilOnAllFiles"] # rubocop:todo InternalAffairs/UndefinedConfig
+          !!cop_config["RequireSigilOnAllFiles"]
         end
 
         # Default is `'false'`
         def suggested_strictness
-          config = cop_config["SuggestedStrictness"].to_s # rubocop:todo InternalAffairs/UndefinedConfig
+          config = cop_config["SuggestedStrictness"].to_s
           STRICTNESS_LEVELS.include?(config) ? config : "false"
         end
 
         # Default is `nil`
         def minimum_strictness
-          config = cop_config["MinimumStrictness"].to_s # rubocop:todo InternalAffairs/UndefinedConfig
+          config = cop_config["MinimumStrictness"].to_s
           config if STRICTNESS_LEVELS.include?(config)
         end
 
         # Default is `nil`
         def exact_strictness
-          config = cop_config["ExactStrictness"].to_s # rubocop:todo InternalAffairs/UndefinedConfig
+          config = cop_config["ExactStrictness"].to_s
           config if STRICTNESS_LEVELS.include?(config)
         end
       end


### PR DESCRIPTION
There appears to be a bug in the cop causing it to continue failing even if the missing config is added. Other Rubocop plugins (such as `rubocop-rails` and `rubocop-performance`) also disable it, citing

```yaml
# FIXME: Workaround for a false positive caused by this cop when using `bundle exec rake`.
```

I didn't find any open issue in Rubocop, so I'll open one when I have the time to put together a simplified reproduction case.

Related to #183, which ran into this cop, and couldn't get it to pass.