### PR TITLE
Add missing AllowRBS for default config of EnforceSignatures

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -60,6 +60,7 @@ Sorbet/EnforceSingleSigil:
 Sorbet/EnforceSignatures:
   Description: 'Ensures all methods have a valid signature.'
   Enabled: false
+  AllowRBS: false
   VersionAdded: 0.3.4
 
 Sorbet/FalseSigil:

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -254,6 +254,12 @@ You can configure the placeholders used by changing the following options:
 * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
 * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowRBS | `false` | Boolean
+
 ## Sorbet/EnforceSingleSigil
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged


### PR DESCRIPTION
### Description

Small PR to add missing default value for `Sorbet/EnforceSignatures` config of `AllowRBS` added here: https://github.com/Shopify/rubocop-sorbet/pull/291

This will help to reduce any warnings when someone has enabled in their own config.

**Note** This didn't impact the running of the cop, it would still work either way.  