### PR TITLE
Remove Sorbet/OneAncestorPerLine cop from config/rbi.yml

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -211,9 +211,6 @@ Sorbet/ForbidIncludeConstLiteral:
 Sorbet/ForbidSuperclassConstLiteral:
   Enabled: true
 
-Sorbet/OneAncestorPerLine:
-  Enabled: true
-
 Sorbet/SignatureBuildOrder:
   Enabled: true
 


### PR DESCRIPTION
This cop has been removed in #206, so we should remove it from the rubocop config as well. Otherwise, downstream users will see this error:

```
Error: The `Sorbet/OneAncestorPerLine` cop has been removed since `require_ancestor` now takes a block instead of arguments.
(obsolete configuration found in vendor/bundle/ruby/3.3.0/gems/rubocop-sorbet-0.8.2/config/rbi.yml, please update it)
```