### PR TITLE
Set `DocumentationBaseURL` and `DocumentationExtension`

### DIFF
--- a/lib/rubocop/sorbet/inject.rb
+++ b/lib/rubocop/sorbet/inject.rb
@@ -11,6 +11,14 @@ module RuboCop
         def defaults!
           path = CONFIG_DEFAULT.to_s
           hash = ConfigLoader.send(:load_yaml_configuration, path)
+          if Gem::Version.new(RuboCop::Version::STRING) >= Gem::Version.new("1.66")
+            # We use markdown for cop documentation. Unconditionally setting
+            # the base url will produce incorrect urls on older RuboCop versions,
+            # so we do that for fully supported version only here.
+            hash["Sorbet"] ||= {}
+            hash["Sorbet"]["DocumentationBaseURL"] = "https://github.com/Shopify/rubocop-sorbet/blob/main/manual"
+            hash["Sorbet"]["DocumentationExtension"] = ".md"
+          end
           config = Config.new(hash, path).tap(&:make_excludes_absolute)
           puts "configuration from #{path}" if ConfigLoader.debug?
           config = ConfigLoader.merge_with_default(config, path)


### PR DESCRIPTION
This allows `ruby-lsp` to link to cop documentation for this extension (notice the blue link which wasn't present before).

![image](https://github.com/user-attachments/assets/fe0700c6-2e82-43ef-942d-a59a4d8d0ca6)

It takes you to https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetstrictsigil

Documentation here is in markdown and rubocop didn't support that until recently, so only set this when it supports both options. Otherwise it would link to non-existant html docs.

Requires a rubocop release with https://github.com/rubocop/rubocop/pull/13080, draft for now.