### PR TITLE
Document `SignatureBuildOrder` cop

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -12,6 +12,25 @@ end
 module RuboCop
   module Cop
     module Sorbet
+      # Checks for the correct order of sig builder methods:
+      # - abstract, override, or overridable
+      # - type_parameters
+      # - params
+      # - returns, or void
+      # - soft, checked, or on_failure
+      #
+      # @example
+      #   # bad
+      #   sig { void.abstract }
+      #
+      #   # good
+      #   sig { abstract.void }
+      #
+      #  # bad
+      #  sig { returns(Integer).params(x: Integer) }
+      #
+      #  # good
+      #  sig { params(x: Integer).returns(Integer) }
       class SignatureBuildOrder < SignatureCop
         ORDER =
           [

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -710,7 +710,28 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.3.0 | -
 
-No documentation
+Checks for the correct order of sig builder methods:
+- abstract, override, or overridable
+- type_parameters
+- params
+- returns, or void
+- soft, checked, or on_failure
+
+ # bad
+ sig { returns(Integer).params(x: Integer) }
+
+ # good
+ sig { params(x: Integer).returns(Integer) }
+
+### Examples
+
+```ruby
+# bad
+sig { void.abstract }
+
+# good
+sig { abstract.void }
+```
 
 ## Sorbet/SignatureCop
 


### PR DESCRIPTION
Not having documentation means that `rubocop:todo` comments attached to the class end up erroneously treated as documentation, and the simplest way to avoid that is to document the doc, which we should be doing anyway.

See #183 for why this is relevant.