### PR TITLE
Enable `Layout/SpaceInsideReferenceBrackets` for RBIs

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -175,6 +175,9 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideParens:
   Enabled: true
 
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+
 Layout/TrailingEmptyLines:
   Enabled: true
   EnforcedStyle: final_newline


### PR DESCRIPTION
To avoid stuff like `T::Array[ Foo]`.