### PR TITLE
Add `final`, `bind`, & `implementation` to `SignatureBuildOrder`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ gemspec
 
 gem "byebug"
 gem "rake", ">= 12.3.3"
-gem "rspec"
+gem "rspec", "~> 3.7"
 gem "rubocop-shopify", require: false
 gem "yard", "~> 0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   rake (>= 12.3.3)
-  rspec
+  rspec (~> 3.7)
   rubocop-shopify
   rubocop-sorbet!
   yard (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,9 +51,6 @@ GEM
       rubocop (~> 1.51)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.4.2)
-    unparser (0.6.0)
-      diff-lcs (~> 1.3)
-      parser (>= 3.0.0)
     yard (0.9.36)
 
 PLATFORMS
@@ -65,7 +62,6 @@ DEPENDENCIES
   rspec
   rubocop-shopify
   rubocop-sorbet!
-  unparser (~> 0.6)
   yard (~> 0.9)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ or, if you use `Bundler`, add this line your application's `Gemfile`:
 gem 'rubocop-sorbet', require: false
 ```
 
-Note: in order to use the [Sorbet/SignatureBuildOrder](https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetsignaturebuildorder) cop autocorrect feature, it is necessary
-to install `unparser` in addition to `rubocop-sorbet`.
-
-```ruby
-gem "unparser", require: false
-```
-
 ## Usage
 
 You need to tell RuboCop to load the Sorbet extension. There are three ways to do this:

--- a/config/default.yml
+++ b/config/default.yml
@@ -223,6 +223,17 @@ Sorbet/SignatureBuildOrder:
                   then params, then return and finally the modifier
                   such as: `abstract.params(...).returns(...).soft`.'
   Enabled: true
+  Order:
+    - abstract
+    - override
+    - overridable
+    - type_parameters
+    - params
+    - returns
+    - void
+    - soft
+    - checked
+    - on_failure
   VersionAdded: 0.3.0
 
 Sorbet/SingleLineRbiClassModuleDefinitions:

--- a/config/default.yml
+++ b/config/default.yml
@@ -188,12 +188,12 @@ Sorbet/BuggyObsoleteStrictMemoization:
     Checks for the a mistaken variant of the "obsolete memoization pattern" that used to be required
     for older Sorbet versions in `#typed: strict` files. The mistaken variant would overwrite the ivar with `nil`
     on every call, causing the memoized value to be discarded and recomputed on every call.
-    
+
     This cop will correct it to read from the ivar instead of `nil`, which will memoize it correctly.
-    
+
     The result of this correction will be the "obsolete memoization pattern", which can further be corrected by
     the `Sorbet/ObsoleteStrictMemoization` cop.
-    
+
     See `Sorbet/ObsoleteStrictMemoization` for more details.
   Enabled: true
   VersionAdded: '0.7.3'

--- a/config/default.yml
+++ b/config/default.yml
@@ -224,11 +224,14 @@ Sorbet/SignatureBuildOrder:
                   such as: `abstract.params(...).returns(...).soft`.'
   Enabled: true
   Order:
+    - final
     - abstract
+    - implementation
     - override
     - overridable
     - type_parameters
     - params
+    - bind
     - returns
     - void
     - soft

--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-begin
-  require "unparser"
-rescue LoadError
-  nil
-end
-
 module RuboCop
   module Cop
     module Sorbet
@@ -27,7 +21,8 @@ module RuboCop
       #
       #   # good
       #   sig { params(x: Integer).returns(Integer) }
-      class SignatureBuildOrder < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
+      class SignatureBuildOrder < ::RuboCop::Cop::Base
+        extend AutoCorrector
         include SignatureHelp
 
         # @!method root_call(node)
@@ -36,92 +31,66 @@ module RuboCop
         PATTERN
 
         def on_signature(node)
-          calls = call_chain(node.children[2]).map(&:method_name)
-          return if calls.empty?
+          body = node.body
 
