### PR TITLE
add missing markdown code fence around example

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
+++ b/lib/rubocop/cop/sorbet/signatures/signature_build_order.rb
@@ -23,11 +23,11 @@ module RuboCop
       #   # good
       #   sig { abstract.void }
       #
-      #  # bad
-      #  sig { returns(Integer).params(x: Integer) }
+      #   # bad
+      #   sig { returns(Integer).params(x: Integer) }
       #
-      #  # good
-      #  sig { params(x: Integer).returns(Integer) }
+      #   # good
+      #   sig { params(x: Integer).returns(Integer) }
       class SignatureBuildOrder < ::RuboCop::Cop::Cop # rubocop:todo InternalAffairs/InheritDeprecatedCopClass
         include SignatureHelp
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -740,12 +740,6 @@ Checks for the correct order of sig builder methods:
 - returns, or void
 - soft, checked, or on_failure
 
- # bad
- sig { returns(Integer).params(x: Integer) }
-
- # good
- sig { params(x: Integer).returns(Integer) }
-
 ### Examples
 
 ```ruby
@@ -754,6 +748,12 @@ sig { void.abstract }
 
 # good
 sig { abstract.void }
+
+# bad
+sig { returns(Integer).params(x: Integer) }
+
+# good
+sig { params(x: Integer).returns(Integer) }
 ```
 
 ## Sorbet/SingleLineRbiClassModuleDefinitions


### PR DESCRIPTION
This example was missing the code block fencing around it. So just adding that in.