### PR TITLE
Add runtime dependency to lint_roller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-sorbet (0.10.0)
+      lint_roller
       rubocop (>= 1)
 
 GEM

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency("lint_roller")
   spec.add_runtime_dependency("rubocop", ">= 1")
 end


### PR DESCRIPTION
It's used to define the rubocop plugin.

https://github.com/Shopify/rubocop-sorbet/pull/301#discussion_r2049707412