### PR TITLE
Check that `on_failure` is used with `checked(:{tests,always})`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -324,6 +324,14 @@ Sorbet/Refinement:
   Enabled: pending
   VersionAdded: 0.8.6
 
+Sorbet/RuntimeOnFailureDependsOnChecked:
+  Description: >-
+                  Ensures that `on_failure` is called after `checked` in signatures.
+                  The `on_failure` method has no effect unless `checked(:tests)` or
+                  `checked(:always)` is also called.
+  Enabled: true
+  VersionAdded: '<<next>>'
+
 Sorbet/SelectByIsA:
   Description: >-
     Suggests using `grep` over `select` when using it only for type narrowing.

--- a/lib/rubocop/cop/sorbet/signatures/runtime_on_failure_depends_on_checked.rb
+++ b/lib/rubocop/cop/sorbet/signatures/runtime_on_failure_depends_on_checked.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Checks that `on_failure` is not used without `checked(:tests)` or `checked(:always)`.
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { params(x: Integer).returns(Integer).on_failure(:raise) }
+      #   def plus_one(x)
+      #     x + 1
+      #   end
+      #
+      #   # good
+      #   sig { params(x: Integer).returns(Integer).checked(:always).on_failure(:raise) }
+      #   def plus_one(x)
+      #     x + 1
+      #   end
+      #
+      class RuntimeOnFailureDependsOnChecked < ::RuboCop::Cop::Base
+        include SignatureHelp
+
+        MSG = "To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect."
+
+        # @!method on_failure_call?(node)
+        def_node_matcher :on_failure_call?, <<~PATTERN
+          (send _ :on_failure ...)
+        PATTERN
+
+        # @!method checked_tests_or_always?(node)
+        def_node_matcher :checked_tests_or_always?, <<~PATTERN
+          (send _ :checked (sym {:tests | :always}))
+        PATTERN
+
+        def on_signature(node)
+          return unless node.descendants.any? { |n| on_failure_call?(n) }
+          return if node.descendants.any? { |n| checked_tests_or_always?(n) }
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -50,6 +50,7 @@ require_relative "sorbet/signatures/forbid_sig"
 require_relative "sorbet/signatures/forbid_sig_with_runtime"
 require_relative "sorbet/signatures/forbid_sig_without_runtime"
 require_relative "sorbet/signatures/keyword_argument_ordering"
+require_relative "sorbet/signatures/runtime_on_failure_depends_on_checked"
 require_relative "sorbet/signatures/signature_build_order"
 require_relative "sorbet/signatures/void_checked_tests"
 

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -50,6 +50,7 @@ In the following section you find all available cops:
 * [Sorbet/ObsoleteStrictMemoization](cops_sorbet.md#sorbetobsoletestrictmemoization)
 * [Sorbet/RedundantExtendTSig](cops_sorbet.md#sorbetredundantextendtsig)
 * [Sorbet/Refinement](cops_sorbet.md#sorbetrefinement)
+* [Sorbet/RuntimeOnFailureDependsOnChecked](cops_sorbet.md#sorbetruntimeonfailuredependsonchecked)
 * [Sorbet/SelectByIsA](cops_sorbet.md#sorbetselectbyisa)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
 * [Sorbet/SingleLineRbiClassModuleDefinitions](cops_sorbet.md#sorbetsinglelinerbiclassmoduledefinitions)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1197,6 +1197,30 @@ module Foo
 end
 ```
 
+## Sorbet/RuntimeOnFailureDependsOnChecked
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | <<next>> | -
+
+Checks that `on_failure` is not used without `checked(:tests)` or `checked(:always)`.
+
+### Examples
+
+```ruby
+# bad
+sig { params(x: Integer).returns(Integer).on_failure(:raise) }
+def plus_one(x)
+  x + 1
+end
+
+# good
+sig { params(x: Integer).returns(Integer).checked(:always).on_failure(:raise) }
+def plus_one(x)
+  x + 1
+end
+```
+
 ## Sorbet/SelectByIsA
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/sorbet/signatures/runtime_on_failure_depends_on_checked_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/runtime_on_failure_depends_on_checked_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      module Signatures
+        class RuntimeOnFailureDependsOnCheckedTest < ::Minitest::Test
+          MSG = "Sorbet/RuntimeOnFailureDependsOnChecked: To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect."
+
+          def setup
+            @cop = RuntimeOnFailureDependsOnChecked.new
+          end
+
+          def test_offends_when_on_failure_is_without_checked_always_or_tests
+            assert_offense(<<~RUBY)
+              sig { params(x: Integer).returns(Integer).on_failure(:raise) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+              sig { params(x: String).returns(String).checked(:none).on_failure(:raise) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+              sig { params(x: String).returns(String).checked().on_failure(:log) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+              sig { params(x: String).returns(String).checked(true).on_failure(:raise) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+              sig { params(x: String).returns(String).checked("tests").on_failure(:log) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+              sig { void.on_failure(:log) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+            RUBY
+          end
+
+          def test_ok_with_checked_always_or_tests_and_on_failure
+            assert_no_offenses(<<~RUBY)
+              sig { params(x: Integer).returns(Integer).checked(:always).on_failure(:raise) }
+
+              sig { params(x: Integer).returns(Integer).checked(:tests).on_failure(:log) }
+
+              sig { void.checked(:always).on_failure(:raise) }
+            RUBY
+          end
+
+          def test_ok_without_on_failure
+            assert_no_offenses(<<~RUBY)
+              sig { params(x: Integer).returns(Integer) }
+
+              sig { params(x: Integer).returns(Integer).checked(:always) }
+            RUBY
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Our app had a PR that made it into our pre-production environment with Sorbet signatures that used `on_failure` without `checked(:tests)` or `checked(:always)`.
- Hence, we got an error that we had to rollback for, and I thought it would be a good candidate for a cop to catch this statically.

```
Exception: ArgumentError
Details: Error interpreting sig:
 To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect.
```