### PR TITLE
Extract lint & docs CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ env:
   SRB_SKIP_GEM_RBIS: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
@@ -20,9 +20,22 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Run tests
+        run: bin/rspec
+
+  lint-and-docs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Lint & Docs
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
       - name: Lint Ruby files
         run: bin/rubocop
       - name: Verify documentation is up to date
         run: bundle exec rake generate_cops_documentation
-      - name: Run tests
-        run: bin/rspec


### PR DESCRIPTION
There's no need to re-run Rubocop across every Ruby version, we explicitly specify the target Ruby version, so we'll always have the same output.

Splitting it out into a separate job ensures we can get test results across Ruby versions without being blocked by the same Rubocop error across all versions.

Likewise, the documentation will always be the same, so it can come with.