-          expected_order = calls.sort_by do |call|
-            builder_method_indexes.fetch(call) do
-              # Abort if we don't have a configured order for this call,
-              # likely because the method name is still being typed.
-              return nil
-            end
+          actual_calls_and_indexes = call_chain(body).map.with_index do |send_node, actual_index|
+            # The index this method call appears at in the configured Order.
+            expected_index = builder_method_indexes[send_node.method_name]
+
+            [send_node, actual_index, expected_index]
           end
-          return if expected_order == calls
 
-          message = "Sig builders must be invoked in the following order: #{expected_order.join(", ")}."
+          # Temporarily extract unknown method calls
+          expected_calls_and_indexes, unknown_calls_and_indexes = actual_calls_and_indexes
+            .partition { |_, _, expected_index| expected_index }
 
-          unless can_autocorrect?
-            message += " For autocorrection, add the `unparser` gem to your project."
+          # Sort known method calls by expected index
+          expected_calls_and_indexes.sort_by! { |_, _, expected_index| expected_index }
+
+          # Re-insert unknown method calls in their positions
+          unknown_calls_and_indexes.each do |entry|
+            _, original_index, _ = entry
+
+            expected_calls_and_indexes.insert(original_index, entry)
           end
+
+          # Compare expected and actual ordering
+          expected_method_names = expected_calls_and_indexes.map { |send_node, _, _| send_node.method_name }
+          actual_method_names = actual_calls_and_indexes.map { |send_node, _, _| send_node.method_name }
+          return if expected_method_names == actual_method_names
 
           add_offense(
-            node.children[2],
-            message: message,
-          )
-          node
+            body,
+            message: "Sig builders must be invoked in the following order: #{expected_method_names.join(", ")}.",
+          ) { |corrector| corrector.replace(body, expected_source(expected_calls_and_indexes)) }
         end
-
-        def autocorrect(node)
-          return unless can_autocorrect?
-
-          lambda do |corrector|
-            tree = call_chain(node_reparsed_with_modern_features(node))
-              .sort_by { |call| builder_method_indexes[call.method_name] }
-              .reduce(nil) do |receiver, caller|
-                caller.updated(nil, [receiver] + caller.children.drop(1))
-              end
-
-            corrector.replace(
-              node,
-              Unparser.unparse(tree),
-            )
-          end
-        end
-
-        # Create a subclass of AST Builder that has modern features turned on
-        class ModernBuilder < RuboCop::AST::Builder
-          modernize
-        end
-        private_constant :ModernBuilder
 
         private
 
-        # This method exists to reparse the current node with modern features enabled.
-        # Modern features include "index send" emitting, which is necessary to unparse
-        # "index sends" (i.e. `[]` calls) back to index accessors (i.e. as `foo[bar]``).
-        # Otherwise, we would get the unparsed node as `foo.[](bar)`.
-        def node_reparsed_with_modern_features(node)
-          # Create a new parser with a modern builder class instance
-          parser = Parser::CurrentRuby.new(ModernBuilder.new)
-          # Create a new source buffer with the node source
-          buffer = Parser::Source::Buffer.new(processed_source.path, source: node.source)
-          # Re-parse the buffer
-          parser.parse(buffer)
+        def expected_source(expected_calls_and_indexes)
+          expected_calls_and_indexes.reduce(nil) do |receiver_source, (send_node, _, _)|
+            send_source = if send_node.arguments?
+              "#{send_node.method_name}(#{send_node.arguments.map(&:source).join(", ")})"
+            else
+              send_node.method_name.to_s
+            end
+
+            receiver_source ? "#{receiver_source}.#{send_source}" : send_source
+          end
         end
 
-        def can_autocorrect?
-          defined?(::Unparser)
-        end
+        # Split foo.bar.baz into [foo, foo.bar, foo.bar.baz]
+        def call_chain(node)
+          chain = []
 
