### PR TITLE
Disable Style/Empty method for RBIs

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -245,10 +245,6 @@ Style/DefWithParentheses:
 Sorbet/EmptyLineAfterSig:
   Enabled: true
 
-Style/EmptyMethod:
-  Enabled: true
-  EnforcedStyle: compact
-
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: never


### PR DESCRIPTION
As discussed with @Morriar, if `Style/EmptyMethod` ([docs](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod)) is enabled then it will prevent us from breaking up long argument lists in shims.

So instead of writing:

```ruby
  def remote_test(
    long_argument_name_1:,
    long_argument_name_2:,
    long_argument_name_3:
    )
  end
```

You would need to write

```ruby
  def remote_test(long_argument_name_1:, long_argument_name_2:, long_argument_name_3:); end
```
