### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configures Dependabot to bump gems and GitHub Actions versions.

See https://github.com/Shopify/rubocop-sorbet/pull/208#issuecomment-2016872194 for motivation (in addition to all the normal reasons we would want up-to-date dependencies).