### PR TITLE
Tweak Rubocop rules for inline RBS in RBI files

### DIFF
--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -103,11 +103,11 @@ Layout/InitialIndentation:
 
 Layout/LeadingCommentSpace:
   Enabled: true
+  AllowRBSInlineAnnotation: true
 
 Layout/LeadingEmptyLines:
   Enabled: true
 
-# TODO: make Tapioca break long lines?
 Layout/LineLength:
   Enabled: false
 


### PR DESCRIPTION
So we can use RBS comments within RBI files (especially useful to write shims):

```rb
#: -> String
def to_s; end
```