### PR TITLE
Exclude unfreezable Sorbet invocations from Style/MutableConstant

### DIFF
--- a/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
+++ b/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
@@ -12,6 +12,12 @@ module RuboCop
             base.def_node_matcher(:t_let, <<~PATTERN)
               (send (const nil? :T) :let $_constant _type)
             PATTERN
+            base.def_node_matcher(:t_type_alias?, <<~PATTERN)
+              (block (send (const {nil? cbase} :T) :type_alias ...) ...)
+            PATTERN
+            base.def_node_matcher(:type_member?, <<~PATTERN)
+              (block (send nil? :type_member ...) ...)
+            PATTERN
           end
         end
 
@@ -19,6 +25,8 @@ module RuboCop
           t_let(value) do |constant|
             value = constant
           end
+          return if t_type_alias?(value)
+          return if type_member?(value)
 
           super(value)
         end

--- a/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
+++ b/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
@@ -12,9 +12,13 @@ module RuboCop
             base.def_node_matcher(:t_let, <<~PATTERN)
               (send (const nil? :T) :let $_constant _type)
             PATTERN
+
+            # @!method t_type_alias?(node)
             base.def_node_matcher(:t_type_alias?, <<~PATTERN)
               (block (send (const {nil? cbase} :T) :type_alias ...) ...)
             PATTERN
+
+            # @!method type_member?(node)
             base.def_node_matcher(:type_member?, <<~PATTERN)
               (block (send nil? :type_member ...) ...)
             PATTERN

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -465,6 +465,9 @@ RSpec.describe(RuboCop::Cop::Style::MutableConstant, :config) do
     it_behaves_like "immutable objects", "Struct.new"
     it_behaves_like "immutable objects", "::Struct.new"
     it_behaves_like "immutable objects", "Struct.new(:a, :b)"
+    it_behaves_like "immutable objects", "T.type_alias { T.nilable(T.any(Pathname, String)) }"
+    it_behaves_like "immutable objects", "::T.type_alias { T.nilable(T.any(Pathname, String)) }"
+    it_behaves_like "immutable objects", "type_member { { fixed: Module } }"
     it_behaves_like "immutable objects", <<~RUBY
       Struct.new(:node) do
         def assignment?


### PR DESCRIPTION
With `strict` mode enabled, `Style/MutableConstant` requires constants declared with `T.type_alias` and `type_member` to be frozen. However, doing so results in Sorbet [errors](https://github.com/sorbet/sorbet/issues/3532).

Thus, I would like to exclude these unfreezable patterns from `Style/MutableConstant`.