### PR TITLE
Register offense for `ConstantsFromStrings` with safe navigation

### DIFF
--- a/lib/rubocop/cop/sorbet/constants_from_strings.rb
+++ b/lib/rubocop/cop/sorbet/constants_from_strings.rb
@@ -46,6 +46,7 @@ module RuboCop
         def on_send(node)
           add_offense(node.selector, message: format(MSG, method_name: node.method_name))
         end
+        alias_method :on_csend, :on_send
       end
     end
   end

--- a/spec/rubocop/cop/sorbet/constants_from_strings_spec.rb
+++ b/spec/rubocop/cop/sorbet/constants_from_strings_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe(RuboCop::Cop::Sorbet::ConstantsFromStrings, :config) do
       RUBY
     end
 
+    it("disallows constantize with safe navigation") do
+      expect_offense(<<~RUBY)
+        klass = class_name&.constantize
+                            ^^^^^^^^^^^ #{message("constantize")}
+      RUBY
+    end
+
     it("disallows const_get with receiver") do
       expect_offense(<<~RUBY)
         klass = Object.const_get("Foo")


### PR DESCRIPTION
Closes #140

From a quick look through, this is the only one where handling safe navigation makes much sense.