### PR TITLE
Add `AllowUntypedHashValues` option to `Sorbet/ForbidTUntyped`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -236,6 +236,7 @@ Sorbet/ForbidTUnsafe:
 Sorbet/ForbidTUntyped:
   Description: 'Forbid usage of T.untyped'
   Enabled: false
+  AllowUntypedHashValues: false
   VersionAdded: 0.6.9
   VersionChanged: 0.7.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -238,7 +238,7 @@ Sorbet/ForbidTUntyped:
   Enabled: false
   AllowUntypedHashValues: false
   VersionAdded: 0.6.9
-  VersionChanged: 0.7.0
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTypeAliasedShapes:
   Description: 'Forbids defining type aliases that contain shapes'

--- a/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
@@ -59,7 +59,7 @@ module RuboCop
         def hash_value_position?(node)
           parent = node.parent
           parent&.send_type? &&
-            parent.method_name == :[] &&
+            parent.method?(:[]) &&
             t_hash_receiver?(parent.receiver) &&
             parent.arguments[1].equal?(node)
         end

--- a/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_untyped.rb
@@ -17,6 +17,22 @@ module RuboCop
       #   sig { params(my_argument: String).void }
       #   def foo(my_argument); end
       #
+      # @example AllowUntypedHashValues: false (default)
+      #
+      #   # bad
+      #   sig { returns(T::Hash[Symbol, T.untyped]) }
+      #   def metadata; end
+      #
+      # @example AllowUntypedHashValues: true
+      #
+      #   # good (T.untyped in value position of T::Hash)
+      #   sig { returns(T::Hash[Symbol, T.untyped]) }
+      #   def metadata; end
+      #
+      #   # bad (T.untyped in key position of T::Hash — still flagged)
+      #   sig { returns(T::Hash[T.untyped, String]) }
+      #   def metadata; end
+      #
       class ForbidTUntyped < RuboCop::Cop::Base
         MSG = "Do not use `T.untyped`."
         RESTRICT_ON_SEND = [:untyped].freeze
@@ -24,8 +40,28 @@ module RuboCop
         # @!method t_untyped?(node)
         def_node_matcher(:t_untyped?, "(send (const nil? :T) :untyped)")
 
+        # @!method t_hash_receiver?(node)
+        def_node_matcher(:t_hash_receiver?, "(const (const {nil? cbase} :T) :Hash)")
+
         def on_send(node)
-          add_offense(node) if t_untyped?(node)
+          return unless t_untyped?(node)
+          return if allow_untyped_hash_values? && hash_value_position?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def allow_untyped_hash_values?
+          cop_config.fetch("AllowUntypedHashValues", false)
+        end
+
+        def hash_value_position?(node)
+          parent = node.parent
+          parent&.send_type? &&
+            parent.method_name == :[] &&
+            t_hash_receiver?(parent.receiver) &&
+            parent.arguments[1].equal?(node)
         end
       end
     end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -925,6 +925,32 @@ sig { params(my_argument: String).void }
 def foo(my_argument); end
 ```
 
+#### `AllowUntypedHashValues: false` (default)
+
+```ruby
+# bad
+sig { returns(T::Hash[Symbol, T.untyped]) }
+def metadata; end
+```
+
+#### `AllowUntypedHashValues: true`
+
+```ruby
+# good (T.untyped in value position of T::Hash)
+sig { returns(T::Hash[Symbol, T.untyped]) }
+def metadata; end
+
+# bad (T.untyped in key position — still flagged)
+sig { returns(T::Hash[T.untyped, String]) }
+def metadata; end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowUntypedHashValues | `false` | Boolean
+
 ## Sorbet/ForbidTypeAliasedShapes
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -909,7 +909,7 @@ foo
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.6.9 | 0.7.0
+Disabled | Yes | No | 0.6.9 | <<next>>
 
 Disallows using `T.untyped` anywhere.
 
@@ -924,23 +924,21 @@ def foo(my_argument); end
 sig { params(my_argument: String).void }
 def foo(my_argument); end
 ```
-
-#### `AllowUntypedHashValues: false` (default)
+#### AllowUntypedHashValues: false (default)
 
 ```ruby
 # bad
 sig { returns(T::Hash[Symbol, T.untyped]) }
 def metadata; end
 ```
-
-#### `AllowUntypedHashValues: true`
+#### AllowUntypedHashValues: true
 
 ```ruby
 # good (T.untyped in value position of T::Hash)
 sig { returns(T::Hash[Symbol, T.untyped]) }
 def metadata; end
 
