### PR TITLE
Migrate to rubocop plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,8 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
 
-require:
-  - rubocop/cop/internal_affairs
+plugins:
+  - rubocop-internal_affairs
 
 AllCops:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rubocop-sorbet (0.9.0)
       lint_roller (~> 1.1)
-      rubocop (>= 1)
+      rubocop (>= 1.72)
 
 GEM
   remote: https://rubygems.org/

--- a/config/rbi.yml
+++ b/config/rbi.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-sorbet
 
 AllCops:

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("lint_roller", "~> 1.1")
-  spec.add_runtime_dependency("rubocop", ">= 1")
+  spec.add_runtime_dependency("rubocop", ">= 1.72")
 end


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/plugin_migration_guide.html

Suppresses warnings in this repo and other repos that utilize it.

```
Error: rubocop-sorbet extension supports plugin, specify `plugins: rubocop-sorbet` instead of `require: rubocop-sorbet` in /opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/gems/3.3.0/gems/rubocop-sorbet-0.9.0/config/rbi.yml.
```

and

```
Specify `rubocop-internal_affairs` instead of `rubocop/cop/internal_affairs` in your configuration.
```