### PR TITLE
Add cop to ensure type parameters are always capitalized

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -47,6 +47,12 @@ Sorbet/CallbackConditionalsBinding:
   Safe: false
   VersionAdded: 0.7.0
 
+Sorbet/CapitalizedTypeParameters:
+  Description: 'Ensures that type parameters are capitalized.'
+  Enabled: true
+  SafeAutoCorrect: false
+  VersionAdded: <<next>>
+
 Sorbet/CheckedTrueInSignature:
   Description: 'Disallows the usage of `checked(true)` in signatures.'
   Enabled: true

--- a/lib/rubocop/cop/sorbet/signatures/capitalized_type_parameters.rb
+++ b/lib/rubocop/cop/sorbet/signatures/capitalized_type_parameters.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Ensure type parameters used in generic methods are always capitalized.
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { type_parameters(:x).params(a: T.type_parameter(:x)).void }
+      #   def foo(a); end
+      #
+      #   # good
+      #   sig { type_parameters(:X).params(a: T.type_parameter(:X)).void }
+      #   def foo(a: 1); end
+      class CapitalizedTypeParameters < ::RuboCop::Cop::Base
+        extend AutoCorrector
+        include SignatureHelp
+
+        MSG = "Type parameters must be capitalized."
+
+        RESTRICT_ON_SEND = [:type_parameter].freeze
+
+        # @!method type_parameters?(node)
+        def_node_matcher(:type_parameters?, <<-PATTERN)
+          (send nil? :type_parameters ...)
+        PATTERN
+
+        # @!method t_type_parameter?(node)
+        def_node_matcher(:t_type_parameter?, <<-PATTERN)
+          (send (const {nil? | cbase} :T) :type_parameter ...)
+        PATTERN
+
+        def on_signature(node)
+          send = node.children[2]
+
+          while send&.send_type?
+            if type_parameters?(send)
+              check_type_parameters_case(send)
+            end
+
+            send = send.children[0]
+          end
+        end
+
+        def on_send(node)
+          check_type_parameters_case(node) if t_type_parameter?(node)
+        end
+
+        def on_csend(node)
+          check_type_parameters_case(node) if t_type_parameter?(node)
+        end
+
+        private
+
+        def check_type_parameters_case(node)
+          node.children[2..].each do |arg|
+            next unless arg.is_a?(RuboCop::AST::SymbolNode)
+            next if arg.value =~ /^[A-Z]/
+
+            add_offense(arg) do |corrector|
+              corrector.replace(arg, arg.value.capitalize.to_sym.inspect)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -33,6 +33,7 @@ require_relative "sorbet/rbi_versioning/gem_version_annotation_helper"
 require_relative "sorbet/rbi_versioning/valid_gem_version_annotations"
 
 require_relative "sorbet/signatures/allow_incompatible_override"
