### PR TITLE
Fix EmptyLineAfterSig cop to preserve RuboCop directive comments

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,6 +37,7 @@ Sorbet/EmptyLineAfterSig:
   Description: 'Ensures that there are no blank lines after signatures'
   Enabled: true
   VersionAdded: 0.7.0
+  VersionChanged: '<<next>>'
 
 Sorbet/ConstantsFromStrings:
   Description: >-

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -180,7 +180,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.7.0 | -
+Enabled | Yes | Yes  | 0.7.0 | <<next>>
 
 Checks for blank lines after signatures.
 

--- a/test/rubocop/cop/sorbet/signatures/empty_line_after_sig_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/empty_line_after_sig_test.rb
@@ -250,6 +250,42 @@ module RuboCop
               def foo; end
             RUBY
           end
+
+          def test_does_not_move_rubocop_directive_comments
+            assert_no_offenses(<<~RUBY)
+              sig { void }
+              # rubocop:disable Style/Foo
+              def foo; end
+              # rubocop:enable Style/Foo
+            RUBY
+          end
+
+          def test_does_not_move_rubocop_todo_comments
+            assert_no_offenses(<<~RUBY)
+              sig { void }
+              # rubocop:todo Style/Foo
+              def foo; end
+            RUBY
+          end
+
+          def test_does_not_move_rubocop_comments_but_moves_other_comments
+            assert_offense(<<~RUBY)
+              # rubocop:todo Style/Foo
+              sig { void }
+              # rubocop:enable Style/Foo
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              # Comment
+              def foo; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              # rubocop:todo Style/Foo
+              # Comment
+              sig { void }
+              # rubocop:enable Style/Foo
+              def foo; end
+            RUBY
+          end
         end
       end
     end


### PR DESCRIPTION
The cop now correctly handles RuboCop directive comments (like `rubocop:disable`, `rubocop:enable`, and `rubocop:todo`) by:
- Not moving RuboCop directive comments before the sig method
- Preserving RuboCop directive comments in their original position
- Still moving other comments and empty lines before the sig method

This change ensures that RuboCop directive comments maintain their intended scope and functionality while still enforcing the rule that no empty lines or other comments should appear between a sig and its method definition.

Fixes #306.