### PR TITLE
Enable `EmptyLineAfterSig` in RBI config

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -242,6 +242,9 @@ Style/ClassAndModuleChildren:
 Style/DefWithParentheses:
   Enabled: true
 
+Sorbet/EmptyLineAfterSig:
+  Enabled: true
+
 Style/EmptyMethod:
   Enabled: true
   EnforcedStyle: compact

--- a/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
+++ b/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
@@ -21,17 +21,18 @@ module RuboCop
 
         MSG = "Extra empty line or comment detected"
 
-        # @!method signable_method_definition?(node)
-        def_node_matcher :signable_method_definition?, <<~PATTERN
+        # @!method sig_or_signable_method_definition?(node)
+        def_node_matcher :sig_or_signable_method_definition?, <<~PATTERN
           ${
             def
             defs
             (send nil? {:attr_reader :attr_writer :attr_accessor} ...)
+            #signature?
           }
         PATTERN
 
         def on_signature(sig)
-          signable_method_definition?(next_sibling(sig)) do |definition|
+          sig_or_signable_method_definition?(next_sibling(sig)) do |definition|
             range = lines_between(sig, definition)
             next if range.empty? || range.single_line?
 

--- a/spec/rubocop/cop/sorbet/signatures/empty_line_after_sig_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/empty_line_after_sig_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe(RuboCop::Cop::Sorbet::EmptyLineAfterSig, :config) do
         sig { void }; def foo; end
       RUBY
     end
+
+    it("does not register an offense or fail if a method definition has multiple sigs (e.g. RBI files)") do
+      expect_no_offenses(<<~RUBY)
+        sig { void }
+        sig { params(foo: String).void }
+        def bar(foo); end
+      RUBY
+    end
   end
 
   context("with an empty line between sig and method definition") do
@@ -189,6 +197,38 @@ RSpec.describe(RuboCop::Cop::Sorbet::EmptyLineAfterSig, :config) do
         # Comment
         true; sig { void }
         def m; end
+      RUBY
+    end
+
+    it("registers an offense for empty line following multiple sigs") do
+      expect_offense(<<~RUBY)
+        sig { void }
+        sig { params(foo: String).void }
+
+        ^{} Extra empty line or comment detected
+        def bar(foo); end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        sig { void }
+        sig { params(foo: String).void }
+        def bar(foo); end
+      RUBY
+    end
+
+    it("registers an offense for empty line in between multiple sigs") do
+      expect_offense(<<~RUBY)
+        sig { void }
+
+        ^{} Extra empty line or comment detected
+        sig { params(foo: String).void }
+        def bar(foo); end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        sig { void }
+        sig { params(foo: String).void }
+        def bar(foo); end
       RUBY
     end
   end


### PR DESCRIPTION
This teaches `EmptyLineAfterSig` to detect empty lines between signatures in RBIs where methods may have multiple signatures, and enables the cop in the `rbi.yml` config.

As per https://github.com/Shopify/rubocop-sorbet/pull/185#discussion_r1358704727.

---

### Before Merging

- [x] Rebase after #185 is merged