### PR TITLE
Check examples on CI and fix typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,7 @@ jobs:
           bin/rubocop --config config/default.yml config -r rubocop-sorbet
       - name: Lint Ruby files
         run: bin/rubocop
+      - name: Verify cop examples
+        run: bundle exec rake documentation_syntax_check
       - name: Verify documentation is up to date
         run: bundle exec rake generate_cops_documentation

--- a/lib/rubocop/cop/sorbet/forbid_t_enum.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_enum.rb
@@ -10,7 +10,7 @@ module RuboCop
       # @example
       #
       #   # bad
-      #   class MyEnum < T::Struct
+      #   class MyEnum < T::Enum
       #     enums do
       #       A = new
       #       B = new
@@ -19,7 +19,7 @@ module RuboCop
       #
       #   # good
       #   class MyEnum
-      #     A = "a'
+      #     A = "a"
       #     B = "b"
       #     C = "c"
       #   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -460,7 +460,7 @@ Disallow using `T::Enum`.
 
 ```ruby
 # bad
-class MyEnum < T::Struct
+class MyEnum < T::Enum
   enums do
     A = new
     B = new
@@ -469,7 +469,7 @@ end
 
 # good
 class MyEnum
-  A = "a'
+  A = "a"
   B = "b"
   C = "c"
 end


### PR DESCRIPTION
I noticed the example from #284 was having syntax errors, this shouldn't happen and we can enable `bundle exec rake documentation_syntax_check` on CI to avoid it.