### PR TITLE
Rescue ::Bundler::GemfileNotFound if sorbet-statis is not found

### DIFF
--- a/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
+++ b/lib/rubocop/cop/sorbet/mixin/target_sorbet_version.rb
@@ -44,7 +44,7 @@ module RuboCop
         def read_sorbet_static_version_from_bundler_lock_file
           require "bundler"
           ::Bundler.locked_gems.specs.find { |spec| spec.name == "sorbet-static" }&.version
-        rescue LoadError, Bundler::GemfileNotFound
+        rescue LoadError, ::Bundler::GemfileNotFound
           nil
         end
       end


### PR DESCRIPTION
Rescue `::Bundler::GemfileNotFound`; otherwise, Ruby searches for `Bundler::GemfileNotFound` in `Cop::Sorbet::TargetSorbetVersion` module.