-# bad (T.untyped in key position — still flagged)
+# bad (T.untyped in key position of T::Hash — still flagged)
 sig { returns(T::Hash[T.untyped, String]) }
 def metadata; end
 ```

--- a/test/rubocop/cop/sorbet/forbid_t_untyped_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_untyped_test.rb
@@ -45,6 +45,94 @@ module RuboCop
           RUBY
         end
       end
+
+      class ForbidTUntypedAllowUntypedHashValuesTest < ::Minitest::Test
+        MSG = "Do not use `T.untyped`."
+
+        def target_cop
+          ForbidTUntyped
+        end
+
+        def setup
+          @cop = target_cop.new(cop_config({ "AllowUntypedHashValues" => true }))
+        end
+
+        def test_no_offense_for_t_untyped_as_hash_value_type
+          assert_no_offenses(<<~RUBY)
+            sig { returns(T::Hash[Symbol, T.untyped]) }
+            def metadata; end
+          RUBY
+        end
+
+        def test_adds_offense_for_t_untyped_as_hash_key_type
+          assert_offense(<<~RUBY)
+            sig { returns(T::Hash[T.untyped, String]) }
+                                  ^^^^^^^^^ #{MSG}
+            def metadata; end
+          RUBY
+        end
+
+        def test_adds_offense_for_direct_t_untyped
+          assert_offense(<<~RUBY)
+            sig { params(x: T.untyped).void }
+                            ^^^^^^^^^ #{MSG}
+            def foo(x); end
+          RUBY
+        end
+
+        def test_adds_offense_for_t_untyped_in_t_array
+          assert_offense(<<~RUBY)
+            sig { returns(T::Array[T.untyped]) }
+                                   ^^^^^^^^^ #{MSG}
+            def items; end
+          RUBY
+        end
+
+        def test_adds_offense_for_t_untyped_in_both_key_and_value_positions
+          assert_offense(<<~RUBY)
+            sig { returns(T::Hash[T.untyped, T.untyped]) }
+                                  ^^^^^^^^^ #{MSG}
+            def metadata; end
+          RUBY
+        end
+
+        def test_no_offense_for_nested_hash_with_untyped_value
+          assert_no_offenses(<<~RUBY)
+            sig { returns(T::Hash[Symbol, T::Hash[String, T.untyped]]) }
+            def metadata; end
+          RUBY
+        end
+
+        def test_no_offense_for_nilable_hash_with_untyped_value
+          assert_no_offenses(<<~RUBY)
+            sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+            def metadata; end
+          RUBY
+        end
+
+        def test_no_offense_for_union_type_hash_with_untyped_value
+          assert_no_offenses(<<~RUBY)
+            sig { returns(T.any(T::Hash[Symbol, T.untyped], NilClass)) }
+            def metadata; end
+          RUBY
+        end
+      end
+
+      class ForbidTUntypedDefaultConfigTest < ::Minitest::Test
+        MSG = "Sorbet/ForbidTUntyped: Do not use `T.untyped`."
+
+        def setup
+          @cop = ForbidTUntyped.new
+        end
+
+        def test_adds_offense_for_t_untyped_as_hash_value_type_by_default
+          assert_offense(<<~RUBY)
+            sig { returns(T::Hash[Symbol, T.untyped]) }
+                                          ^^^^^^^^^ #{MSG}
+            def metadata; end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Implements the feature requested in #373.

Adds an `AllowUntypedHashValues` boolean configuration option (defaulting to `false`) to `Sorbet/ForbidTUntyped`. When enabled, `T.untyped` in the value position of `T::Hash` is allowed, while the key position and all other usages remain flagged.

```yaml
Sorbet/ForbidTUntyped:
  Enabled: true
  AllowUntypedHashValues: true
```

```ruby
# good (T.untyped in value position of T::Hash)
sig { returns(T::Hash[Symbol, T.untyped]) }
def metadata; end

# bad (T.untyped in key position — still flagged)
sig { returns(T::Hash[T.untyped, String]) }
def metadata; end

# bad (T.untyped used directly — still flagged)
sig { params(x: T.untyped).void }
def foo(x); end
```

## Test plan

- [x] Existing `ForbidTUntypedTest` tests continue to pass (default behavior unchanged)
- [x] `ForbidTUntypedAllowUntypedHashValuesTest` covers:
  - Value position allowed: `T::Hash[Symbol, T.untyped]` → no offense
  - Key position flagged: `T::Hash[T.untyped, String]` → offense
  - Both positions untyped: `T::Hash[T.untyped, T.untyped]` → offense on key only (not value)
  - Nested hash value position: `T::Hash[Symbol, T::Hash[String, T.untyped]]` → no offense
  - Nilable-wrapped hash: `T.nilable(T::Hash[Symbol, T.untyped])` → no offense
  - Union type containing hash: `T.any(T::Hash[Symbol, T.untyped], NilClass)` → no offense
  - Direct usage flagged: `T.untyped` → offense
  - `T::Array[T.untyped]` → offense
- [x] `ForbidTUntypedDefaultConfigTest` verifies `T::Hash[Symbol, T.untyped]` is flagged when `AllowUntypedHashValues` is `false` (default)