### PR TITLE
Specify minimum RuboCop version as v1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-sorbet (0.8.3)
-      rubocop (>= 0.90.0)
+      rubocop (>= 1)
 
 GEM
   remote: https://rubygems.org/

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("rubocop", ">= 0.90.0")
+  spec.add_runtime_dependency("rubocop", ">= 1")
 end


### PR DESCRIPTION
Now that we've [updated the cops](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html), I think it makes sense to bump the minimum RuboCop version so we can be confident in having a stable RuboCop API.