### PR TITLE
Remove warning from RuboCop in rbi config

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -199,9 +199,6 @@ Lint/Syntax:
 
 ## Sorbet
 
-Sorbet:
-  DisabledByDefault: true
-
 Sorbet/EnforceSigilOrder:
   Enabled: true
 


### PR DESCRIPTION
```
Warning: Sorbet does not support DisabledByDefault parameter.

Supported parameters are:

  - DocumentationBaseURL
  - DocumentationExtension
```

This is true. Because of #252, the top-level Sorbet config key now can be present simply by loading the config, which causes RuboCop to do some extra validating.

`DisabledByDefault` is already set for all cops at the top anyways.