### PR TITLE
Handle methods with no arguments in `BlockMethodDefinition` autocorrector

### DIFF
--- a/lib/rubocop/cop/sorbet/block_method_definition.rb
+++ b/lib/rubocop/cop/sorbet/block_method_definition.rb
@@ -66,13 +66,14 @@ module RuboCop
 
           method_name = node.method_name
           args = node.arguments.map(&:source).join(", ")
+          args = " |#{args}|" unless args.empty?
           body = node.body&.source&.prepend("\n#{indent}  ")
 
           if node.def_type?
-            replacement = "define_method(:#{method_name}) do |#{args}|#{body}\n#{indent}end"
+            replacement = "define_method(:#{method_name}) do#{args}#{body}\n#{indent}end"
           elsif node.defs_type?
             receiver = node.receiver.source
-            replacement = "#{receiver}.define_singleton_method(:#{method_name}) do |#{args}|#{body}\n#{indent}end"
+            replacement = "#{receiver}.define_singleton_method(:#{method_name}) do#{args}#{body}\n#{indent}end"
           end
 
           corrector.replace(node, replacement)

--- a/test/rubocop/cop/sorbet/block_method_definition_test.rb
+++ b/test/rubocop/cop/sorbet/block_method_definition_test.rb
@@ -105,6 +105,29 @@ module RuboCop
             end
           RUBY
         end
+
+        def test_autocorrects_a_method_with_no_arguments
+          assert_offense(<<~RUBY)
+            yielding_method do
+              def bad_method
+              ^^^^^^^^^^^^^^ Sorbet/BlockMethodDefinition: Do not define methods in blocks (use `define_method` as a workaround).
+                if arg0
+                  arg0 + arg1
+                end
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            yielding_method do
+              define_method(:bad_method) do
+                if arg0
+                  arg0 + arg1
+                end
+              end
+            end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
I missed this edge case when adding the cop in #319 🙇🏼 