### PR TITLE
Support `attr` method in `EmptyLineAfterSig` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,6 +37,7 @@ Sorbet/EmptyLineAfterSig:
   Description: 'Ensures that there are no blank lines after signatures'
   Enabled: true
   VersionAdded: 0.7.0
+  VersionChanged: '<<next>>'
 
 Sorbet/ConstantsFromStrings:
   Description: >-

--- a/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
+++ b/lib/rubocop/cop/sorbet/signatures/empty_line_after_sig.rb
@@ -25,7 +25,7 @@ module RuboCop
         def_node_matcher :sig_or_signable_method_definition?, <<~PATTERN
           ${
             any_def
-            (send nil? {:attr_reader :attr_writer :attr_accessor} ...)
+            (send nil? {:attr :attr_reader :attr_writer :attr_accessor} ...)
             #signature?
           }
         PATTERN

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -180,7 +180,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.7.0 | -
+Enabled | Yes | Yes  | 0.7.0 | <<next>>
 
 Checks for blank lines after signatures.
 

--- a/test/rubocop/cop/sorbet/signatures/empty_line_after_sig_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/empty_line_after_sig_test.rb
@@ -87,6 +87,34 @@ module RuboCop
             RUBY
           end
 
+          def test_registers_offense_for_attr
+            assert_offense(<<~RUBY)
+              sig { void }
+
+              ^{} #{MSG}
+              attr :bar
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { void }
+              attr :bar
+            RUBY
+          end
+
+          def test_registers_offense_for_attr_with_boolean
+            assert_offense(<<~RUBY)
+              sig { void }
+
+              ^{} #{MSG}
+              attr :bar, true
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { void }
+              attr :bar, true
+            RUBY
+          end
+
           def test_registers_offense_for_multiline_sigs_with_indentation
             assert_offense(<<~RUBY)
               module Example


### PR DESCRIPTION
The `EmptyLineAfterSig` cop now properly handles `attr` declarations with signatures, similar to how it handles `attr_reader`, `attr_writer`, and `attr_accessor`.

Fixes #159