### PR TITLE
Fix new cop generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ task :new_cop, [:cop] do |_task, args|
   # We don't use Rubocop's changelog automation workflow
   todo_without_changelog_instruction = generator.todo
     .sub(/$\s+4\. Run.*changelog.*for your new cop\.$/m, "")
+    .sub(/^  3./, "  3. Run `bundle exec rake generate_cops_documentation` to generate\n     documentation for your new cop.\n  4.")
   puts todo_without_changelog_instruction
 end
 


### PR DESCRIPTION
This updates the rake task that creates new cops in two ways:

1. ~~It generates a Minitest file instead of an RSpec test file.~~ (Fixed by #314)
1. Instead of saying we have 4 steps and showing only 3, it now shows a fourth step: I added in generating the new documentation as a step.

To test it out, run:
`bundle exec rake "new_cop[Sorbet/MyNewCopName]"`