### PR TITLE
Bump minimum RuboCop version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2"]
-    name: Test Ruby ${{ matrix.ruby }}
+        gemfile: ["Gemfile", "gemfiles/minimum_rubocop.gemfile"]
+    name: Test Ruby ${{ matrix.ruby }} | ${{ matrix.gemfile }}
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -20,6 +23,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Rubocop Version
+        run: bundle info rubocop | head -1
       - name: Run tests
         run: bin/rspec
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+gemfiles/*.gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-sorbet (0.8.0)
-      rubocop (>= 0.90.0)
+      rubocop (>= 1.45.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/minimum_rubocop.gemfile
+++ b/gemfiles/minimum_rubocop.gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+# This naively extracts the minimum rubocop version from our gemspec,
+# allowing us to ensure that it remains compatible.
+minimum_rubocop_version = File.read("rubocop-sorbet.gemspec")[
+  /(?<=add_runtime_dependency\("rubocop", "(~>|>=) ).*(?="\)$)/
+]
+raise "Failed to extract minimum rubocop version from gemspec" if minimum_rubocop_version.nil?
+
+gem "rubocop", minimum_rubocop_version

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("rubocop", ">= 0.90.0")
+  spec.add_runtime_dependency("rubocop", ">= 1.45.1")
 end


### PR DESCRIPTION
_This PR originally just added the minimum RuboCop version to the CI matrix, but it was [discovered](https://github.com/Shopify/rubocop-sorbet/pull/210#issuecomment-2016910622) that that version doesn't work, so in now also bumps it._

This bumps the minimum RuboCop version to 1.45.1, to reflect actual compatibility.

It also adds the minimum RuboCop version to the CI matrix. This ensures we're compatible with the minimum RuboCop version we claim in `rubocop-sorbet.gemspec`.

This approach is [copied from `rubocop-shopify`](https://github.com/Shopify/ruby-style-guide/blob/main/gemfiles/minimum_rubocop.gemfile).