### PR TITLE
Add `Sorbet/BlockMethodDefinition`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,8 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
 
-require:
-  - rubocop/cop/internal_affairs
+plugins:
+  - rubocop-internal_affairs
 
 AllCops:
   Exclude:

--- a/config/default.yml
+++ b/config/default.yml
@@ -22,6 +22,16 @@ Sorbet/BindingConstantWithoutTypeAlias:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/BlockMethodDefinition:
+  Description: >-
+                  Disallows defining methods inside blocks without using `define_method`,
+                  unless the block is a named class definition. This is to avoid running
+                  into https://github.com/sorbet/sorbet/issues/3609.
+  Enabled: pending
+  Safe: true
+  SafeAutoCorrect: false
+  VersionAdded: '<<next>>'
+
 Sorbet/CallbackConditionalsBinding:
   Description: 'Ensures callback conditionals are bound to the right type.'
   Enabled: false

--- a/lib/rubocop/cop/sorbet/block_method_definition.rb
+++ b/lib/rubocop/cop/sorbet/block_method_definition.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Disallow defining methods in blocks, to prevent running into issues
+      # caused by https://github.com/sorbet/sorbet/issues/3609.
+      #
+      # As a workaround, use `define_method` instead.
+      #
+      # The one exception is for `Class.new` blocks, as long as the result is
+      # assigned to a constant (i.e. as long as it is not an anonymous class).
+
+      # @example
+      #   # bad
+      #   yielding_method do
+      #     def bad(args)
+      #       # ...
+      #     end
+      #   end
+      #
+      #   # bad
+      #   Class.new do
+      #     def bad(args)
+      #       # ...
+      #     end
+      #   end
+      #
+      #   # good
+      #   yielding_method do
+      #     define_method(:good) do |args|
+      #       # ...
+      #     end
+      #   end
+      #
+      #   # good
+      #   MyClass = Class.new do
+      #     def good(args)
+      #       # ...
+      #     end
+      #   end
+      #
+      class BlockMethodDefinition < Base
+        include RuboCop::Cop::Alignment
+        extend AutoCorrector
+
+        MSG = "Do not define methods in blocks (use `define_method` as a workaround)."
+
+        def on_block(node)
+          if (parent = node.parent)
+            return if parent.casgn_type?
+          end
+
+          node.each_descendant(:any_def) do |def_node|
+            add_offense(def_node) do |corrector|
+              autocorrect_method_in_block(corrector, def_node)
+            end
+          end
+        end
+        alias_method :on_numblock, :on_block
+
+        private
+
+        def autocorrect_method_in_block(corrector, node)
+          indent = offset(node)
+
+          method_name = node.method_name
+          args = node.arguments.map(&:source).join(", ")
+          body = node.body&.source&.prepend("\n#{indent}  ")
+
+          if node.def_type?
+            replacement = "define_method(:#{method_name}) do |#{args}|#{body}\n#{indent}end"
+          elsif node.defs_type?
+            receiver = node.receiver.source
+            replacement = "#{receiver}.define_singleton_method(:#{method_name}) do |#{args}|#{body}\n#{indent}end"
+          end
+
+          corrector.replace(node, replacement)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -5,6 +5,7 @@ require_relative "sorbet/mixin/t_enum"
 require_relative "sorbet/mixin/signature_help"
 
 require_relative "sorbet/binding_constant_without_type_alias"
