### PR TITLE
Fix Sorbet/RedundantTLet: match T.let type against multiline sig annotations

### DIFF
--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -61,7 +61,7 @@ module RuboCop
           # When the def is wrapped by a method modifier (`private def initialize`),
           # Sorbet's initializer rewriter does not process the ivar assignments,
           # so T.let annotations remain required. Skip by returning nil.
-          return nil if method_node.parent&.send_type?
+          return if method_node.parent&.send_type?
 
           method_node.left_sibling.then { |s| signature?(s) ? s : nil }
         end

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -42,8 +42,8 @@ module RuboCop
           method_args = node.arguments&.to_h { |arg| [arg.name, arg.type] }
           return unless method_args&.any?
 
-          sig_node = node.left_sibling
-          return unless sig_node && signature?(sig_node)
+          sig_node = find_sig_node(node)
+          return unless sig_node
 
           sig_params = sig_params(sig_node)&.to_h { |pair| [pair.key.value, pair.value] }
           return unless sig_params&.any?
@@ -56,6 +56,26 @@ module RuboCop
         end
 
         private
+
+        def find_sig_node(method_node)
+          # When the def is wrapped by a method modifier (`private def initialize`),
+          # Sorbet's initializer rewriter does not process the ivar assignments,
+          # so T.let annotations remain required. Skip by returning nil.
+          return nil if method_node.parent&.send_type?
+
+          method_node.left_sibling.then { |s| signature?(s) ? s : nil }
+        end
+
+        def normalize_whitespace(source)
+          source
+            .gsub(/\s+/, " ")              # collapse all whitespace to single spaces
+            .gsub(/,\s*([)\]\}])/, "\\1")  # remove trailing commas before closing delimiters
+            .gsub(/\(\s*/, "(")            # remove space after (
+            .gsub(/\s*\)/, ")")            # remove space before )
+            .gsub(/\[\s*/, "[")            # remove space after [
+            .gsub(/\s*\]/, "]")            # remove space before ]
+            .strip
+        end
 
         def ivar_assignments(node)
           return [] unless node.body
@@ -72,8 +92,8 @@ module RuboCop
           method_arg_kind = method_args[tlet_key]
           return unless method_arg_kind
 
-          arg_type = expected_type(sig_type.source, method_arg_kind)
-          return unless tlet_value.source == arg_type
+          arg_type = expected_type(normalize_whitespace(sig_type.source), method_arg_kind)
+          return unless normalize_whitespace(tlet_value.source) == arg_type
 
           add_offense(node) do |corrector|
             corrector.replace(node, tlet_key.to_s)

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -269,6 +269,84 @@ module RuboCop
             end
           RUBY
         end
+
+        # Sorbet's initializer rewriter does not process ivar assignments
+        # inside a rescue body, so T.let remains required there.
+        def test_no_offense_with_rescue_in_body
+          assert_no_offenses(<<~RUBY)
+            sig { params(a: Integer).void }
+            def initialize(a)
+              @a = T.let(a, Integer)
+            rescue
+              @a = T.let(0, Integer)
+            end
+          RUBY
+        end
+
+        # Multiline type annotations in the sig contain whitespace and trailing
+        # commas that do not appear in the T.let argument; both sides are
+        # normalized before comparison.
+        def test_offense_on_multiline_type_in_sig
+          assert_offense(<<~RUBY)
+            sig do
+              params(
+                a: T.any(
+                  Integer,
+                  String,
+                ),
+              ).void
+            end
+            def initialize(a)
+              @a = T.let(a, T.any(Integer, String))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            sig do
+              params(
+                a: T.any(
+                  Integer,
+                  String,
+                ),
+              ).void
+            end
+            def initialize(a)
+              @a = a
+            end
+          RUBY
+        end
+
+        def test_offense_on_multiline_type_in_t_let
+          assert_offense(<<~RUBY)
+            sig { params(a: T.any(Integer, String)).void }
+            def initialize(a)
+              @a = T.let(a, T.any(
+                   ^^^^^^^^^^^^^^^ #{MSG}
+                Integer,
+                String
+              ))
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            sig { params(a: T.any(Integer, String)).void }
+            def initialize(a)
+              @a = a
+            end
+          RUBY
+        end
+
+        # Sorbet's initializer rewriter does not process ivar assignments when
+        # the def is wrapped by a method modifier, so T.let remains required.
+        def test_no_offense_with_method_modifier_wrapping_def
+          assert_no_offenses(<<~RUBY)
+            sig { params(a: Integer).void }
+            private def initialize(a)
+              @a = T.let(a, Integer)
+            end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes one bug in the `Sorbet/RedundantTLet` cop introduced in #362,
and adds tests documenting two edge cases where T.let must be kept.

### Bug: Multiline sig type annotations are not matched

When a sig uses a multiline type annotation, `sig_type.source` contains
newlines, indentation, and trailing commas that don't appear in the
single-line T.let argument, causing a spurious no-match:

```ruby
sig do
  params(
    a: T.any(
      Integer,
      String,
    ),
  ).void
end
def initialize(a)
  @a = T.let(a, T.any(Integer, String))  # was not flagged
end
```

Fix: normalize both sides of the type comparison by collapsing
whitespace and stripping trailing commas before closing delimiters.

### Documented edge case: method modifier-wrapped def

When `initialize` is wrapped by a method modifier (`private def initialize`),
Sorbet's initializer rewriter does **not** process ivar assignments, so
`T.let` remains required for type correctness at `# typed: strict`.
The cop correctly skips these methods by checking whether the def's
parent is a send node.

Note: `initialize` is already private, so `private def initialize` is
unusual, but any other method modifier would trigger the same issue.

### Documented edge case: rescue in initialize body

`initialize` bodies with a method-level `rescue` clause are correctly
left alone. Sorbet's initializer rewriter does not process ivar
assignments inside a rescue-wrapped body, so removing `T.let` there
would cause a type error in `# typed: strict` files. The existing
`ivar_assignments` guard already handles this, but the behavior was
not previously tested.
