### PR TITLE
Add `Sorbet/RBSAnnotatedModuleNew` cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rubocop-sorbet (0.10.5)
       lint_roller
-      rubocop (>= 1.75.2)
+      rubocop (>= 1.75.3)
 
 GEM
   remote: https://rubygems.org/

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,25 @@ Sorbet/AllowIncompatibleOverride:
   Enabled: true
   VersionAdded: 0.2.0
 
+Sorbet/RBSAnnotatedModuleNew:
+  Description: >-
+                Checks for uses of Sorbet RBS annotations (e.g., `@abstract`, `@interface`, `@sealed`)
+                with dynamic module/class creation using `Module.new` or `Class.new`.
+                These annotations don't work with dynamic instantiation because the RBS
+                rewriter runs before the instantiation rewriter.
+  Enabled: true
+  VersionAdded: '<<next>>'
+  Safe: true
+  SafeAutoCorrect: true
+  References:
+    - https://github.com/sorbet/sorbet/issues/9153
+  Annotations:
+    - abstract
+    - interface
+    - sealed
+    - final
+    - requires_ancestor
+
 Sorbet/BindingConstantWithoutTypeAlias:
   Description: >-
                   Disallows binding the return value of `T.any`, `T.all`, `T.enum`

--- a/lib/rubocop/cop/sorbet/rbs_annotated_module_new.rb
+++ b/lib/rubocop/cop/sorbet/rbs_annotated_module_new.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Checks for uses of Sorbet RBS annotations (e.g., `@abstract`, `@interface`, `@sealed`)
+      # with dynamic module/class creation using `Module.new` or `Class.new`.
+      # These annotations don't work with dynamic instantiation because the RBS rewriter runs
+      # before the instantiation rewriter. Instead, regular module/class syntax should be used.
+      #
+      # @example
+      #   # bad
+      #   # @abstract
+      #   Foo = Class.new
+      #
+      #   # bad
+      #   # @interface
+      #   Bar = Module.new(Supermodule)
+      #
+      #   # bad
+      #   # @sealed
+      #   Baz = Class.new do
+      #     def method
+      #     end
+      #   end
+      #
+      #   # good
+      #   # @abstract
+      #   class Foo
+      #   end
+      #
+      #   # good
+      #   # @interface
+      #   module Bar
+      #     include Supermodule
+      #   end
+      #
+      #   # good
+      #   # @sealed
+      #   class Baz
+      #     def method
+      #     end
+      #   end
+      class RBSAnnotatedModuleNew < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = "Sorbet RBS annotations (%<annotation>s) do not work with dynamic `%<module_type>s.new` instantiation. Use regular %<module_type>s syntax instead."
+
+        # @!method module_instantiation_assignment?(node)
+        def_node_matcher :module_instantiation_assignment?, <<~PATTERN
+          (casgn _ $_ {
+            $#module_instantiation? |
+            $(block #module_instantiation? ...)
+          })
+        PATTERN
+
+        # @!method module_instantiation?(node)
+        def_node_matcher :module_instantiation?, <<~PATTERN
+          (send (const {nil? | cbase} {:Class | :Module}) :new ...)
+        PATTERN
+
+        def initialize(config = nil, options = nil)
+          super
+          annotations = cop_config.fetch("Annotations", [])
+          return if annotations.empty?
+
+          # Pre-compile a single regex to match any of the configured annotations
+          annotation_pattern = annotations.map { |a| Regexp.escape(a) }.join("|")
+          @annotation_regex = /^\s*#\s*@(#{annotation_pattern})(\s|:|$)/
+        end
+
+        def on_casgn(node)
+          return unless @annotation_regex
+
+          module_instantiation_assignment?(node) do |const_name, instantiation_node|
+            # instantiation_node is either a send node or a block node
+            send_node = instantiation_node.block_type? ? instantiation_node.send_node : instantiation_node
+            module_type = send_node.receiver.const_name.downcase
+
+            # Find the immediately preceding comment that matches our annotation pattern
+            annotation_comment = processed_source.ast_with_comments[node]&.find do |comment|
+              comment.location.line == node.location.line - 1 &&
+                comment.text.match(@annotation_regex)
+            end
+
+            return unless annotation_comment
+
+            # Extract which annotation was matched for the message (already captured in last match)
+            annotation = Regexp.last_match(1)
+
+            # Get the full constant path
+            full_const_name = constant_full_name(node)
+
+            message = format(MSG, annotation: "@#{annotation}", module_type: module_type)
+            add_offense(node, message: message) do |corrector|
+              autocorrect(corrector, node, full_const_name, instantiation_node, module_type, annotation_comment)
+            end
+          end
+        end
+
+        private
+
+        def constant_full_name(node)
+          # For a casgn node, build the full constant path
+          # node is (casgn namespace const_name value)
+          namespace, const_name, = *node
+          
+          if namespace
+            "#{namespace.const_name}::#{const_name}"
+          else
+            const_name.to_s
+          end
+        end
+
+        def autocorrect(corrector, node, const_name, instantiation_node, module_type, annotation_comment) # rubocop:disable Metrics/ParameterLists
+          send_node = instantiation_node.block_type? ? instantiation_node.send_node : instantiation_node
+          superclass = send_node.first_argument if module_type == "class"
+
+          indent = " " * node.location.column
+
+          # Build the new definition
+          parts = [annotation_comment.text]
+
+          parts << if superclass
+            "#{indent}class #{const_name} < #{superclass.source}"
+          else
+            "#{indent}#{module_type} #{const_name}"
+          end
+
+          if instantiation_node.block_type? && instantiation_node.body
+            parts << indented_body(instantiation_node.body, indent)
+          end
+
+          parts << "#{indent}end"
+
+          corrector.replace(
+            range_between(annotation_comment.source_range.begin_pos, node.source_range.end_pos),
+            parts.compact.join("\n"),
+          )
+        end
+
+        def indented_body(body_node, base_indent)
+          # Get the body source directly from the processed source lines
+          body_range = body_node.source_range
+          body_lines = processed_source.lines[body_range.line - 1...body_range.last_line]
+
+          # Find minimum indentation of non-empty lines
+          min_indent = body_lines.reject { |line| line.strip.empty? }
+            .map { |line| line[/^(\s*)/, 1].length }
+            .min || 0
+
+          # Re-indent with proper nesting
+          body_lines.map do |line|
+            content = line.chomp
+            if content.strip.empty?
+              ""
+            else
+              # Remove original indent, add new indent
+              "#{base_indent}  #{content[min_indent..]}"
+            end
+          end.join("\n").rstrip
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -30,6 +30,7 @@ require_relative "sorbet/select_by_is_a"
 require_relative "sorbet/type_alias_name"
 require_relative "sorbet/obsolete_strict_memoization"
 require_relative "sorbet/buggy_obsolete_strict_memoization"
+require_relative "sorbet/rbs_annotated_module_new"
 
 require_relative "sorbet/rbi/forbid_extend_t_sig_helpers_in_shims"
 require_relative "sorbet/rbi/forbid_rbi_outside_of_allowed_paths"

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("lint_roller")
-  spec.add_runtime_dependency("rubocop", ">= 1.75.2")
+  spec.add_runtime_dependency("rubocop", ">= 1.75.3")
 end

--- a/test/rubocop/cop/sorbet/rbs_annotated_module_new_test.rb
+++ b/test/rubocop/cop/sorbet/rbs_annotated_module_new_test.rb
@@ -1,0 +1,506 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      class RBSAnnotatedModuleNewTest < ::Minitest::Test
+        def setup
+          config = RuboCop::Config.new(
+            "Sorbet/RBSAnnotatedModuleNew" => {
+              "Annotations" => ["abstract", "interface", "sealed", "final", "requires_ancestor"],
+            },
+          )
+          @cop = RBSAnnotatedModuleNew.new(config, {})
+        end
+
+        def test_registers_offense_for_abstract_with_simple_class_new
+          assert_offense(<<~RUBY)
+            # @abstract
+            Foo = Class.new
+            ^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Foo
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_interface_with_module_new
+          assert_offense(<<~RUBY)
+            # @interface
+            Bar = Module.new
+            ^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@interface) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @interface
+            module Bar
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_sealed_with_class_new
+          assert_offense(<<~RUBY)
+            # @sealed
+            Baz = Class.new
+            ^^^^^^^^^^^^^^^ Sorbet RBS annotations (@sealed) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @sealed
+            class Baz
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_requires_ancestor_with_class_new
+          assert_offense(<<~RUBY)
+            # @requires_ancestor: SomeModule
+            Qux = Class.new
+            ^^^^^^^^^^^^^^^ Sorbet RBS annotations (@requires_ancestor) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @requires_ancestor: SomeModule
+            class Qux
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_final_with_class_new
+          assert_offense(<<~RUBY)
+            # @final
+            FinalClass = Class.new
+            ^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@final) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @final
+            class FinalClass
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_final_with_module_new
+          assert_offense(<<~RUBY)
+            # @final
+            FinalModule = Module.new
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@final) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @final
+            module FinalModule
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_abstract_with_class_new_with_superclass
+          assert_offense(<<~RUBY)
+            # @abstract
+            Bar = Class.new(Superclass)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Bar < Superclass
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_abstract_with_class_new_with_block
+          assert_offense(<<~RUBY)
+            # @abstract
+            Baz = Class.new do
+            ^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+              def method
+                "hello"
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Baz
+              def method
+                "hello"
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_interface_with_module_new_with_block
+          assert_offense(<<~RUBY)
+            # @interface
+            MyModule = Module.new do
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@interface) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+              def method
+                "hello"
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @interface
+            module MyModule
+              def method
+                "hello"
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_abstract_with_class_new_with_superclass_and_block
+          assert_offense(<<~RUBY)
+            # @abstract
+            Qux = Class.new(BaseClass) do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+              def method
+                super + " world"
+              end
+
+              def another_method
+                42
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Qux < BaseClass
+              def method
+                super + " world"
+              end
+
+              def another_method
+                42
+              end
+            end
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_class_new_without_annotation
+          assert_no_offenses(<<~RUBY)
+            # Some other comment
+            Foo = Class.new
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_module_new_without_annotation
+          assert_no_offenses(<<~RUBY)
+            # Some other comment
+            Foo = Module.new
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_regular_class_with_annotation
+          assert_no_offenses(<<~RUBY)
+            # @abstract
+            class Foo
+            end
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_regular_module_with_annotation
+          assert_no_offenses(<<~RUBY)
+            # @interface
+            module Bar
+            end
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_class_new_with_non_sorbet_comment
+          assert_no_offenses(<<~RUBY)
+            # @deprecated
+            Bar = Class.new(Superclass)
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_annotation_comment_not_directly_above
+          assert_no_offenses(<<~RUBY)
+            # @abstract
+
+            Foo = Class.new
+          RUBY
+        end
+
+        def test_handles_namespaced_constants_with_class
+          assert_offense(<<~RUBY)
+            module MyModule
+              # @abstract
+              MyClass = Class.new
+              ^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            module MyModule
+              # @abstract
+              class MyClass
+              end
+            end
+          RUBY
+        end
+
+        def test_handles_namespaced_constants_with_module
+          assert_offense(<<~RUBY)
+            module OuterModule
+              # @interface
+              InnerModule = Module.new
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@interface) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            module OuterModule
+              # @interface
+              module InnerModule
+              end
+            end
+          RUBY
+        end
+
+        def test_handles_fully_qualified_class_constant
+          assert_offense(<<~RUBY)
+            # @abstract
+            Foo = ::Class.new
+            ^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Foo
+            end
+          RUBY
+        end
+
+        def test_handles_fully_qualified_module_constant
+          assert_offense(<<~RUBY)
+            # @interface
+            Bar = ::Module.new
+            ^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@interface) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @interface
+            module Bar
+            end
+          RUBY
+        end
+
+        def test_handles_explicit_namespace_constant_assignment
+          assert_offense(<<~RUBY)
+            # @abstract
+            Foo::Bar = Class.new
+            ^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class Foo::Bar
+            end
+          RUBY
+        end
+
+        def test_handles_explicit_namespace_module_assignment
+          assert_offense(<<~RUBY)
+            # @sealed
+            Some::Deep::Module = Module.new
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@sealed) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @sealed
+            module Some::Deep::Module
+            end
+          RUBY
+        end
+
+        def test_preserves_block_body_with_multiple_methods
+          assert_offense(<<~RUBY)
+            # @abstract
+            MyClass = Class.new do
+            ^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+              attr_reader :value
+
+              def initialize(value)
+                @value = value
+              end
+
+              sig { returns(String) }
+              def to_s
+                value.to_s
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @abstract
+            class MyClass
+              attr_reader :value
+
+              def initialize(value)
+                @value = value
+              end
+
+              sig { returns(String) }
+              def to_s
+                value.to_s
+              end
+            end
+          RUBY
+        end
+
+        def test_handles_multiple_annotations
+          assert_offense(<<~RUBY)
+            # @abstract
+            # @sealed
+            Foo = Class.new
+            ^^^^^^^^^^^^^^^ Sorbet RBS annotations (@sealed) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+        end
+
+        def test_custom_annotations_configuration
+          config = RuboCop::Config.new(
+            "Sorbet/RBSAnnotatedModuleNew" => {
+              "Annotations" => ["custom_annotation"],
+            },
+          )
+          @cop = RBSAnnotatedModuleNew.new(config, {})
+
+          # Should detect custom annotation
+          assert_offense(<<~RUBY)
+            # @custom_annotation
+            Foo = Class.new
+            ^^^^^^^^^^^^^^^ Sorbet RBS annotations (@custom_annotation) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+          RUBY
+        end
+
+        def test_ignores_annotations_not_in_configuration
+          config = RuboCop::Config.new(
+            "Sorbet/RBSAnnotatedModuleNew" => {
+              "Annotations" => ["abstract"],
+            },
+          )
+          @cop = RBSAnnotatedModuleNew.new(config, {})
+
+          # Should not detect @interface since it's not in the configured list
+          assert_no_offenses(<<~RUBY)
+            # @interface
+            Foo = Class.new
+          RUBY
+        end
+
+        def test_ignores_non_annotation_comments_starting_with_at
+          assert_no_offenses(<<~RUBY)
+            # @param name [String] the name
+            Foo = Class.new
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            # @return [String]
+            Bar = Module.new
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            # @note This is a note
+            Baz = Class.new
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_non_constant_assignment
+          # Local variable assignment
+          assert_no_offenses(<<~RUBY)
+            # @abstract
+            foo = Class.new
+          RUBY
+
+          # Instance variable assignment
+          assert_no_offenses(<<~RUBY)
+            # @interface
+            @bar = Module.new
+          RUBY
+
+          # Class variable assignment
+          assert_no_offenses(<<~RUBY)
+            # @sealed
+            @@baz = Class.new
+          RUBY
+        end
+
+        def test_does_not_register_offense_for_method_call_assignment
+          assert_no_offenses(<<~RUBY)
+            # @abstract
+            self.foo = Class.new
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            # @interface
+            foo[0] = Module.new
+          RUBY
+        end
+
+        def test_handles_module_new_with_argument
+          # Module.new doesn't support superclass like Class.new does,
+          # but it can be passed a block
+          assert_offense(<<~RUBY)
+            # @interface
+            MyInterface = Module.new do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@interface) do not work with dynamic `module.new` instantiation. Use regular module syntax instead.
+              def method
+                :result
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # @interface
+            module MyInterface
+              def method
+                :result
+              end
+            end
+          RUBY
+        end
+
+        def test_handles_deeply_nested_blocks
+          assert_offense(<<~RUBY)
+            module OuterModule
+              module InnerModule
+                # @abstract
+                DeeplyNested = Class.new do
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sorbet RBS annotations (@abstract) do not work with dynamic `class.new` instantiation. Use regular class syntax instead.
+                  attr_reader :value
+
+                  def initialize(value)
+                    @value = value
+                  end
+                end
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            module OuterModule
+              module InnerModule
+                # @abstract
+                class DeeplyNested
+                  attr_reader :value
+
+                  def initialize(value)
+                    @value = value
+                  end
+                end
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop checks for uses of Sorbet RBS annotations (e.g., `@abstract`, `@interface`, `@sealed`, `@final`, `@requires_ancestor`) with dynamic module/class creation using `Module.new` or `Class.new`.

These annotations don't work with dynamic instantiation because the RBS rewriter runs before the instantiation rewriter in Sorbet's processing pipeline. The cop detects this pattern and provides autocorrection to convert the dynamic instantiation to regular class/module syntax.

The cop supports:
- Detection of RBS annotations in comments directly above assignments
- Autocorrection that preserves superclass relationships and block bodies
- Configurable list of annotations to check for
- Safe autocorrection that maintains code functionality

The minimum RuboCop version is bumped to 1.75.3 to support the References configuration field, which allows us to link to the upstream Sorbet issue that documents this limitation.

Fixes https://github.com/Shopify/rubocop-sorbet/issues/352
References https://github.com/sorbet/sorbet/issues/9153