### PR TITLE
Handle double-commented Sorbet sigils correctly

### DIFF
--- a/test/rubocop/cop/sorbet/sigils/enforce_single_sigil_test.rb
+++ b/test/rubocop/cop/sorbet/sigils/enforce_single_sigil_test.rb
@@ -61,6 +61,17 @@ module RuboCop
             RUBY
           end
 
+          def test_makes_offense_on_every_extra_sigil_beyond_the_first_one_even_if_the_first_one_is_a_double_commented_sigil
+            assert_offense(<<~RUBY)
+              # # typed: true
+              # typed: false
+              ^^^^^^^^^^^^^^ #{MSG}
+              # # typed: true
+              ^^^^^^^^^^^^^^^ #{MSG}
+              class Foo; end
+            RUBY
+          end
+
           def test_makes_offense_on_every_extra_sigil_beyond_the_first_one_when_there_are_other_comments_in_between
             assert_offense(<<~RUBY)
               # typed: true
@@ -109,6 +120,27 @@ module RuboCop
             RUBY
             assert_correction(<<~RUBY)
               # typed: true
+              # frozen_string_literal: true
+              class Foo; end
+            RUBY
+          end
+
+          def test_autocorrects_duplicate_sigils_by_selecting_the_first_as_the_real_sigil_even_if_it_is_double_commented
+            assert_offense(<<~RUBY)
+              # # typed: true
+              # typed: false
+              ^^^^^^^^^^^^^^ #{MSG}
+              # typed: strict
+              ^^^^^^^^^^^^^^^ #{MSG}
+              # frozen_string_literal: true
+              # typed: strong
+              ^^^^^^^^^^^^^^^ #{MSG}
+              # typed: ignore
+              ^^^^^^^^^^^^^^^ #{MSG}
+              class Foo; end
+            RUBY
+            assert_correction(<<~RUBY)
+              # # typed: true
               # frozen_string_literal: true
               class Foo; end
             RUBY

--- a/test/rubocop/cop/sorbet/sigils/valid_sigil_test.rb
+++ b/test/rubocop/cop/sorbet/sigils/valid_sigil_test.rb
@@ -110,6 +110,42 @@ module RuboCop
             RUBY
           end
 
+          def test_makes_offense_for_double_commented_sigil
+            assert_offense(<<~RUBY)
+              # # typed: true
+              ^^^^^^^^^^^^^^^ #{format(INVALID_SIGIL_MSG, sigil: "# # typed: true")}
+              class Foo; end
+            RUBY
+            assert_correction(<<~RUBY)
+              # typed: true
+              class Foo; end
+            RUBY
+          end
+
+          def test_makes_offense_for_double_commented_sigil_with_strictness
+            assert_offense(<<~RUBY)
+              # # typed: strict
+              ^^^^^^^^^^^^^^^^^ #{format(INVALID_SIGIL_MSG, sigil: "# # typed: strict")}
+              class Foo; end
+            RUBY
+            assert_correction(<<~RUBY)
+              # typed: strict
+              class Foo; end
+            RUBY
+          end
+
+          def test_makes_offense_for_double_commented_sigil_with_extra_spaces
+            assert_offense(<<~RUBY)
+              # #  typed:  true
+              ^^^^^^^^^^^^^^^^^ #{format(INVALID_SIGIL_MSG, sigil: "# #  typed:  true")}
+              class Foo; end
+            RUBY
+            assert_correction(<<~RUBY)
+              # typed: true
+              class Foo; end
+            RUBY
+          end
+
           def test_autocorrects_by_adding_typed_false_to_file_without_sigil_when_required
             @cop = target_cop.new(cop_config({ "RequireSigilOnAllFiles" => true }))
             assert_offense(<<~RUBY)
@@ -176,6 +212,18 @@ module RuboCop
               # frozen_string_literal: true
               # typed: false
               ^^^^^^^^^^^^^^ #{format(MINIMUM_STRICTNESS_MSG, minimum: "true", actual: "false")}
+              class Foo; end
+            RUBY
+          end
+
+          def test_makes_offense_for_double_commented_sigil_with_arbitrary_spaces
+            assert_offense(<<~RUBY)
+              #    # typed: false
+              ^^^^^^^^^^^^^^^^^^^ Invalid Sorbet sigil `#    # typed: false`.
+              class Foo; end
+            RUBY
+            assert_correction(<<~RUBY)
+              # typed: false
               class Foo; end
             RUBY
           end


### PR DESCRIPTION
- Ensure double-commented sigils are properly detected and corrected
- Maintain strictness level when fixing double-commented sigils

This change ensures that files with double-commented sigils (e.g. "# # typed: true") are properly detected and corrected to single-commented sigils while preserving their strictness level.

Closes #156.