+require_relative "sorbet/block_method_definition"
 require_relative "sorbet/constants_from_strings"
 require_relative "sorbet/forbid_superclass_const_literal"
 require_relative "sorbet/forbid_include_const_literal"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -7,6 +7,7 @@ In the following section you find all available cops:
 
 * [Sorbet/AllowIncompatibleOverride](cops_sorbet.md#sorbetallowincompatibleoverride)
 * [Sorbet/BindingConstantWithoutTypeAlias](cops_sorbet.md#sorbetbindingconstantwithouttypealias)
+* [Sorbet/BlockMethodDefinition](cops_sorbet.md#sorbetblockmethoddefinition)
 * [Sorbet/BuggyObsoleteStrictMemoization](cops_sorbet.md#sorbetbuggyobsoletestrictmemoization)
 * [Sorbet/CallbackConditionalsBinding](cops_sorbet.md#sorbetcallbackconditionalsbinding)
 * [Sorbet/CheckedTrueInSignature](cops_sorbet.md#sorbetcheckedtrueinsignature)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -41,6 +41,46 @@ FooOrBar = T.any(Foo, Bar)
 FooOrBar = T.type_alias { T.any(Foo, Bar) }
 ```
 
+## Sorbet/BlockMethodDefinition
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes (Unsafe) | <<next>> | -
+
+
+
+### Examples
+
+```ruby
+# bad
+yielding_method do
+  def bad(args)
+    # ...
+  end
+end
+
+# bad
+Class.new do
+  def bad(args)
+    # ...
+  end
+end
+
+# good
+yielding_method do
+  define_method(:good) do |args|
+    # ...
+  end
+end
+
+# good
+MyClass = Class.new do
+  def good(args)
+    # ...
+  end
+end
+```
+
 ## Sorbet/BuggyObsoleteStrictMemoization
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/sorbet/block_method_definition_test.rb
+++ b/test/rubocop/cop/sorbet/block_method_definition_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      class BlockMethodDefinitionTest < ::Minitest::Test
+        def setup
+          @cop = BlockMethodDefinition.new
+        end
+
+        def test_registers_an_offense_when_defining_a_method_in_a_block
+          assert_offense(<<~RUBY)
+            yielding_method do
+              def bad_method(arg0, arg1 = 1, *args, foo:, bar: nil, **kwargs, &block)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet/BlockMethodDefinition: Do not define methods in blocks (use `define_method` as a workaround).
+                if arg0
+                  arg0 + arg1
+                end
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            yielding_method do
+              define_method(:bad_method) do |arg0, arg1 = 1, *args, foo:, bar: nil, **kwargs, &block|
+                if arg0
+                  arg0 + arg1
+                end
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_an_offense_when_defining_a_method_in_a_block_with_numbered_arguments
+          assert_offense(<<~RUBY)
+            yielding_method do
+              puts _1
+
+              def bad_method(args)
+              ^^^^^^^^^^^^^^^^^^^^ Sorbet/BlockMethodDefinition: Do not define methods in blocks (use `define_method` as a workaround).
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_an_offense_when_defining_a_class_method_in_a_block
+          assert_offense(<<~RUBY)
+            yielding_method do
+              def self.bad_method(args)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet/BlockMethodDefinition: Do not define methods in blocks (use `define_method` as a workaround).
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            yielding_method do
+              self.define_singleton_method(:bad_method) do |args|
+              end
+            end
+          RUBY
+        end
+
+        def test_does_not_register_an_offense_when_using_define_method_as_a_workaround
+          assert_no_offenses(<<~RUBY)
+            yielding_method do
+              define_method(:good_method) do |args|
+              end
+            end
+          RUBY
+        end
+
+        def test_does_not_register_an_offense_when_defining_a_top_level_method
+          assert_no_offenses(<<~RUBY)
+            def good_method
+            end
+          RUBY
+        end
+
+        def test_does_not_register_an_offense_when_defining_a_method_in_a_class
+          assert_no_offenses(<<~RUBY)
+            class MyClass
+              def good_method
+              end
+            end
+          RUBY
+        end
+
+        def test_does_not_register_an_offense_when_defining_a_method_in_a_named_class_defined_by_class_new
+          assert_no_offenses(<<~RUBY)
+            MyClass = Class.new do
+              def good_method
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_an_offense_when_defining_a_method_in_an_anonymous_class
+          assert_offense(<<~RUBY)
+            Class.new do
+              def bad_method(args)
+              ^^^^^^^^^^^^^^^^^^^^ Sorbet/BlockMethodDefinition: Do not define methods in blocks (use `define_method` as a workaround).
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Second attempt at #298, taking into account a couple of key aspects:
- methods defined in `Class.new` blocks don't cause any `Object` typing pollution _as long as `Class.new` is assigned to a constant_.
- methods defined in _all blocks_, not just `Class.new` blocks, cause `Object` typing pollution.