+require_relative "sorbet/signatures/capitalized_type_parameters"
 require_relative "sorbet/signatures/checked_true_in_signature"
 require_relative "sorbet/signatures/empty_line_after_sig"
 require_relative "sorbet/signatures/enforce_signatures"

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -10,6 +10,7 @@ In the following section you find all available cops:
 * [Sorbet/BlockMethodDefinition](cops_sorbet.md#sorbetblockmethoddefinition)
 * [Sorbet/BuggyObsoleteStrictMemoization](cops_sorbet.md#sorbetbuggyobsoletestrictmemoization)
 * [Sorbet/CallbackConditionalsBinding](cops_sorbet.md#sorbetcallbackconditionalsbinding)
+* [Sorbet/CapitalizedTypeParameters](cops_sorbet.md#sorbetcapitalizedtypeparameters)
 * [Sorbet/CheckedTrueInSignature](cops_sorbet.md#sorbetcheckedtrueinsignature)
 * [Sorbet/ConstantsFromStrings](cops_sorbet.md#sorbetconstantsfromstrings)
 * [Sorbet/EmptyLineAfterSig](cops_sorbet.md#sorbetemptylineaftersig)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -157,6 +157,26 @@ class Post < ApplicationRecord
 end
 ```
 
+## Sorbet/CapitalizedTypeParameters
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes (Unsafe) | <<next>> | -
+
+Ensure type parameters used in generic methods are always capitalized.
+
+### Examples
+
+```ruby
+# bad
+sig { type_parameters(:x).params(a: T.type_parameter(:x)).void }
+def foo(a); end
+
+# good
+sig { type_parameters(:X).params(a: T.type_parameter(:X)).void }
+def foo(a: 1); end
+```
+
 ## Sorbet/CheckedTrueInSignature
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/sorbet/signatures/capitalized_type_parameters_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/capitalized_type_parameters_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      module Signatures
+        class CapitalizedTypeParametersTest < ::Minitest::Test
+          MSG = "Sorbet/CapitalizedTypeParameters: Type parameters must be capitalized."
+
+          def setup
+            @cop = CapitalizedTypeParameters.new
+          end
+
+          def test_adds_offense_when_type_parameters_are_not_capitalized
+            assert_offense(<<~RUBY)
+              sig { type_parameters(:x).params(a: T.type_parameter(:x)).void }
+                                    ^^ #{MSG}
+                                                                   ^^ #{MSG}
+              def foo(a); end
+
+              sig do
+                type_parameters(:foo, :Bar, :baz)
+                                ^^^^ #{MSG}
+                                            ^^^^ #{MSG}
+                  .params(
+                    a: T.type_parameter(:foo),
+                                        ^^^^ #{MSG}
+                    b: T.type_parameter(:Bar),
+                    c: T.type_parameter(:baz),
+                                        ^^^^ #{MSG}
+                  ).void
+              end
+              def foo(a, b, c); end
+            RUBY
+          end
+
+          def test_does_not_add_offense_when_type_parameters_are_capitalized
+            assert_no_offenses(<<~RUBY)
+              sig { type_parameters(:X).params(a: T.type_parameter(:X)).void }
+              def foo(a); end
+
+              sig do
+                type_parameters(:Foo, :Bar, :Baz)
+                  .params(
+                    a: T.type_parameter(:Foo),
+                    b: T.type_parameter(:Bar),
+                    c: T.type_parameter(:Baz),
+                  ).void
+              end
+              def foo(a, b, c); end
+            RUBY
+          end
+
+          def test_autocorrects_type_parameters_to_capitalized
+            assert_offense(<<~RUBY)
+              sig { type_parameters(:x).params(a: T.type_parameter(:x)).void }
+                                    ^^ #{MSG}
+                                                                   ^^ #{MSG}
+              def foo(a); end
+
+              sig do
+                type_parameters(:foo, :Bar, :baz)
+                                ^^^^ #{MSG}
+                                            ^^^^ #{MSG}
+                  .params(
+                    a: T.type_parameter(:foo),
+                                        ^^^^ #{MSG}
+                    b: T.type_parameter(:Bar),
+                    c: T.type_parameter(:baz),
+                                        ^^^^ #{MSG}
+                  ).void
+              end
+              def foo(a, b, c); end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { type_parameters(:X).params(a: T.type_parameter(:X)).void }
+              def foo(a); end
+
+              sig do
+                type_parameters(:Foo, :Bar, :Baz)
+                  .params(
+                    a: T.type_parameter(:Foo),
+                    b: T.type_parameter(:Bar),
+                    c: T.type_parameter(:Baz),
+                  ).void
+              end
+              def foo(a, b, c); end
+            RUBY
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensure type parameters used in generic methods are always capitalized.

Example:
```rb
# bad
sig { type_parameters(:x).params(a: T.type_parameter(:x)).void }
def foo(a); end

# good
sig { type_parameters(:X).params(a: T.type_parameter(:X)).void }
def foo(a: 1); end
```