### PR TITLE
Fix `Sorbet/ForbidTStruct` crash when `Layout/LineLength` is disabled

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_struct.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_struct.rb
@@ -222,7 +222,7 @@ module RuboCop
           string = +"\n"
 
           line = "#{indent}sig { params(#{sorted_props.map(&:initialize_sig_param).join(", ")}).void }\n"
-          if line.length <= max_line_length
+          if max_line_length.nil? || line.length <= max_line_length
             string << line
           else
             string << "#{indent}sig do\n"
@@ -237,7 +237,7 @@ module RuboCop
           end
 
           line = "#{indent}def initialize(#{sorted_props.map(&:initialize_param).join(", ")})\n"
-          if line.length <= max_line_length
+          if max_line_length.nil? || line.length <= max_line_length
             string << line
           else
             string << "#{indent}def initialize(\n"


### PR DESCRIPTION
## Summary

- Fix `ArgumentError: comparison of Integer with nil failed` when `Layout/LineLength` is disabled

## Problem

The `ForbidTStruct` cop uses `max_line_length` to decide whether to format generated signatures on single or multiple lines. When `Layout/LineLength` is disabled, `max_line_length` returns `nil`, causing the comparison `line.length <= nil` to raise an `ArgumentError`.

This was introduced in RuboCop 1.82.0 via [rubocop/rubocop#14658](https://github.com/rubocop/rubocop/pull/14658), which added a guard to `max_line_length` that returns `nil` when `Layout/LineLength` is disabled. Previously it always returned the configured max (or 120).

## Solution

Check for `nil` before comparing. When `max_line_length` is `nil`, default to single-line formatting.

## Test plan

- [x] Added regression test with `Layout/LineLength` disabled
- [x] Verified test catches the bug when run against RuboCop 1.82.0+
- [x] All existing tests pass

> [!NOTE]
> The regression test was verified against RuboCop 1.82.0+ via `bundle update`, but those gem bumps are not included in this PR as they're out of scope. The test will become effective once RuboCop is updated separately.

🤖 Generated with [Claude Code](https://claude.ai/code)