### PR TITLE
Introduce `MultipleTEnumValues` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -312,3 +312,8 @@ Sorbet/VoidCheckedTests:
   Description: 'Forbid `.void.checked(:tests)`'
   Enabled: true
   VersionAdded: 0.7.7
+
+Sorbet/MultipleTEnumValues:
+  Description: 'Ensures that all `T::Enum`s have multiple values.'
+  Enabled: true
+  VersionAdded: 0.8.2

--- a/lib/rubocop/cop/sorbet/multiple_t_enum_values.rb
+++ b/lib/rubocop/cop/sorbet/multiple_t_enum_values.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Disallow creating a `T::Enum` with less than two values.
+      #
+      # @example
+      #
+      #  # bad
+      #  class ErrorMessages < T::Enum
+      #    enums do
+      #      ServerError = new("There was a server error.")
+      #    end
+      #  end
+      #
+      #  # good
+      #  class ErrorMessages < T::Enum
+      #    enums do
+      #      ServerError = new("There was a server error.")
+      #      NotFound = new("The resource was not found.")
+      #    end
+      #  end
+      class MultipleTEnumValues < Base
+        def initialize(*)
+          @scopes = []
+          super
+        end
+
+        MSG = "`T::Enum` should have at least two values."
+
+        # @!method t_enum?(node)
+        def_node_matcher :t_enum?, <<~PATTERN
+          (class (const...) (const (const nil? :T) :Enum) ...)
+        PATTERN
+
+        # @!method enums_block?(node)
+        def_node_matcher :enums_block?, <<~PATTERN
+          (block (send nil? :enums) ...)
+        PATTERN
+
+        def on_class(node)
+          @scopes.push(node)
+
+          add_offense(node) if t_enum?(node) && node.body.nil?
+        end
+
+        def after_class(node)
+          @scopes.pop
+        end
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return if @scopes.empty? || !t_enum?(@scopes.last)
+          return unless enums_block?(node)
+
+          scope = @scopes.last
+
+          if node.body.nil?
+            add_offense(scope)
+            return
+          end
+
+          begin_node = node.children.find(&:begin_type?)
+
+          num_casgn_nodes = (begin_node || node).children.count(&:casgn_type?)
+          add_offense(scope) if num_casgn_nodes < 2
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -19,6 +19,7 @@ require_relative "sorbet/redundant_extend_t_sig"
 require_relative "sorbet/type_alias_name"
 require_relative "sorbet/obsolete_strict_memoization"
 require_relative "sorbet/buggy_obsolete_strict_memoization"
+require_relative "sorbet/multiple_t_enum_values"
 
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"
 require_relative "sorbet/rbi/forbid_rbi_outside_of_allowed_paths"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -29,6 +29,7 @@ In the following section you find all available cops:
 * [Sorbet/IgnoreSigil](cops_sorbet.md#sorbetignoresigil)
 * [Sorbet/ImplicitConversionMethod](cops_sorbet.md#sorbetimplicitconversionmethod)
 * [Sorbet/KeywordArgumentOrdering](cops_sorbet.md#sorbetkeywordargumentordering)
+* [Sorbet/MultipleTEnumValues](cops_sorbet.md#sorbetmultipletenumvalues)
 * [Sorbet/ObsoleteStrictMemoization](cops_sorbet.md#sorbetobsoletestrictmemoization)
 * [Sorbet/OneAncestorPerLine](cops_sorbet.md#sorbetoneancestorperline)
 * [Sorbet/RedundantExtendTSig](cops_sorbet.md#sorbetredundantextendtsig)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -639,6 +639,33 @@ sig { params(b: String, a: Integer).void }
 def foo(b:, a: 1); end
 ```
 
+## Sorbet/MultipleTEnumValues
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.8.2 | -
+
+Disallow creating a `T::Enum` with less than two values.
+
+### Examples
+
+```ruby
+# bad
+class ErrorMessages < T::Enum
+  enums do
+    ServerError = new("There was a server error.")
+  end
+end
+
+# good
+class ErrorMessages < T::Enum
+  enums do
+    ServerError = new("There was a server error.")
+    NotFound = new("The resource was not found.")
+  end
+end
+```
+
 ## Sorbet/ObsoleteStrictMemoization
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/spec/rubocop/cop/sorbet/multiple_t_enum_values_spec.rb
+++ b/spec/rubocop/cop/sorbet/multiple_t_enum_values_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe(RuboCop::Cop::Sorbet::MultipleTEnumValues, :config) do
+  it "registers an offense when creating a T::Enum with no values" do
+    expect_offense(<<~RUBY)
+      class MyEnum < T::Enum
+      ^^^^^^^^^^^^^^^^^^^^^^ `T::Enum` should have at least two values.
+        enums do
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense when creating a T::Enum with one value" do
+    expect_offense(<<~RUBY)
+      class MyEnum < T::Enum
+      ^^^^^^^^^^^^^^^^^^^^^^ `T::Enum` should have at least two values.
+        enums do
+          A = new
+        end
+      end
+    RUBY
+  end
+
+  it "does not register an offense when creating a T::Enum with two values" do
+    expect_no_offenses(<<~RUBY)
+      class MyEnum < T::Enum
+        enums do
+          A = new
+          B = new
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense for a nested T::Enum" do
+    expect_offense(<<~RUBY)
+      class MyEnum < T::Enum
+        class NestedEnum < T::Enum
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `T::Enum` should have at least two values.
+          enums do
+            A = new
+          end
+        end
+
+        enums do
+          B = new
+          C = new
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense for outer T::Enum" do
+    expect_offense(<<~RUBY)
+      class MyEnum < T::Enum
+      ^^^^^^^^^^^^^^^^^^^^^^ `T::Enum` should have at least two values.
+        class NestedEnum < T::Enum
+          enums do
+            A = new
+            B = new
+          end
+        end
+
+        enums do
+          C = new
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense for a T::Enum with no `enums` block" do
+    expect_offense(<<~RUBY)
+      class MyEnum < T::Enum
+      ^^^^^^^^^^^^^^^^^^^^^^ `T::Enum` should have at least two values.
+      end
+    RUBY
+  end
+
+  it "does not register an offense for a non-T::Enum class with an enums block" do
+    expect_no_offenses(<<~RUBY)
+      class MyEnum < T::Enum
+        class Foo
+          enums do; end
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Related to #219.

This cop ensures that all `T::Enum`s have at least two values to limit unnecessary uses of `T::Enum`.