-        def call_chain(sig_child_node)
-          return [] if sig_child_node.nil?
-
-          call_node = root_call(sig_child_node).first
-          return [] unless call_node
-
-          calls = []
-          while call_node != sig_child_node
-            calls << call_node
-            call_node = call_node.parent
+          while node&.send_type?
+            chain << node
+            node = node.receiver
           end
 
-          calls << sig_child_node
+          chain.reverse!
 
-          calls
-        end
-
-        def builder?(method_name)
-          builder_method_indexes.key?(method_name)
+          chain
         end
 
         def builder_method_indexes

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -733,12 +733,11 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.3.0 | -
 
-Checks for the correct order of sig builder methods:
-- abstract, override, or overridable
-- type_parameters
-- params
-- returns, or void
-- soft, checked, or on_failure
+Checks for the correct order of `sig` builder methods.
+
+Options:
+
+* `Order`: The order in which to enforce the builder methods are called.
 
 ### Examples
 
@@ -755,6 +754,12 @@ sig { returns(Integer).params(x: Integer) }
 # good
 sig { params(x: Integer).returns(Integer) }
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+Order | `abstract`, `override`, `overridable`, `type_parameters`, `params`, `returns`, `void`, `soft`, `checked`, `on_failure` | Array
 
 ## Sorbet/SingleLineRbiClassModuleDefinitions
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -759,7 +759,7 @@ sig { params(x: Integer).returns(Integer) }
 
 Name | Default value | Configurable values
 --- | --- | ---
-Order | `abstract`, `override`, `overridable`, `type_parameters`, `params`, `returns`, `void`, `soft`, `checked`, `on_failure` | Array
+Order | `final`, `abstract`, `implementation`, `override`, `overridable`, `type_parameters`, `params`, `bind`, `returns`, `void`, `soft`, `checked`, `on_failure` | Array
 
 ## Sorbet/SingleLineRbiClassModuleDefinitions
 

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency("rspec", "~> 3.7")
-  spec.add_development_dependency("unparser", "~> 0.6")
 
   spec.add_runtime_dependency("rubocop", ">= 0.90.0")
 end

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -25,7 +25,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency("rspec", "~> 3.7")
-
   spec.add_runtime_dependency("rubocop", ">= 0.90.0")
 end

--- a/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/signature_build_order_spec.rb
@@ -95,4 +95,32 @@ RSpec.describe(RuboCop::Cop::Sorbet::SignatureBuildOrder, :config) do
       Object.const_set(:Unparser, original_unparser)
     end
   end
+
+  describe("config") do
+    let :cop_config do
+      {
+        "Order" => [
+          "returns",
+          "override",
+        ],
+      }
+    end
+
+    it("ignores chains including unknown methods") do
+      expect_no_offenses(<<~RUBY)
+        sig { override.params(x: Integer).returns(Integer) } # params not in Order
+      RUBY
+    end
+
+    it("allows customizing the order") do
+      expect_offense(<<~RUBY)
+        sig { override.returns(Integer) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Sig builders must be invoked in the following order: returns, override.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        sig { returns(Integer).override }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This teaches `SignatureBuildOrder` to also enforce the ordering of [`final`](https://github.com/sorbet/sorbet/blob/4ef2b632ae1433ed1a544fd568f3481a4fc8f2df/rbi/sorbet/builder.rbi#L9-L10), [`bind`](https://github.com/sorbet/sorbet/blob/4ef2b632ae1433ed1a544fd568f3481a4fc8f2df/rbi/sorbet/builder.rbi#L21-L22), and [`implementation`](https://github.com/sorbet/sorbet/blob/4ef2b632ae1433ed1a544fd568f3481a4fc8f2df/rbi/sorbet/builder.rbi#L12-L13) builder methods.

As per https://github.com/Shopify/rubocop-sorbet/pull/186#discussion_r1358707761

It also includes a refactor which
- **drops the need for `unparser`**, and
- teaches `SignatureBuildOrder` to handle `sig`s which include unknown builder methods, rather than ignore them

### Before Merging

- [x] Rebase after #186 is merged.