### PR TITLE
Make incompatible override rule not fail on incomplete signatures

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/allow_incompatible_override.rb
+++ b/lib/rubocop/cop/sorbet/signatures/allow_incompatible_override.rb
@@ -56,7 +56,7 @@ module RuboCop
           return unless sig?(node.send_node)
 
           block = node.children.last
-          return unless block.send_type?
+          return unless block&.send_type?
 
           receiver = block.receiver
           while receiver

--- a/spec/rubocop/cop/sorbet/signatures/allow_incompatible_override_spec.rb
+++ b/spec/rubocop/cop/sorbet/signatures/allow_incompatible_override_spec.rb
@@ -74,4 +74,13 @@ RSpec.describe(RuboCop::Cop::Sorbet::AllowIncompatibleOverride, :config) do
       end
     RUBY
   end
+
+  it("doesn't break on incomplete signatures") do
+    expect_no_offenses(<<~RUBY)
+      class Foo
+        sig {  }
+        def foo; end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This cop is breaking while editing files in the Ruby LSP.