### PR TITLE
Bump rubocop requirement to include `any_def_type?`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rubocop-sorbet (0.10.1)
       lint_roller
-      rubocop (>= 1)
+      rubocop (>= 1.75.2)
 
 GEM
   remote: https://rubygems.org/

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("lint_roller")
-  spec.add_runtime_dependency("rubocop", ">= 1")
+  spec.add_runtime_dependency("rubocop", ">= 1.75.2")
 end


### PR DESCRIPTION
Resolves `undefined method 'any_def_type?' for an instance of RuboCop::AST::DefNode` errors when using an older rubocop version.

Introduced in [v1.75.2](https://github.com/rubocop/rubocop/commit/ae1f33c406cce91e979c9e46ceb2a03dafce97ed)