### PR TITLE
Use `add_global_offense` for `ForbidRBIOutsideOfAllowedPaths`

### DIFF
--- a/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
+++ b/lib/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths.rb
@@ -27,16 +27,10 @@ module RuboCop
           paths = allowed_paths
 
           if paths.nil?
-            add_offense(
-              source_range(processed_source.buffer, 1, 0),
-              message: "AllowedPaths expects an array",
-            )
+            add_global_offense("AllowedPaths expects an array")
             return
           elsif paths.empty?
-            add_offense(
-              source_range(processed_source.buffer, 1, 0),
-              message: "AllowedPaths cannot be empty",
-            )
+            add_global_offense("AllowedPaths cannot be empty")
             return
           end
 
@@ -44,9 +38,8 @@ module RuboCop
           # We need to remove the exec path directory prefix before matching with the filename regular expressions.
           rel_path = processed_source.file_path.sub("#{Dir.pwd}/", "")
 
-          add_offense(
-            source_range(processed_source.buffer, 1, 0),
-            message: "RBI file path should match one of: #{paths.join(", ")}",
+          add_global_offense(
+            "RBI file path should match one of: #{paths.join(", ")}",
           ) if paths.none? { |pattern| File.fnmatch(pattern, rel_path) }
         end
 

--- a/spec/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths_spec.rb
+++ b/spec/rubocop/cop/sorbet/rbi/forbid_rbi_outside_of_allowed_paths_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if an RBI file is outside of sorbet/rbi/**" do
         expect_offense(<<~RUBY, "some/dir/file.rbi")
           print 1
-          ^ RBI file path should match one of: rbi/**, sorbet/rbi/**
+          ^{} RBI file path should match one of: rbi/**, sorbet/rbi/**
+        RUBY
+      end
+
+      it "registers an offense when the file is empty" do
+        expect_offense(<<~RUBY, "some/dir/file.rbi")
+          ^{} RBI file path should match one of: rbi/**, sorbet/rbi/**
         RUBY
       end
     end
@@ -50,7 +56,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if an RBI file is outside of the allowed path" do
         expect_offense(<<~RUBY, "some/forbidden/directory/file.rbi")
           print 1
-          ^ RBI file path should match one of: some/allowed/**
+          ^{} RBI file path should match one of: some/allowed/**
         RUBY
       end
     end
@@ -92,7 +98,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if an RBI file is outside of the allowed path" do
         expect_offense(<<~RUBY, "some/forbidden/directory/file.rbi")
           print 1
-          ^ RBI file path should match one of: some/allowed/**, hello/other/allowed/**
+          ^{} RBI file path should match one of: some/allowed/**, hello/other/allowed/**
         RUBY
       end
     end
@@ -110,7 +116,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if AllowedPaths is set to an empty list" do
         expect_offense(<<~RUBY, "sorbet/rbi/file.rbi")
           print 1
-          ^ AllowedPaths cannot be empty
+          ^{} AllowedPaths cannot be empty
         RUBY
       end
     end
@@ -126,7 +132,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if AllowedPaths is set to nil" do
         expect_offense(<<~RUBY, "some/directory/file.rbi")
           print 1
-          ^ AllowedPaths expects an array
+          ^{} AllowedPaths expects an array
         RUBY
       end
     end
@@ -142,7 +148,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if AllowedPaths is a list containing only nil" do
         expect_offense(<<~RUBY, "some/directory/file.rbi")
           print 1
-          ^ AllowedPaths cannot be empty
+          ^{} AllowedPaths cannot be empty
         RUBY
       end
     end
@@ -158,7 +164,7 @@ RSpec.describe(RuboCop::Cop::Sorbet::ForbidRBIOutsideOfAllowedPaths, :config) do
       it "makes an offense if AllowedPaths is not an array" do
         expect_offense(<<~RUBY, "some/directory/file.rbi")
           print 1
-          ^ AllowedPaths expects an array
+          ^{} AllowedPaths expects an array
         RUBY
       end
     end


### PR DESCRIPTION
The previous `add_offense` errors when the file is empty: Range 0..1 makes no sense in that context. The error occurs during output:

```
test.rbi:1:1: C: Sorbet/ForbidRBIOutsideOfAllowedPaths: RBI file path should match one of: rbi/**, sorbet/rbi/**
index 0 outside of array bounds: 0...0
```

`add_global_offense` was added for Rubocop v1 which is great since 1.0.0 is now the minimum required version.

#### Why even bother?

I created a new rbi file for testing and `ruby-lsp` runs over it with rubocop immediatly which means it will error.