### PR TITLE
Extend RedundantTLet cops for freeze-transparent inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,6 @@ Sorbet cops support the following versions:
 - Sorbet >= 0.5
 - Ruby >= 3.1
 
-The `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral` cops flag some
-constructs (constructor calls, frozen literals, and literal arrays) whose
-redundancy relies on Sorbet type inference added up to Sorbet 0.6.13304. Those
-newer cases would remove a `T.let` that an older Sorbet still requires, so they
-detect the `sorbet-static` version in your `Gemfile.lock` and disable themselves
-below 0.6.13304; their older cases (instance variables, bare simple literals)
-remain active. See each cop's documentation for details.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to this project.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,15 @@ You can read about each cop supplied by RuboCop Sorbet in [the manual](manual/co
 
 Sorbet cops support the following versions:
 
-- Sorbet >= 0.5
+- Sorbet >= 0.6.13304
 - Ruby >= 3.1
+
+The `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral` cops autocorrect
+based on Sorbet's type inference, which has changed over time. Their newer cases
+(constructor calls, frozen literals, and literal arrays) rely on inference added
+up to Sorbet 0.6.13304 — running their autocorrect against an older Sorbet can
+remove a `T.let` that the older Sorbet still requires. See each cop's
+documentation for details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,15 +94,16 @@ You can read about each cop supplied by RuboCop Sorbet in [the manual](manual/co
 
 Sorbet cops support the following versions:
 
-- Sorbet >= 0.6.13304
+- Sorbet >= 0.5
 - Ruby >= 3.1
 
-The `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral` cops autocorrect
-based on Sorbet's type inference, which has changed over time. Their newer cases
-(constructor calls, frozen literals, and literal arrays) rely on inference added
-up to Sorbet 0.6.13304 — running their autocorrect against an older Sorbet can
-remove a `T.let` that the older Sorbet still requires. See each cop's
-documentation for details.
+The `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral` cops flag some
+constructs (constructor calls, frozen literals, and literal arrays) whose
+redundancy relies on Sorbet type inference added up to Sorbet 0.6.13304. Those
+newer cases would remove a `T.let` that an older Sorbet still requires, so they
+detect the `sorbet-static` version in your `Gemfile.lock` and disable themselves
+below 0.6.13304; their older cases (instance variables, bare simple literals)
+remain active. See each cop's documentation for details.
 
 ## Contributing
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -14,6 +14,7 @@ Sorbet/RedundantTLet:
     instance variables assigned from signature parameters in `initialize`, and
     constants assigned constructor calls.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: <<next>>
 
 inherit_mode:
@@ -330,7 +331,7 @@ Sorbet/RedundantTLetForLiteral:
     is a simple literal whose type Sorbet can infer automatically.
   Enabled: pending
   Safe: true
-  SafeAutoCorrect: true
+  SafeAutoCorrect: false
   VersionAdded: <<next>>
 
 Sorbet/Refinement:

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,7 +9,10 @@ Sorbet/ForbidTSig:
   VersionAdded: '0.11.0'
 
 Sorbet/RedundantTLet:
-  Description: 'Prevents redundant use of `T.let` in initialize methods where types can be inferred from the signature.'
+  Description: >-
+    Prevents redundant use of `T.let` where Sorbet infers types automatically:
+    instance variables assigned from signature parameters in `initialize`, and
+    constants assigned constructor calls.
   Enabled: true
   VersionAdded: <<next>>
 

--- a/lib/rubocop/cop/sorbet/mixin/constant_scope.rb
+++ b/lib/rubocop/cop/sorbet/mixin/constant_scope.rb
@@ -3,16 +3,14 @@
 module RuboCop
   module Cop
     module Sorbet
-      # Shared helper for cops that decide whether a constant assignment
-      # (`casgn`) can have its `T.let` annotation safely removed.
+      # Shared helper for cops that unwrap a `T.let` on a constant assignment.
       module ConstantScope
         private
 
-        # A constant is statically scoped when it is assigned directly in a
-        # class, module, or top-level body, rather than nested inside a
-        # conditional, loop, block, or method. In `typed: strict` files Sorbet
-        # requires an explicit `T.let` on constants that are not statically
-        # scoped (error 7027), so removing the annotation there would break
+        # True when the constant is assigned directly in a class, module, or
+        # top-level body. In `typed: strict` files Sorbet requires a `T.let` on
+        # constants assigned elsewhere (inside a conditional, loop, block, or
+        # method — error 7027), so removing the annotation there would break
         # typechecking.
         def statically_scoped?(node)
           ancestor = node.parent

--- a/lib/rubocop/cop/sorbet/mixin/constant_scope.rb
+++ b/lib/rubocop/cop/sorbet/mixin/constant_scope.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Shared helper for cops that decide whether a constant assignment
+      # (`casgn`) can have its `T.let` annotation safely removed.
+      module ConstantScope
+        private
+
+        # A constant is statically scoped when it is assigned directly in a
+        # class, module, or top-level body, rather than nested inside a
+        # conditional, loop, block, or method. In `typed: strict` files Sorbet
+        # requires an explicit `T.let` on constants that are not statically
+        # scoped (error 7027), so removing the annotation there would break
+        # typechecking.
+        def statically_scoped?(node)
+          ancestor = node.parent
+          ancestor = ancestor.parent if ancestor&.begin_type?
+          ancestor.nil? || ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -11,31 +11,47 @@ module RuboCop
       module TLetCorrection
         private
 
+        # Replaces `T.let(value, Type)` with `value`.
         def replace_t_let(corrector, t_let_node, value_node)
           heredocs = value_node.each_node(:any_str).select(&:heredoc?)
-          if heredocs.empty?
-            corrector.replace(t_let_node, value_node.source)
-            return
-          end
+          return corrector.replace(t_let_node, value_node.source) if heredocs.empty?
 
-          # The `T.let(...)` closing paren can fall after the heredoc bodies
-          # (multi-line, type on its own line) or before them (single-line,
-          # `T.let(<<~SQL, String)`). Extend the replaced range to whichever
-          # ends last so no body is left dangling.
-          last_heredoc_end = heredocs.map { |node| node.loc.heredoc_end.end_pos }.max
-          paren_end = t_let_node.source_range.end_pos
-          range = t_let_node.source_range.with(end_pos: [last_heredoc_end, paren_end].max)
-
-          # A comment can trail the value on the marker line (before the body);
-          # the extended range would delete it, so recover it and re-emit it on
-          # the reconstructed marker line. Only a comment can appear there once
-          # the value's source ends — the `, Type)` tokens carry no `#`.
-          bodies = heredocs
-            .sort_by { |node| node.loc.heredoc_body.begin_pos }
-            .map { |node| node.loc.heredoc_body.source + node.loc.heredoc_end.source }
-          corrector.replace(range, "#{value_node.source}#{marker_line_comment(value_node)}\n#{bodies.join("\n")}")
+          replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs)
         end
 
+        # Replaces `T.let(value, Type)` with `value` without losing any heredocs
+        # contained in the value. For example, `T.let(<<~SQL, String)` becomes
+        # `<<~SQL` followed by its original body and terminator.
+        def replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs)
+          corrector.replace(
+            range_including_heredocs(t_let_node, heredocs),
+            source_including_heredocs(value_node, heredocs),
+          )
+        end
+
+        # Expands the correction range to include every heredoc body and terminator.
+        # For example, the range for `T.let(<<~SQL, String)` extends through the
+        # final `SQL` terminator rather than ending at the closing parenthesis.
+        def range_including_heredocs(t_let_node, heredocs)
+          end_positions = [t_let_node.source_range.end_pos]
+          end_positions.concat(heredocs.map { |node| node.loc.heredoc_end.end_pos })
+          t_let_node.source_range.with(end_pos: end_positions.max)
+        end
+
+        # Reconstructs the value with its marker-line comment and heredoc bodies.
+        # For example, `T.let(<<~SQL, String) # query` becomes a source string
+        # containing `<<~SQL # query`, followed by its body and `SQL` terminator.
+        def source_including_heredocs(value_node, heredocs)
+          marker_line = "#{value_node.source}#{marker_line_comment(value_node)}"
+          heredoc_bodies = heredocs
+            .sort_by { |node| node.loc.heredoc_body.begin_pos }
+            .map { |node| "#{node.loc.heredoc_body.source}#{node.loc.heredoc_end.source}" }
+
+          ([marker_line] + heredoc_bodies).join("\n")
+        end
+
+        # Returns the comment trailing the heredoc marker, including its leading space.
+        # For example, the marker line `<<~SQL, String) # query` returns ` # query`.
         def marker_line_comment(value_node)
           buffer = value_node.source_range.source_buffer.source
           value_end = value_node.source_range.end_pos

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -23,15 +23,29 @@ module RuboCop
             return
           end
 
-          # The closing `)` may come before (single-line) or after (multi-line)
-          # the heredoc bodies, so extend to whichever ends last.
-          end_pos = heredocs.map { |node| node.loc.heredoc_end.end_pos }.push(t_let_node.source_range.end_pos).max
-          range = t_let_node.source_range.with(end_pos: end_pos)
+          # A heredoc body sits on the lines below its marker, so the closing
+          # `)` can fall either after the bodies (multi-line, with the type on
+          # its own line) or before them (single-line, `T.let(<<~SQL, String)`).
+          # Extend the replaced range to whichever ends last so no body is left
+          # dangling.
+          last_heredoc_end = heredocs.map { |node| node.loc.heredoc_end.end_pos }.max
+          paren_end = t_let_node.source_range.end_pos
+          range = t_let_node.source_range.with(end_pos: [last_heredoc_end, paren_end].max)
+
+          # When the `)` closes before the bodies, the extended range would also
+          # swallow anything trailing it on that line (e.g. a comment), so carry
+          # that text back onto the reconstructed marker line.
+          inline_tail = ""
+          if paren_end < last_heredoc_end
+            source = t_let_node.source_range.source_buffer.source
+            line_end = source.index("\n", paren_end) || source.length
+            inline_tail = source[paren_end...line_end]
+          end
 
           bodies = heredocs
             .sort_by { |node| node.loc.heredoc_body.begin_pos }
             .map { |node| node.loc.heredoc_body.source + node.loc.heredoc_end.source }
-          corrector.replace(range, "#{value_node.source}\n#{bodies.join("\n")}")
+          corrector.replace(range, "#{value_node.source}#{inline_tail}\n#{bodies.join("\n")}")
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -4,15 +4,10 @@ module RuboCop
   module Cop
     module Sorbet
       # Shared autocorrection helper for cops that unwrap a redundant
-      # `T.let(value, Type)` down to `value`.
-      #
-      # A naive `corrector.replace(t_let_node, value_node.source)` drops heredoc
-      # bodies: `value_node.source` stops at the heredoc marker line (`<<~SQL`),
-      # and when the `T.let` spans multiple lines its `, Type)` and closing paren
-      # sit *after* the heredoc body — so replacing the whole `T.let(...)` range
-      # with just the marker deletes the body and terminator, producing an
-      # unterminated heredoc. This reattaches every heredoc body nested in
-      # `value_node` and extends the replaced range past their terminators.
+      # `T.let(value, Type)` down to `value`, preserving heredoc bodies that a
+      # naive `corrector.replace(t_let_node, value_node.source)` would drop
+      # (`value_node.source` stops at the marker line, so the body and its
+      # terminator sit outside it).
       module TLetCorrection
         private
 
@@ -23,29 +18,30 @@ module RuboCop
             return
           end
 
-          # A heredoc body sits on the lines below its marker, so the closing
-          # `)` can fall either after the bodies (multi-line, with the type on
-          # its own line) or before them (single-line, `T.let(<<~SQL, String)`).
-          # Extend the replaced range to whichever ends last so no body is left
-          # dangling.
+          # The `T.let(...)` closing paren can fall after the heredoc bodies
+          # (multi-line, type on its own line) or before them (single-line,
+          # `T.let(<<~SQL, String)`). Extend the replaced range to whichever
+          # ends last so no body is left dangling.
           last_heredoc_end = heredocs.map { |node| node.loc.heredoc_end.end_pos }.max
           paren_end = t_let_node.source_range.end_pos
           range = t_let_node.source_range.with(end_pos: [last_heredoc_end, paren_end].max)
 
-          # When the `)` closes before the bodies, the extended range would also
-          # swallow anything trailing it on that line (e.g. a comment), so carry
-          # that text back onto the reconstructed marker line.
-          inline_tail = ""
-          if paren_end < last_heredoc_end
-            source = t_let_node.source_range.source_buffer.source
-            line_end = source.index("\n", paren_end) || source.length
-            inline_tail = source[paren_end...line_end]
-          end
-
+          # A comment can trail the value on the marker line (before the body);
+          # the extended range would delete it, so recover it and re-emit it on
+          # the reconstructed marker line. Only a comment can appear there once
+          # the value's source ends — the `, Type)` tokens carry no `#`.
           bodies = heredocs
             .sort_by { |node| node.loc.heredoc_body.begin_pos }
             .map { |node| node.loc.heredoc_body.source + node.loc.heredoc_end.source }
-          corrector.replace(range, "#{value_node.source}#{inline_tail}\n#{bodies.join("\n")}")
+          corrector.replace(range, "#{value_node.source}#{marker_line_comment(value_node)}\n#{bodies.join("\n")}")
+        end
+
+        def marker_line_comment(value_node)
+          buffer = value_node.source_range.source_buffer.source
+          value_end = value_node.source_range.end_pos
+          line_end = buffer.index("\n", value_end) || buffer.length
+          comment = buffer[value_end...line_end][/#.*/]
+          comment ? " #{comment}" : ""
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Shared autocorrection helper for cops that unwrap a redundant
+      # `T.let(value, Type)` down to `value`.
+      #
+      # A naive `corrector.replace(t_let_node, value_node.source)` drops heredoc
+      # bodies: `value_node.source` stops at the heredoc marker line (`<<~SQL`),
+      # and when the `T.let` spans multiple lines its `, Type)` and closing paren
+      # sit *after* the heredoc body — so replacing the whole `T.let(...)` range
+      # with just the marker deletes the body and terminator, producing an
+      # unterminated heredoc. This reattaches every heredoc body nested in
+      # `value_node` and extends the replaced range past their terminators.
+      module TLetCorrection
+        private
+
+        def replace_t_let(corrector, t_let_node, value_node)
+          heredocs = value_node.each_node(:any_str).select(&:heredoc?)
+          if heredocs.empty?
+            corrector.replace(t_let_node, value_node.source)
+            return
+          end
+
+          # The closing `)` may come before (single-line) or after (multi-line)
+          # the heredoc bodies, so extend to whichever ends last.
+          end_pos = heredocs.map { |node| node.loc.heredoc_end.end_pos }.push(t_let_node.source_range.end_pos).max
+          range = t_let_node.source_range.with(end_pos: end_pos)
+
+          bodies = heredocs
+            .sort_by { |node| node.loc.heredoc_body.begin_pos }
+            .map { |node| node.loc.heredoc_body.source + node.loc.heredoc_end.source }
+          corrector.replace(range, "#{value_node.source}\n#{bodies.join("\n")}")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -47,6 +47,7 @@ module RuboCop
       #  @path = T.let(Pathname.new("/usr/local"), Pathname)
       class RedundantTLet < RuboCop::Cop::Base
         include SignatureHelp
+        include ConstantScope
         extend AutoCorrector
 
         MSG = "Unnecessary T.let. The instance variable type is inferred from the signature."
@@ -108,12 +109,6 @@ module RuboCop
         end
 
         private
-
-        def statically_scoped?(node)
-          ancestor = node.parent
-          ancestor = ancestor.parent if ancestor&.begin_type?
-          ancestor.nil? || ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
-        end
 
         def constructor_call(node)
           node = node.receiver if node.send_type? && node.method?(:freeze)

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -80,9 +80,7 @@ module RuboCop
         def on_def(node)
           return unless node.method?(:initialize)
 
-          # Destructured parameters (`def initialize((a, b))`) are mlhs nodes
-          # without a name; they cannot appear in a sig, so skip them.
-          method_args = node.arguments.filter_map { |arg| [arg.name, arg.type] if arg.respond_to?(:name) }.to_h
+          method_args = named_argument_types(node)
           return if method_args.none?
 
           sig_node = find_sig_node(node)
@@ -120,15 +118,34 @@ module RuboCop
 
         private
 
+        # Maps named parameters to their AST types, omitting destructured
+        # parameters because they have no name and cannot appear in a signature.
+        # For example, `def initialize(a, (left, right), *rest)` returns
+        # `{ a: :arg, rest: :restarg }`, omitting `(left, right)`.
+        def named_argument_types(method_node)
+          method_node.arguments.filter_map do |argument|
+            [argument.name, argument.type] if argument.respond_to?(:name)
+          end.to_h
+        end
+
+        # Returns the `.new` call for a constant constructor, looking through
+        # an optional block and trailing `.freeze`. For example,
+        # `Foo.new { _1.enabled = true }.freeze` returns the `Foo.new` call,
+        # while `foo.new` and `Foo.build` return `nil`.
         def constructor_call(node)
           node = node.receiver if node.send_type? && node.method?(:freeze)
-          # `Foo.new { ... }` wraps the `.new` send in a block node; this
-          # includes numbered-parameter (`{ _1 }`) and `it` block forms.
-          node = node.send_node if node&.any_block_type?
+          node = unwrap_block(node)
           return unless node&.send_type? && node.method?(:new)
           return unless node.receiver&.const_type?
 
           node
+        end
+
+        # Returns the method send wrapped by a block, or the original node when
+        # no block is present. For example, `Foo.new { _1.enabled = true }`
+        # returns the `Foo.new` send node.
+        def unwrap_block(node)
+          node&.any_block_type? ? node.send_node : node
         end
 
         def find_sig_node(method_node)

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -105,9 +105,9 @@ module RuboCop
         private
 
         def constructor_call(node)
-          return unless node.send_type?
-
-          node = node.receiver if node.method?(:freeze)
+          node = node.receiver if node.send_type? && node.method?(:freeze)
+          # `Foo.new { ... }` is a block node wrapping the `.new` send.
+          node = node.send_node if node&.block_type?
           return unless node&.send_type? && node.method?(:new)
           return unless node.receiver&.const_type?
 

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -3,7 +3,16 @@
 module RuboCop
   module Cop
     module Sorbet
-      # Prevents unnecessary `T.let` in `initialize` methods. When a signature parameter is assigned to an instance variable, the type is inferred automatically.
+      # Prevents unnecessary `T.let` where Sorbet infers the type automatically.
+      #
+      # When a signature parameter is assigned to an instance variable in
+      # `initialize`, the type is inferred from the signature.
+      #
+      # When a constant is assigned a constructor call (`.new`), optionally
+      # followed by `.freeze` (Sorbet 0.6.13304+), the type is inferred from
+      # the class being instantiated. Generic classes (e.g. `Set`) are
+      # excluded: Sorbet infers their constructor calls as applied types like
+      # `T::Set[T.untyped]`, so an annotation is still required.
       #
       # @example
       #
@@ -24,14 +33,35 @@ module RuboCop
       #  def initialize(a)
       #    @a = T.let(a, T.any(Integer, String))
       #  end
+      #
+      #  # bad
+      #  DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+      #
+      #  # good
+      #  DEFAULT_PATH = Pathname.new("/usr/local").freeze
+      #
+      #  # good — generic classes are not inferred, so T.let is required
+      #  LICENSES = T.let(Set.new(["mit"]).freeze, T::Set[String])
+      #
+      #  # good — instance variables are only inferred from signature parameters
+      #  @path = T.let(Pathname.new("/usr/local"), Pathname)
       class RedundantTLet < RuboCop::Cop::Base
         include SignatureHelp
         extend AutoCorrector
 
         MSG = "Unnecessary T.let. The instance variable type is inferred from the signature."
+        MSG_CONSTRUCTOR = "Unnecessary T.let. The constant type is inferred from the constructor."
+
+        # Classes whose constructor calls Sorbet infers as applied generic
+        # types (e.g. `T::Set[T.untyped]`) rather than the bare class, so
+        # constants assigned them still need an explicit annotation.
+        GENERIC_CLASSES = ["Array", "Class", "Enumerator", "Hash", "Module", "Range", "Set"].freeze
 
         # @!method t_let(node)
         def_node_matcher :t_let, "(ivasgn _ $(send (const {nil? cbase} :T) :let (lvar $_) $_))"
+
+        # @!method t_let_casgn(node)
+        def_node_matcher :t_let_casgn, "(casgn _ _ $(send (const {nil? cbase} :T) :let $_ $_))"
 
         # @!method sig_params(node)
         def_node_matcher :sig_params, "`(send nil? :params (hash $...))"
@@ -55,7 +85,34 @@ module RuboCop
           end
         end
 
+        def on_casgn(node)
+          t_let_casgn(node) do |tlet_node, value_node, type_node|
+            next unless type_node.const_type?
+
+            constructor = constructor_call(value_node)
+            next unless constructor
+
+            class_path = constructor.receiver.source.delete_prefix("::")
+            next if GENERIC_CLASSES.include?(class_path)
+            next unless class_path == type_node.source.delete_prefix("::")
+
+            add_offense(tlet_node, message: MSG_CONSTRUCTOR) do |corrector|
+              corrector.replace(tlet_node, value_node.source)
+            end
+          end
+        end
+
         private
+
+        def constructor_call(node)
+          return unless node.send_type?
+
+          node = node.receiver if node.method?(:freeze)
+          return unless node&.send_type? && node.method?(:new)
+          return unless node.receiver&.const_type?
+
+          node
+        end
 
         def find_sig_node(method_node)
           # When the def is wrapped by a method modifier (`private def initialize`),

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -70,8 +70,10 @@ module RuboCop
         def on_def(node)
           return unless node.method?(:initialize)
 
-          method_args = node.arguments&.to_h { |arg| [arg.name, arg.type] }
-          return unless method_args&.any?
+          # Destructured parameters (`def initialize((a, b))`) are mlhs nodes
+          # without a name; they cannot appear in a sig, so skip them.
+          method_args = node.arguments.filter_map { |arg| [arg.name, arg.type] if arg.respond_to?(:name) }.to_h
+          return if method_args.none?
 
           sig_node = find_sig_node(node)
           return unless sig_node

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -49,6 +49,7 @@ module RuboCop
         include SignatureHelp
         include ConstantScope
         include TargetSorbetVersion
+        include TLetCorrection
         extend AutoCorrector
 
         # The constructor-constant inference these cops rely on (`X = A.new`,
@@ -118,7 +119,7 @@ module RuboCop
             next unless class_path == type_node.source.delete_prefix("::")
 
             add_offense(tlet_node, message: MSG_CONSTRUCTOR) do |corrector|
-              corrector.replace(tlet_node, value_node.source)
+              replace_t_let(corrector, tlet_node, value_node)
             end
           end
         end

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -48,7 +48,16 @@ module RuboCop
       class RedundantTLet < RuboCop::Cop::Base
         include SignatureHelp
         include ConstantScope
+        include TargetSorbetVersion
         extend AutoCorrector
+
+        # The constructor-constant inference these cops rely on (`X = A.new`,
+        # `X = A.new.freeze`) was finalized by Sorbet's freeze-transparent
+        # inference in 0.6.13304. Flagging it against an older Sorbet could
+        # remove a `T.let` that Sorbet still requires, so the constant path
+        # (`on_casgn`) disables itself below that version. The signature-based
+        # instance-variable path (`on_def`) predates this and is not gated.
+        minimum_target_sorbet_static_version "0.6.13304"
 
         MSG = "Unnecessary T.let. The instance variable type is inferred from the signature."
         MSG_CONSTRUCTOR = "Unnecessary T.let. The constant type is inferred from the constructor."
@@ -89,6 +98,10 @@ module RuboCop
         end
 
         def on_casgn(node)
+          # The constructor inference this path relies on requires Sorbet
+          # 0.6.13304+ (see `minimum_target_sorbet_static_version` above).
+          return unless enabled_for_sorbet_static_version?
+
           # In `typed: strict` files Sorbet requires `T.let` on constants that
           # are not assigned at class/module/top-level scope (e.g. inside an
           # `if` or block), so removing it there would break typechecking.

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -99,13 +99,7 @@ module RuboCop
         end
 
         def on_casgn(node)
-          # The constructor inference this path relies on requires Sorbet
-          # 0.6.13304+ (see `minimum_target_sorbet_static_version` above).
           return unless enabled_for_sorbet_static_version?
-
-          # In `typed: strict` files Sorbet requires `T.let` on constants that
-          # are not assigned at class/module/top-level scope (e.g. inside an
-          # `if` or block), so removing it there would break typechecking.
           return unless statically_scoped?(node)
 
           t_let_casgn(node) do |tlet_node, value_node, type_node|
@@ -128,8 +122,9 @@ module RuboCop
 
         def constructor_call(node)
           node = node.receiver if node.send_type? && node.method?(:freeze)
-          # `Foo.new { ... }` is a block node wrapping the `.new` send.
-          node = node.send_node if node&.block_type?
+          # `Foo.new { ... }` wraps the `.new` send in a block node; this
+          # includes numbered-parameter (`{ _1 }`) and `it` block forms.
+          node = node.send_node if node&.any_block_type?
           return unless node&.send_type? && node.method?(:new)
           return unless node.receiver&.const_type?
 
@@ -149,6 +144,7 @@ module RuboCop
           source
             .gsub(/\s+/, " ")              # collapse all whitespace to single spaces
             .gsub(/,\s*([)\]\}])/, "\\1")  # remove trailing commas before closing delimiters
+            .gsub(/,\s*/, ", ")            # normalize to a single space after commas
             .gsub(/\(\s*/, "(")            # remove space after (
             .gsub(/\s*\)/, ")")            # remove space before )
             .gsub(/\[\s*/, "[")            # remove space after [

--- a/lib/rubocop/cop/sorbet/redundant_t_let.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let.rb
@@ -86,6 +86,11 @@ module RuboCop
         end
 
         def on_casgn(node)
+          # In `typed: strict` files Sorbet requires `T.let` on constants that
+          # are not assigned at class/module/top-level scope (e.g. inside an
+          # `if` or block), so removing it there would break typechecking.
+          return unless statically_scoped?(node)
+
           t_let_casgn(node) do |tlet_node, value_node, type_node|
             next unless type_node.const_type?
 
@@ -103,6 +108,12 @@ module RuboCop
         end
 
         private
+
+        def statically_scoped?(node)
+          ancestor = node.parent
+          ancestor = ancestor.parent if ancestor&.begin_type?
+          ancestor.nil? || ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
+        end
 
         def constructor_call(node)
           node = node.receiver if node.send_type? && node.method?(:freeze)

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -124,12 +124,8 @@ module RuboCop
           return unless statically_scoped?(node)
 
           t_let_with_literal_and_class?(node) do |value_node, class_name|
-            # A frozen literal (`/foo/.freeze`) is a `send` whose inference is
-            # version-gated; a bare literal is inferable on any Sorbet.
-            frozen = value_node.send_type?
-            next if frozen && !enabled_for_sorbet_static_version?
-
-            literal_node = frozen ? value_node.receiver : value_node
+            literal_node = inferable_literal_node(value_node)
+            next unless literal_node
             next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
 
             register_offense(node, value_node, class_name)
@@ -141,22 +137,24 @@ module RuboCop
             frozen = value_node.send_type?
             array_node = frozen ? value_node.receiver : value_node
             next unless inferable_array?(array_node)
-
-            if frozen
-              # A frozen array infers as a tuple, a subtype of the annotated
-              # T::Array, so the annotation is redundant.
-              next unless t_array_type?(type_node)
-            else
-              # An unfrozen array infers as T::Array[<element type>]; only
-              # redundant when the annotation is exactly that type.
-              next unless inferred_array_type(array_node) == normalize(type_node.source).delete_prefix("::")
-            end
+            next unless redundant_array_annotation?(array_node, type_node, frozen: frozen)
 
             register_offense(node, value_node, :Array)
           end
         end
 
         private
+
+        # Returns the underlying literal when its inference is supported by the
+        # target Sorbet version. Bare literals are always supported; for example,
+        # `3` returns its integer node. Frozen literals are version-gated, so
+        # `/foo/.freeze` returns its regexp node only for supported targets.
+        def inferable_literal_node(value_node)
+          return value_node unless value_node.send_type?
+          return unless enabled_for_sorbet_static_version?
+
+          value_node.receiver
+        end
 
         def register_offense(node, value_node, type)
           t_let_node = node.children[2]
@@ -180,6 +178,16 @@ module RuboCop
               ARRAY_ELEMENT_TYPES.include?(child.type)
             end
           end
+        end
+
+        # Returns whether Sorbet's inferred array type makes the annotation
+        # redundant. A frozen `[:a].freeze` infers as a tuple compatible with
+        # any `T::Array[...]`; an unfrozen `[:a]` must infer exactly the
+        # annotated type, such as `T::Array[Symbol]`.
+        def redundant_array_annotation?(array_node, type_node, frozen:)
+          return t_array_type?(type_node) if frozen
+
+          inferred_array_type(array_node) == normalize(type_node.source).delete_prefix("::")
         end
 
         # `T::Array[...]` (with or without a leading `::`)

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -66,7 +66,16 @@ module RuboCop
       #   count = T.let(0, Integer)
       class RedundantTLetForLiteral < Base
         include ConstantScope
+        include TargetSorbetVersion
         extend AutoCorrector
+
+        # The frozen-literal and literal-array inference the newer cases rely on
+        # was added up to Sorbet 0.6.13304 (frozen regexp via freeze-transparent
+        # inference; literal arrays via constant tuple inference). Flagging them
+        # against an older Sorbet could remove a `T.let` it still requires, so
+        # those paths disable themselves below that version. Bare simple
+        # literals (`T.let(3, Integer)`) predate this and are not gated.
+        minimum_target_sorbet_static_version "0.6.13304"
 
         MSG = "Redundant `T.let` for %{type} literal. Sorbet can infer this type automatically."
 
@@ -83,12 +92,15 @@ module RuboCop
         # Element node types allowed inside an inferable array literal. These
         # are the literals whose class Sorbet reflects into the array's element
         # type (regexps and ranges, by contrast, degrade the array to
-        # `T.untyped` and so are excluded).
-        ARRAY_ELEMENT_TYPES = [:str, :sym, :int, :float, :true, :false, :nil].freeze
+        # `T.untyped` and so are excluded). Interpolated strings (`dstr`) are
+        # included: Sorbet infers them as `String`, so an array of them infers
+        # the same as an array of plain string literals.
+        ARRAY_ELEMENT_TYPES = [:dstr, :str, :sym, :int, :float, :true, :false, :nil].freeze
 
         # Element node types whose inferred class is unambiguous, used to derive
         # the element type of an unfrozen array literal.
         ELEMENT_TYPE_TO_CLASS = {
+          dstr: "String",
           float: "Float",
           int: "Integer",
           str: "String",
@@ -112,11 +124,21 @@ module RuboCop
           return unless statically_scoped?(node)
 
           t_let_with_literal_and_class?(node) do |value_node, class_name|
-            literal_node = value_node.send_type? ? value_node.receiver : value_node
+            # A frozen regexp (`/foo/.freeze`) is a `send`; its inference
+            # requires Sorbet 0.6.13304+. A bare literal is inferable on any
+            # version, so only the frozen case is gated.
+            frozen = value_node.send_type?
+            next if frozen && !enabled_for_sorbet_static_version?
+
+            literal_node = frozen ? value_node.receiver : value_node
             next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
 
             register_offense(node, value_node, class_name)
           end
+
+          # Literal-array inference requires Sorbet 0.6.13304+ (see
+          # `minimum_target_sorbet_static_version` above).
+          return unless enabled_for_sorbet_static_version?
 
           t_let_with_array?(node) do |value_node, type_node|
             frozen = value_node.send_type?

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -105,6 +105,11 @@ module RuboCop
         PATTERN
 
         def on_casgn(node)
+          # In `typed: strict` files Sorbet requires `T.let` on constants that
+          # are not assigned at class/module/top-level scope (e.g. inside an
+          # `if` or block), so removing it there would break typechecking.
+          return unless statically_scoped?(node)
+
           t_let_with_literal_and_class?(node) do |value_node, class_name|
             literal_node = value_node.send_type? ? value_node.receiver : value_node
             next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
@@ -175,6 +180,15 @@ module RuboCop
 
         def normalize(source)
           source.gsub(/\s+/, "")
+        end
+
+        # A constant is statically scoped when it is assigned directly in a
+        # class, module, or top-level body, rather than nested inside a
+        # conditional, loop, block, or method.
+        def statically_scoped?(node)
+          ancestor = node.parent
+          ancestor = ancestor.parent if ancestor&.begin_type?
+          ancestor.nil? || ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -6,15 +6,25 @@ module RuboCop
   module Cop
     module Sorbet
       # Checks for redundant `T.let` declarations where the first argument
-      # is a simple literal (not a collection like Array or Hash) and the
-      # second argument is the matching class name. Sorbet can infer the types
-      # of simple literals automatically, so wrapping them in `T.let` is
-      # redundant.
+      # is a literal whose type Sorbet can infer automatically, so wrapping
+      # it in `T.let` is redundant.
       #
-      # Regexp literals are the only simple literals whose inference survives
-      # a `.freeze` call (Sorbet 0.6.13304+), so `T.let(/foo/.freeze, Regexp)`
-      # is also redundant. Other frozen literals (e.g. `"hello".freeze`) are
-      # not inferred and still require `T.let`.
+      # Simple literals (strings, symbols, integers, floats, regexps) infer as
+      # their own class. Regexp literals are the only simple literals whose
+      # inference survives a `.freeze` call (Sorbet 0.6.13304+), so
+      # `T.let(/foo/.freeze, Regexp)` is also redundant; other frozen simple
+      # literals (e.g. `"hello".freeze`) are not inferred and still need `T.let`.
+      #
+      # Array literals of simple literals are also inferred:
+      #
+      # * A frozen array (`[...].freeze`) infers as a fixed-size tuple, which is
+      #   a subtype of the annotated `T::Array`, so the annotation is redundant.
+      # * An unfrozen array infers as `T::Array[<element type>]`. It is only
+      #   flagged when that inferred type matches the annotation exactly, to
+      #   avoid silently widening (e.g. `["a", nil]` infers a nilable element).
+      #
+      # Hashes are excluded: Sorbet infers hash literals as `T.untyped`, so the
+      # annotation is required.
       #
       # @example
       #   # bad
@@ -24,6 +34,8 @@ module RuboCop
       #   PATTERN = T.let(/foo/, Regexp)
       #   FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
       #   STATUS = T.let(:active, Symbol)
+      #   SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
+      #   NAMES = T.let(["alice", "bob"], T::Array[String])
       #
       #   # good
       #   MAX_RETRIES = 3
@@ -32,14 +44,17 @@ module RuboCop
       #   PATTERN = /foo/
       #   FROZEN_PATTERN = /foo/.freeze
       #   STATUS = :active
+      #   SHELLS = [:bash, :zsh].freeze
+      #   NAMES = ["alice", "bob"]
       #
-      #   # good — non-regexp frozen literals are not inferred
+      #   # good — non-regexp frozen simple literals are not inferred
       #   GREETING = T.let("hello".freeze, String)
       #
-      #   # good — collections still need T.let (array literals would infer
-      #   # as fixed-size tuple types rather than the annotated T::Array)
-      #   NAMES = T.let(["alice", "bob"], T::Array[String])
+      #   # good — hash literals are inferred as T.untyped
       #   OPTIONS = T.let({ verbose: true }, T::Hash[Symbol, T::Boolean])
+      #
+      #   # good — unfrozen array whose annotation is wider than the inferred type
+      #   NAMES = T.let(["alice", "bob"], T::Array[T.nilable(String)])
       #
       #   # good — type is not the literal's own class
       #   value = T.let("hello", T.nilable(String))
@@ -54,12 +69,7 @@ module RuboCop
 
         MSG = "Redundant `T.let` for %{type} literal. Sorbet can infer this type automatically."
 
-        # @!method t_let_with_literal_and_class?(node)
-        def_node_matcher :t_let_with_literal_and_class?, <<~PATTERN
-          (casgn _ _ (send (const nil? :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
-        PATTERN
-
-        # Maps AST literal node types to the class name Sorbet would infer.
+        # Simple literal node types Sorbet infers, mapped to the class name.
         LITERAL_TYPE_TO_CLASS = {
           dstr: :String,
           float: :Float,
@@ -69,16 +79,102 @@ module RuboCop
           sym: :Symbol,
         }.freeze
 
+        # Element node types allowed inside an inferable array literal. These
+        # are the literals whose class Sorbet reflects into the array's element
+        # type (regexps and ranges, by contrast, degrade the array to
+        # `T.untyped` and so are excluded).
+        ARRAY_ELEMENT_TYPES = [:str, :sym, :int, :float, :true, :false, :nil].freeze
+
+        # Element node types whose inferred class is unambiguous, used to derive
+        # the element type of an unfrozen array literal.
+        ELEMENT_TYPE_TO_CLASS = {
+          float: "Float",
+          int: "Integer",
+          str: "String",
+          sym: "Symbol",
+        }.freeze
+
+        # @!method t_let_with_literal_and_class?(node)
+        def_node_matcher :t_let_with_literal_and_class?, <<~PATTERN
+          (casgn _ _ (send (const nil? :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
+        PATTERN
+
+        # @!method t_let_with_array?(node)
+        def_node_matcher :t_let_with_array?, <<~PATTERN
+          (casgn _ _ (send (const nil? :T) :let ${array (send array :freeze)} $_))
+        PATTERN
+
         def on_casgn(node)
           t_let_with_literal_and_class?(node) do |value_node, class_name|
             literal_node = value_node.send_type? ? value_node.receiver : value_node
             next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
 
-            t_let_node = node.children[2]
-            add_offense(t_let_node, message: format(MSG, type: class_name)) do |corrector|
-              corrector.replace(t_let_node, value_node.source)
+            register_offense(node, value_node, class_name)
+          end
+
+          t_let_with_array?(node) do |value_node, type_node|
+            frozen = value_node.send_type?
+            array_node = frozen ? value_node.receiver : value_node
+            next unless inferable_array?(array_node)
+
+            if frozen
+              # A frozen literal array infers as a tuple, a subtype of the
+              # annotated T::Array, so the annotation is redundant.
+              next unless t_array_type?(type_node)
+            else
+              # An unfrozen literal array infers as T::Array[<element type>];
+              # only redundant when the annotation is exactly that type.
+              next unless inferred_array_type(array_node) == normalize(type_node.source)
+            end
+
+            register_offense(node, value_node, :Array)
+          end
+        end
+
+        private
+
+        def register_offense(node, value_node, type)
+          t_let_node = node.children[2]
+          add_offense(t_let_node, message: format(MSG, type: type)) do |corrector|
+            corrector.replace(t_let_node, value_node.source)
+          end
+        end
+
+        # An array literal is inferable only when every element is one of the
+        # simple literals Sorbet reflects into the element type (or a nested
+        # inferable array). Empty arrays are excluded: they infer as
+        # `T::Array[T.untyped]` and so still need the annotation.
+        def inferable_array?(node)
+          return false unless node.array_type?
+          return false if node.children.empty?
+
+          node.children.all? do |child|
+            if child.array_type?
+              inferable_array?(child)
+            else
+              ARRAY_ELEMENT_TYPES.include?(child.type)
             end
           end
+        end
+
+        # `T::Array[...]`
+        def t_array_type?(node)
+          node.send_type? && node.method?(:[]) &&
+            node.receiver&.source == "T::Array"
+        end
+
+        # The type Sorbet infers for an unfrozen array literal, or nil when the
+        # element types are not uniform enough to render deterministically
+        # (mixed classes, booleans, nils and nested arrays are left alone).
+        def inferred_array_type(node)
+          classes = node.children.map { |child| ELEMENT_TYPE_TO_CLASS[child.type] }
+          return unless classes.all? && classes.uniq.size == 1
+
+          "T::Array[#{classes.first}]"
+        end
+
+        def normalize(source)
+          source.gsub(/\s+/, "")
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -67,6 +67,7 @@ module RuboCop
       class RedundantTLetForLiteral < Base
         include ConstantScope
         include TargetSorbetVersion
+        include TLetCorrection
         extend AutoCorrector
 
         # The frozen-literal and literal-array inference the newer cases rely on
@@ -164,7 +165,7 @@ module RuboCop
         def register_offense(node, value_node, type)
           t_let_node = node.children[2]
           add_offense(t_let_node, message: format(MSG, type: type)) do |corrector|
-            corrector.replace(t_let_node, value_node.source)
+            replace_t_let(corrector, t_let_node, value_node)
           end
         end
 

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -11,12 +11,18 @@ module RuboCop
       # of simple literals automatically, so wrapping them in `T.let` is
       # redundant.
       #
+      # Regexp literals are the only simple literals whose inference survives
+      # a `.freeze` call (Sorbet 0.6.13304+), so `T.let(/foo/.freeze, Regexp)`
+      # is also redundant. Other frozen literals (e.g. `"hello".freeze`) are
+      # not inferred and still require `T.let`.
+      #
       # @example
       #   # bad
       #   MAX_RETRIES = T.let(3, Integer)
       #   GREETING = T.let("hello", String)
       #   RATE = T.let(1.5, Float)
       #   PATTERN = T.let(/foo/, Regexp)
+      #   FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
       #   STATUS = T.let(:active, Symbol)
       #
       #   # good
@@ -24,9 +30,14 @@ module RuboCop
       #   GREETING = "hello"
       #   RATE = 1.5
       #   PATTERN = /foo/
+      #   FROZEN_PATTERN = /foo/.freeze
       #   STATUS = :active
       #
-      #   # good — collections still need T.let
+      #   # good — non-regexp frozen literals are not inferred
+      #   GREETING = T.let("hello".freeze, String)
+      #
+      #   # good — collections still need T.let (array literals would infer
+      #   # as fixed-size tuple types rather than the annotated T::Array)
       #   NAMES = T.let(["alice", "bob"], T::Array[String])
       #   OPTIONS = T.let({ verbose: true }, T::Hash[Symbol, T::Boolean])
       #
@@ -45,7 +56,7 @@ module RuboCop
 
         # @!method t_let_with_literal_and_class?(node)
         def_node_matcher :t_let_with_literal_and_class?, <<~PATTERN
-          (casgn _ _ (send (const nil? :T) :let $literal? (const nil? $_)))
+          (casgn _ _ (send (const nil? :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
         PATTERN
 
         # Maps AST literal node types to the class name Sorbet would infer.
@@ -59,12 +70,13 @@ module RuboCop
         }.freeze
 
         def on_casgn(node)
-          t_let_with_literal_and_class?(node) do |literal_node, class_name|
+          t_let_with_literal_and_class?(node) do |value_node, class_name|
+            literal_node = value_node.send_type? ? value_node.receiver : value_node
             next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
 
             t_let_node = node.children[2]
             add_offense(t_let_node, message: format(MSG, type: class_name)) do |corrector|
-              corrector.replace(t_let_node, literal_node.source)
+              corrector.replace(t_let_node, value_node.source)
             end
           end
         end

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -81,8 +81,10 @@ module RuboCop
         MSG = "Redundant `T.let` for %{type} literal. Sorbet can infer this type automatically."
 
         # Simple literal node types Sorbet infers, mapped to the class name.
+        # Interpolated strings/symbols (`dstr`/`dsym`) infer as `String`/`Symbol`.
         LITERAL_TYPE_TO_CLASS = {
           dstr: :String,
+          dsym: :Symbol,
           float: :Float,
           int: :Integer,
           regexp: :Regexp,
@@ -90,18 +92,18 @@ module RuboCop
           sym: :Symbol,
         }.freeze
 
-        # Element node types allowed inside an inferable array literal. These
-        # are the literals whose class Sorbet reflects into the array's element
-        # type (regexps and ranges, by contrast, degrade the array to
-        # `T.untyped` and so are excluded). Interpolated strings (`dstr`) are
-        # included: Sorbet infers them as `String`, so an array of them infers
-        # the same as an array of plain string literals.
-        ARRAY_ELEMENT_TYPES = [:dstr, :str, :sym, :int, :float, :true, :false, :nil].freeze
+        # Element node types allowed inside an inferable array literal: the
+        # literals whose class Sorbet reflects into the array's element type.
+        # Regexps and ranges, by contrast, degrade the array to `T.untyped`, so
+        # they are excluded. Interpolated strings/symbols (`dstr`/`dsym`) infer
+        # as `String`/`Symbol`, the same as their plain literal forms.
+        ARRAY_ELEMENT_TYPES = [:dstr, :dsym, :str, :sym, :int, :float, :true, :false, :nil].freeze
 
         # Element node types whose inferred class is unambiguous, used to derive
         # the element type of an unfrozen array literal.
         ELEMENT_TYPE_TO_CLASS = {
           dstr: "String",
+          dsym: "Symbol",
           float: "Float",
           int: "Integer",
           str: "String",
@@ -119,15 +121,11 @@ module RuboCop
         PATTERN
 
         def on_casgn(node)
-          # In `typed: strict` files Sorbet requires `T.let` on constants that
-          # are not assigned at class/module/top-level scope (e.g. inside an
-          # `if` or block), so removing it there would break typechecking.
           return unless statically_scoped?(node)
 
           t_let_with_literal_and_class?(node) do |value_node, class_name|
-            # A frozen regexp (`/foo/.freeze`) is a `send`; its inference
-            # requires Sorbet 0.6.13304+. A bare literal is inferable on any
-            # version, so only the frozen case is gated.
+            # A frozen literal (`/foo/.freeze`) is a `send` whose inference is
+            # version-gated; a bare literal is inferable on any Sorbet.
             frozen = value_node.send_type?
             next if frozen && !enabled_for_sorbet_static_version?
 
@@ -137,8 +135,6 @@ module RuboCop
             register_offense(node, value_node, class_name)
           end
 
-          # Literal-array inference requires Sorbet 0.6.13304+ (see
-          # `minimum_target_sorbet_static_version` above).
           return unless enabled_for_sorbet_static_version?
 
           t_let_with_array?(node) do |value_node, type_node|
@@ -147,13 +143,13 @@ module RuboCop
             next unless inferable_array?(array_node)
 
             if frozen
-              # A frozen literal array infers as a tuple, a subtype of the
-              # annotated T::Array, so the annotation is redundant.
+              # A frozen array infers as a tuple, a subtype of the annotated
+              # T::Array, so the annotation is redundant.
               next unless t_array_type?(type_node)
             else
-              # An unfrozen literal array infers as T::Array[<element type>];
-              # only redundant when the annotation is exactly that type.
-              next unless inferred_array_type(array_node) == normalize(type_node.source)
+              # An unfrozen array infers as T::Array[<element type>]; only
+              # redundant when the annotation is exactly that type.
+              next unless inferred_array_type(array_node) == normalize(type_node.source).delete_prefix("::")
             end
 
             register_offense(node, value_node, :Array)

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -65,6 +65,7 @@ module RuboCop
       #   # good — local variables may need T.let so Sorbet allows reassignment
       #   count = T.let(0, Integer)
       class RedundantTLetForLiteral < Base
+        include ConstantScope
         extend AutoCorrector
 
         MSG = "Redundant `T.let` for %{type} literal. Sorbet can infer this type automatically."
@@ -96,12 +97,12 @@ module RuboCop
 
         # @!method t_let_with_literal_and_class?(node)
         def_node_matcher :t_let_with_literal_and_class?, <<~PATTERN
-          (casgn _ _ (send (const nil? :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
+          (casgn _ _ (send (const {nil? cbase} :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
         PATTERN
 
         # @!method t_let_with_array?(node)
         def_node_matcher :t_let_with_array?, <<~PATTERN
-          (casgn _ _ (send (const nil? :T) :let ${array (send array :freeze)} $_))
+          (casgn _ _ (send (const {nil? cbase} :T) :let ${array (send array :freeze)} $_))
         PATTERN
 
         def on_casgn(node)
@@ -162,10 +163,10 @@ module RuboCop
           end
         end
 
-        # `T::Array[...]`
+        # `T::Array[...]` (with or without a leading `::`)
         def t_array_type?(node)
           node.send_type? && node.method?(:[]) &&
-            node.receiver&.source == "T::Array"
+            node.receiver&.source&.delete_prefix("::") == "T::Array"
         end
 
         # The type Sorbet infers for an unfrozen array literal, or nil when the
@@ -178,17 +179,11 @@ module RuboCop
           "T::Array[#{classes.first}]"
         end
 
+        # Strips whitespace and any trailing comma before a closing delimiter,
+        # so a multi-line annotation (`T::Array[\n  String,\n]`) still compares
+        # equal to the rendered inferred type.
         def normalize(source)
-          source.gsub(/\s+/, "")
-        end
-
-        # A constant is statically scoped when it is assigned directly in a
-        # class, module, or top-level body, rather than nested inside a
-        # conditional, loop, block, or method.
-        def statically_scoped?(node)
-          ancestor = node.parent
-          ancestor = ancestor.parent if ancestor&.begin_type?
-          ancestor.nil? || ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
+          source.gsub(/\s+/, "").gsub(/,([)\]}])/, '\1')
         end
       end
     end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -4,6 +4,7 @@ require_relative "sorbet/mixin/target_sorbet_version"
 require_relative "sorbet/mixin/t_enum"
 require_relative "sorbet/mixin/signature_help"
 require_relative "sorbet/mixin/constant_scope"
+require_relative "sorbet/mixin/t_let_correction"
 
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/block_method_definition"

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -3,6 +3,7 @@
 require_relative "sorbet/mixin/target_sorbet_version"
 require_relative "sorbet/mixin/t_enum"
 require_relative "sorbet/mixin/signature_help"
+require_relative "sorbet/mixin/constant_scope"
 
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/block_method_definition"

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1218,15 +1218,25 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | <<next>> | -
 
 Checks for redundant `T.let` declarations where the first argument
-is a simple literal (not a collection like Array or Hash) and the
-second argument is the matching class name. Sorbet can infer the types
-of simple literals automatically, so wrapping them in `T.let` is
-redundant.
+is a literal whose type Sorbet can infer automatically, so wrapping
+it in `T.let` is redundant.
 
-Regexp literals are the only simple literals whose inference survives
-a `.freeze` call (Sorbet 0.6.13304+), so `T.let(/foo/.freeze, Regexp)`
-is also redundant. Other frozen literals (e.g. `"hello".freeze`) are
-not inferred and still require `T.let`.
+Simple literals (strings, symbols, integers, floats, regexps) infer as
+their own class. Regexp literals are the only simple literals whose
+inference survives a `.freeze` call (Sorbet 0.6.13304+), so
+`T.let(/foo/.freeze, Regexp)` is also redundant; other frozen simple
+literals (e.g. `"hello".freeze`) are not inferred and still need `T.let`.
+
+Array literals of simple literals are also inferred:
+
+* A frozen array (`[...].freeze`) infers as a fixed-size tuple, which is
+  a subtype of the annotated `T::Array`, so the annotation is redundant.
+* An unfrozen array infers as `T::Array[<element type>]`. It is only
+  flagged when that inferred type matches the annotation exactly, to
+  avoid silently widening (e.g. `["a", nil]` infers a nilable element).
+
+Hashes are excluded: Sorbet infers hash literals as `T.untyped`, so the
+annotation is required.
 
 ### Examples
 
@@ -1238,6 +1248,8 @@ RATE = T.let(1.5, Float)
 PATTERN = T.let(/foo/, Regexp)
 FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
 STATUS = T.let(:active, Symbol)
+SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
+NAMES = T.let(["alice", "bob"], T::Array[String])
 
 # good
 MAX_RETRIES = 3
@@ -1246,14 +1258,17 @@ RATE = 1.5
 PATTERN = /foo/
 FROZEN_PATTERN = /foo/.freeze
 STATUS = :active
+SHELLS = [:bash, :zsh].freeze
+NAMES = ["alice", "bob"]
 
-# good — non-regexp frozen literals are not inferred
+# good — non-regexp frozen simple literals are not inferred
 GREETING = T.let("hello".freeze, String)
 
-# good — collections still need T.let (array literals would infer
-# as fixed-size tuple types rather than the annotated T::Array)
-NAMES = T.let(["alice", "bob"], T::Array[String])
+# good — hash literals are inferred as T.untyped
 OPTIONS = T.let({ verbose: true }, T::Hash[Symbol, T::Boolean])
+
+# good — unfrozen array whose annotation is wider than the inferred type
+NAMES = T.let(["alice", "bob"], T::Array[T.nilable(String)])
 
 # good — type is not the literal's own class
 value = T.let("hello", T.nilable(String))

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1166,7 +1166,16 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | <<next>> | -
 
-Prevents unnecessary `T.let` in `initialize` methods. When a signature parameter is assigned to an instance variable, the type is inferred automatically.
+Prevents unnecessary `T.let` where Sorbet infers the type automatically.
+
+When a signature parameter is assigned to an instance variable in
+`initialize`, the type is inferred from the signature.
+
+When a constant is assigned a constructor call (`.new`), optionally
+followed by `.freeze` (Sorbet 0.6.13304+), the type is inferred from
+the class being instantiated. Generic classes (e.g. `Set`) are
+excluded: Sorbet infers their constructor calls as applied types like
+`T::Set[T.untyped]`, so an annotation is still required.
 
 ### Examples
 
@@ -1188,6 +1197,18 @@ sig { params(a: Integer) }
 def initialize(a)
   @a = T.let(a, T.any(Integer, String))
 end
+
+# bad
+DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+
+# good
+DEFAULT_PATH = Pathname.new("/usr/local").freeze
+
+# good — generic classes are not inferred, so T.let is required
+LICENSES = T.let(Set.new(["mit"]).freeze, T::Set[String])
+
+# good — instance variables are only inferred from signature parameters
+@path = T.let(Pathname.new("/usr/local"), Pathname)
 ```
 
 ## Sorbet/RedundantTLetForLiteral
@@ -1202,6 +1223,11 @@ second argument is the matching class name. Sorbet can infer the types
 of simple literals automatically, so wrapping them in `T.let` is
 redundant.
 
+Regexp literals are the only simple literals whose inference survives
+a `.freeze` call (Sorbet 0.6.13304+), so `T.let(/foo/.freeze, Regexp)`
+is also redundant. Other frozen literals (e.g. `"hello".freeze`) are
+not inferred and still require `T.let`.
+
 ### Examples
 
 ```ruby
@@ -1210,6 +1236,7 @@ MAX_RETRIES = T.let(3, Integer)
 GREETING = T.let("hello", String)
 RATE = T.let(1.5, Float)
 PATTERN = T.let(/foo/, Regexp)
+FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
 STATUS = T.let(:active, Symbol)
 
 # good
@@ -1217,9 +1244,14 @@ MAX_RETRIES = 3
 GREETING = "hello"
 RATE = 1.5
 PATTERN = /foo/
+FROZEN_PATTERN = /foo/.freeze
 STATUS = :active
 
-# good — collections still need T.let
+# good — non-regexp frozen literals are not inferred
+GREETING = T.let("hello".freeze, String)
+
+# good — collections still need T.let (array literals would infer
+# as fixed-size tuple types rather than the annotated T::Array)
 NAMES = T.let(["alice", "bob"], T::Array[String])
 OPTIONS = T.let({ verbose: true }, T::Hash[Symbol, T::Boolean])
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1164,7 +1164,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | <<next>> | -
+Enabled | Yes | Yes (Unsafe) | <<next>> | -
 
 Prevents unnecessary `T.let` where Sorbet infers the type automatically.
 
@@ -1215,7 +1215,7 @@ LICENSES = T.let(Set.new(["mit"]).freeze, T::Set[String])
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | <<next>> | -
+Enabled | Yes | Yes (Unsafe) | <<next>> | -
 
 Checks for redundant `T.let` declarations where the first argument
 is a literal whose type Sorbet can infer automatically, so wrapping

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -88,6 +88,18 @@ module RuboCop
           RUBY
         end
 
+        # An interpolated symbol (`dsym`) infers as `Symbol`, like a plain one.
+        def test_registers_offense_for_interpolated_symbol
+          assert_offense(<<~RUBY)
+            STATUS = T.let(:"active_\#{n}", Symbol)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Symbol")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            STATUS = :"active_\#{n}"
+          RUBY
+        end
+
         # Regexp literals
 
         def test_registers_offense_for_regexp_literal
@@ -202,6 +214,19 @@ module RuboCop
 
           assert_correction(<<~RUBY)
             NAMES = ["alice", "\#{prefix}bob"]
+          RUBY
+        end
+
+        # Interpolated symbols (`dsym`) infer as `Symbol`, so an array of them
+        # (e.g. a `%I[...]` word array) infers like an array of plain symbols.
+        def test_registers_offense_for_interpolated_symbol_array
+          assert_offense(<<~RUBY)
+            KEYS = T.let(%I[key_\#{a} key_\#{b}], T::Array[Symbol])
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            KEYS = %I[key_\#{a} key_\#{b}]
           RUBY
         end
 
@@ -414,6 +439,27 @@ module RuboCop
             MSG = <<~MESSAGE
                 hello world
               MESSAGE
+          RUBY
+        end
+
+        # A frozen array can hold more than one heredoc; every body must be
+        # reattached, in source order, after the marker line.
+        def test_registers_offense_for_frozen_array_of_multiple_heredocs
+          assert_offense(<<~RUBY)
+            MESSAGES = T.let([<<~A, <<~B].freeze, T::Array[String])
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+              first
+            A
+              second
+            B
+          RUBY
+
+          assert_correction(<<~RUBY)
+            MESSAGES = [<<~A, <<~B].freeze
+              first
+            A
+              second
+            B
           RUBY
         end
 
@@ -672,6 +718,19 @@ module RuboCop
 
           assert_correction(<<~RUBY)
             SHELLS = [:bash, :zsh].freeze
+          RUBY
+        end
+
+        # An unfrozen array with a fully-qualified `::T::Array` annotation is
+        # flagged too, matching the frozen cbase case above.
+        def test_registers_offense_for_unfrozen_array_with_cbase_annotation
+          assert_offense(<<~RUBY)
+            NAMES = T.let(["alice", "bob"], ::T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = ["alice", "bob"]
           RUBY
         end
 

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -436,6 +436,48 @@ module RuboCop
           RUBY
         end
 
+        # `T.let` may be called with a fully-qualified `::T`.
+        def test_registers_offense_for_cbase_t_let
+          assert_offense(<<~RUBY)
+            MAX = ::T.let(3, Integer)
+                  ^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            MAX = 3
+          RUBY
+        end
+
+        # Both `::T.let` and a fully-qualified `::T::Array` annotation are handled.
+        def test_registers_offense_for_cbase_t_and_t_array
+          assert_offense(<<~RUBY)
+            SHELLS = ::T.let([:bash, :zsh].freeze, ::T::Array[Symbol])
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            SHELLS = [:bash, :zsh].freeze
+          RUBY
+        end
+
+        # A multi-line annotation with a trailing comma still compares equal to
+        # the inferred `T::Array[String]`.
+        def test_registers_offense_for_unfrozen_array_multiline_annotation
+          assert_offense(<<~RUBY)
+            NAMES = T.let(
+                    ^^^^^^ #{format(MSG, type: "Array")}
+              ["alice", "bob"],
+              T::Array[
+                String,
+              ],
+            )
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = ["alice", "bob"]
+          RUBY
+        end
+
         private
 
         def target_cop

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -235,6 +235,76 @@ module RuboCop
           RUBY
         end
 
+        # Autocorrect safety illustrations
+        #
+        # These cases document why the cop is `SafeAutoCorrect: false`. The
+        # correction is always type-sound at the definition (a frozen literal
+        # array infers as a tuple, which is a subtype of the annotated
+        # `T::Array`), but it changes the constant's inferred type from
+        # `T::Array` to a tuple, and that can break typechecking at a consumer
+        # the cop cannot see. The cop still registers and corrects these — the
+        # tests capture that, so the hazard is explicit rather than silent.
+
+        # After correction `CATEGORIES` infers as `[String, String]`. In a
+        # `typed: strong` consumer, `flatten` over the tuple yields
+        # `T.untyped`, which is an error there — so a green typecheck can turn
+        # red even though the cop's edit looks innocuous.
+        def test_autocorrect_narrows_frozen_array_to_tuple_unsafe_under_typed_strong
+          assert_offense(<<~RUBY)
+            # typed: strong
+            class Report
+              CATEGORIES = T.let(["a", "b"].freeze, T::Array[String])
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+
+              def all
+                [CATEGORIES].flatten
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # typed: strong
+            class Report
+              CATEGORIES = ["a", "b"].freeze
+
+              def all
+                [CATEGORIES].flatten
+              end
+            end
+          RUBY
+        end
+
+        # After correction `BASIC` infers as `[Symbol, Symbol]`. A local seeded
+        # from it and reassigned in a loop (`acc += ...`) then fails with
+        # "Changing the type of a variable is not permitted in loops and
+        # blocks", because the tuple type cannot widen to `T::Array[Symbol]`.
+        def test_autocorrect_narrows_frozen_array_to_tuple_unsafe_for_loop_accumulator
+          assert_offense(<<~RUBY)
+            class Builder
+              BASIC = T.let([:a, :b].freeze, T::Array[Symbol])
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+
+              def build
+                acc = BASIC
+                [1, 2].each { |n| acc += [n.to_s.to_sym] }
+                acc
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            class Builder
+              BASIC = [:a, :b].freeze
+
+              def build
+                acc = BASIC
+                [1, 2].each { |n| acc += [n.to_s.to_sym] }
+                acc
+              end
+            end
+          RUBY
+        end
+
         # Non-simple literals
 
         def test_no_offense_for_hash_literal

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -379,6 +379,26 @@ module RuboCop
           RUBY
         end
 
+        def test_registers_offense_for_multiline_heredoc_string
+          assert_offense(<<~RUBY)
+            MSG = T.let(
+                  ^^^^^^ #{format(MSG, type: "String")}
+              <<~MESSAGE,
+                hello world
+              MESSAGE
+              String
+            )
+          RUBY
+
+          # The heredoc body keeps its original indentation; reindenting it is
+          # Layout/HeredocIndentation's job, not this cop's.
+          assert_correction(<<~RUBY)
+            MSG = <<~MESSAGE
+                hello world
+              MESSAGE
+          RUBY
+        end
+
         def test_no_offense_for_complex_literal
           assert_no_offenses(<<~RUBY)
             VALUE = T.let(1 + 1i, Complex)

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -379,6 +379,24 @@ module RuboCop
           RUBY
         end
 
+        # The closing `)` sits before the heredoc body, so extending the
+        # replaced range past the terminator must not swallow the trailing
+        # comment on the marker line.
+        def test_registers_offense_for_heredoc_string_with_trailing_comment
+          assert_offense(<<~RUBY)
+            MSG = T.let(<<~MESSAGE, String) # keep me
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "String")}
+              hello world
+            MESSAGE
+          RUBY
+
+          assert_correction(<<~RUBY)
+            MSG = <<~MESSAGE # keep me
+              hello world
+            MESSAGE
+          RUBY
+        end
+
         def test_registers_offense_for_multiline_heredoc_string
           assert_offense(<<~RUBY)
             MSG = T.let(

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -11,6 +11,7 @@ module RuboCop
 
         def setup
           @cop = RedundantTLetForLiteral.new
+          stub_sorbet_static_version("0.6.13304")
         end
 
         # String literals
@@ -163,6 +164,44 @@ module RuboCop
 
           assert_correction(<<~RUBY)
             WORDS = %w[a b c].freeze
+          RUBY
+        end
+
+        # Interpolated strings (`dstr`) infer as `String`, so an array of them
+        # infers the same as an array of plain string literals: a frozen one as
+        # a `[String, ...]` tuple, an unfrozen one as `T::Array[String]`.
+        def test_registers_offense_for_frozen_interpolated_string_array
+          assert_offense(<<~RUBY)
+            PATHS = T.let(["\#{root}/a", "\#{root}/b"].freeze, T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATHS = ["\#{root}/a", "\#{root}/b"].freeze
+          RUBY
+        end
+
+        def test_registers_offense_for_unfrozen_interpolated_string_array
+          assert_offense(<<~RUBY)
+            PATHS = T.let(["\#{root}/a", "\#{root}/b"], T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATHS = ["\#{root}/a", "\#{root}/b"]
+          RUBY
+        end
+
+        # A mix of plain and interpolated strings still infers a uniform
+        # `String` element type.
+        def test_registers_offense_for_unfrozen_mixed_plain_and_interpolated_string_array
+          assert_offense(<<~RUBY)
+            NAMES = T.let(["alice", "\#{prefix}bob"], T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = ["alice", "\#{prefix}bob"]
           RUBY
         end
 
@@ -486,6 +525,74 @@ module RuboCop
           RUBY
         end
 
+        # A constant inside `class << self` or a bare `module` body is still
+        # statically scoped, so it is flagged there too.
+        def test_registers_offense_for_array_in_singleton_class
+          assert_offense(<<~RUBY)
+            class Foo
+              class << self
+                NAMES = T.let(["a", "b"].freeze, T::Array[String])
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            class Foo
+              class << self
+                NAMES = ["a", "b"].freeze
+              end
+            end
+          RUBY
+        end
+
+        def test_registers_offense_for_array_in_module
+          assert_offense(<<~RUBY)
+            module Foo
+              NAMES = T.let(["a", "b"].freeze, T::Array[String])
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            module Foo
+              NAMES = ["a", "b"].freeze
+            end
+          RUBY
+        end
+
+        # The frozen-literal and array paths rely on inference added up to
+        # Sorbet 0.6.13304, so they disable themselves on older Sorbet (and when
+        # sorbet-static is absent). Bare simple literals stay flagged regardless.
+        def test_no_offense_for_frozen_and_array_below_minimum_sorbet_version
+          stub_sorbet_static_version("0.6.13303")
+          assert_no_offenses(<<~RUBY)
+            PATTERN = T.let(/foo/.freeze, Regexp)
+            SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
+            NAMES = T.let(["alice", "bob"], T::Array[String])
+          RUBY
+        end
+
+        def test_still_flags_bare_literal_below_minimum_sorbet_version
+          stub_sorbet_static_version("0.6.13303")
+          assert_offense(<<~RUBY)
+            MAX = T.let(3, Integer)
+                  ^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            MAX = 3
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_and_array_without_sorbet_static
+          stub_sorbet_static_version(nil)
+          assert_no_offenses(<<~RUBY)
+            PATTERN = T.let(/foo/.freeze, Regexp)
+            SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
+          RUBY
+        end
+
         def test_no_offense_when_receiver_is_not_t
           assert_no_offenses(<<~RUBY)
             value = SomeModule.let(42, Integer)
@@ -549,6 +656,11 @@ module RuboCop
         end
 
         private
+
+        def stub_sorbet_static_version(version)
+          specs = version ? [Gem::Specification.new("sorbet-static", version)] : []
+          ::Bundler.stubs(:locked_gems).returns(Struct.new(:specs).new(specs))
+        end
 
         def target_cop
           RedundantTLetForLiteral

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -405,6 +405,17 @@ module RuboCop
           RUBY
         end
 
+        # In typed: strict, Sorbet requires T.let on constants assigned inside
+        # a conditional or block, so those must not be flagged.
+        def test_no_offense_for_constant_inside_conditional
+          assert_no_offenses(<<~RUBY)
+            if enabled?
+              PATTERN = T.let(/foo/.freeze, Regexp)
+              NAMES = T.let(["a", "b"].freeze, T::Array[String])
+            end
+          RUBY
+        end
+
         def test_no_offense_when_receiver_is_not_t
           assert_no_offenses(<<~RUBY)
             value = SomeModule.let(42, Integer)

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -131,13 +131,111 @@ module RuboCop
           RUBY
         end
 
-        # Non-simple literals
+        # Array literals
 
-        def test_no_offense_for_array_literal
-          assert_no_offenses(<<~RUBY)
+        def test_registers_offense_for_unfrozen_array_matching_annotation
+          assert_offense(<<~RUBY)
             NAMES = T.let(["alice", "bob"], T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = ["alice", "bob"]
           RUBY
         end
+
+        def test_registers_offense_for_frozen_array
+          assert_offense(<<~RUBY)
+            SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            SHELLS = [:bash, :zsh].freeze
+          RUBY
+        end
+
+        def test_registers_offense_for_frozen_percent_word_array
+          assert_offense(<<~RUBY)
+            WORDS = T.let(%w[a b c].freeze, T::Array[String])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            WORDS = %w[a b c].freeze
+          RUBY
+        end
+
+        # A frozen array infers as a tuple, a subtype of the annotated
+        # T::Array, so it is redundant even when the elements are mixed and the
+        # annotation is wider.
+        def test_registers_offense_for_frozen_mixed_array
+          assert_offense(<<~RUBY)
+            VALUES = T.let([1, "a", nil].freeze, T::Array[T.nilable(T.any(Integer, String))])
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            VALUES = [1, "a", nil].freeze
+          RUBY
+        end
+
+        def test_registers_offense_for_frozen_nested_array
+          assert_offense(<<~RUBY)
+            PAIRS = T.let([["a"], ["b"]].freeze, T::Array[T::Array[String]])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PAIRS = [["a"], ["b"]].freeze
+          RUBY
+        end
+
+        # An unfrozen array whose annotation is wider than the inferred element
+        # type must keep T.let, otherwise the type would be silently narrowed.
+        def test_no_offense_for_unfrozen_array_with_wider_annotation
+          assert_no_offenses(<<~RUBY)
+            NAMES = T.let(["alice", "bob"], T::Array[T.nilable(String)])
+          RUBY
+        end
+
+        # An unfrozen array with mixed element types is left alone: the inferred
+        # element type is a union whose rendering is not verified here.
+        def test_no_offense_for_unfrozen_mixed_array
+          assert_no_offenses(<<~RUBY)
+            VALUES = T.let([1, "a"], T::Array[T.any(Integer, String)])
+          RUBY
+        end
+
+        # Empty arrays infer as T::Array[T.untyped], so the annotation is kept.
+        def test_no_offense_for_empty_frozen_array
+          assert_no_offenses(<<~RUBY)
+            NAMES = T.let([].freeze, T::Array[String])
+          RUBY
+        end
+
+        # Regexp and range elements degrade the array to T.untyped.
+        def test_no_offense_for_frozen_regexp_array
+          assert_no_offenses(<<~RUBY)
+            PATTERNS = T.let([/a/, /b/].freeze, T::Array[Regexp])
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_range_array
+          assert_no_offenses(<<~RUBY)
+            RANGES = T.let([(1..2)].freeze, T::Array[T::Range[Integer]])
+          RUBY
+        end
+
+        # Arrays whose elements are not literals (constants, method calls) are
+        # not reflected into a tuple, so the annotation carries the type.
+        def test_no_offense_for_array_of_constants
+          assert_no_offenses(<<~RUBY)
+            BROKERS = T.let([SEQUOIA, BENNIE].freeze, T::Array[String])
+          RUBY
+        end
+
+        # Non-simple literals
 
         def test_no_offense_for_hash_literal
           assert_no_offenses(<<~RUBY)

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -201,6 +201,31 @@ module RuboCop
           RUBY
         end
 
+        def test_no_offense_for_frozen_symbol
+          assert_no_offenses(<<~RUBY)
+            STATUS = T.let(:active.freeze, Symbol)
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_heredoc
+          assert_no_offenses(<<~RUBY)
+            MSG = T.let(<<~MESSAGE.freeze, String)
+              hello world
+            MESSAGE
+          RUBY
+        end
+
+        def test_registers_offense_for_frozen_regexp_literal
+          assert_offense(<<~RUBY)
+            PATTERN = T.let(/foo/.freeze, Regexp)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Regexp")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATTERN = /foo/.freeze
+          RUBY
+        end
+
         def test_no_offense_for_boolean_true
           assert_no_offenses(<<~RUBY)
             FLAG = T.let(true, T::Boolean)

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -255,6 +255,26 @@ module RuboCop
           RUBY
         end
 
+        # A heredoc argument's body lives on the lines after the `T.let` marker,
+        # so the autocorrection must reattach it instead of dropping it.
+        def test_offense_on_constant_constructor_with_heredoc_argument
+          assert_offense(<<~RUBY)
+            PATH = T.let(
+                   ^^^^^^ #{CONSTRUCTOR_MSG}
+              Pathname.new(<<~DIR),
+                /usr/local
+              DIR
+              Pathname,
+            )
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATH = Pathname.new(<<~DIR)
+                /usr/local
+              DIR
+          RUBY
+        end
+
         # Sorbet infers generic constructors as applied types (e.g.
         # `T::Set[T.untyped]`), does not infer through `.tap` or kernel
         # casting methods like `Pathname()`, and only matches when the

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -366,6 +366,14 @@ module RuboCop
           RUBY
         end
 
+        def test_no_offense_with_destructured_parameter
+          assert_no_offenses(<<~RUBY)
+            def initialize((a, b))
+              @a = T.let(a, Integer)
+            end
+          RUBY
+        end
+
         def test_no_offense_inside_conditional
           assert_no_offenses(<<~RUBY)
             sig { params(a: Integer).void }

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -229,6 +229,17 @@ module RuboCop
           RUBY
         end
 
+        def test_offense_on_constant_assigned_block_constructor
+          assert_offense(<<~RUBY)
+            CONFIG = T.let(Config.new { |c| c.enabled = true }.freeze, Config)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            CONFIG = Config.new { |c| c.enabled = true }.freeze
+          RUBY
+        end
+
         def test_offense_on_multiline_constant_constructor
           assert_offense(<<~RUBY)
             GITHUB_ERROR = T.let(

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -271,6 +271,16 @@ module RuboCop
 
         # Instance variables are only inferred when assigned directly from a
         # signature parameter, never from a constructor call.
+        # In typed: strict, Sorbet requires T.let on constants assigned inside
+        # a conditional or block, so those must not be flagged.
+        def test_no_offense_on_constant_constructor_inside_conditional
+          assert_no_offenses(<<~RUBY)
+            if enabled?
+              DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+            end
+          RUBY
+        end
+
         def test_no_offense_on_ivar_assigned_constructor
           assert_no_offenses(<<~RUBY)
             sig { params(path: String).void }

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -7,6 +7,8 @@ module RuboCop
     module Sorbet
       class RedundantTLetTest < ::Minitest::Test
         MSG = "Sorbet/RedundantTLet: Unnecessary T.let. The instance variable type is inferred from the signature."
+        CONSTRUCTOR_MSG = "Sorbet/RedundantTLet: Unnecessary T.let. " \
+          "The constant type is inferred from the constructor."
 
         def setup
           @cop = RedundantTLet.new
@@ -179,6 +181,90 @@ module RuboCop
             sig { params(kwargs: String).void }
             def initialize(**kwargs)
               @kwargs = kwargs
+            end
+          RUBY
+        end
+
+        def test_offense_on_constant_assigned_constructor
+          assert_offense(<<~RUBY)
+            PATTERN = T.let(Regexp.new("foo"), Regexp)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATTERN = Regexp.new("foo")
+          RUBY
+        end
+
+        def test_offense_on_constant_assigned_frozen_constructor
+          assert_offense(<<~RUBY)
+            DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            DEFAULT_PATH = Pathname.new("/usr/local").freeze
+          RUBY
+        end
+
+        def test_offense_on_constant_assigned_namespaced_constructor
+          assert_offense(<<~RUBY)
+            MUTEX = T.let(Thread::Mutex.new.freeze, Thread::Mutex)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            MUTEX = Thread::Mutex.new.freeze
+          RUBY
+        end
+
+        def test_offense_on_constant_assigned_cbase_constructor
+          assert_offense(<<~RUBY)
+            ROOT = T.let(::Pathname.new("/").freeze, Pathname)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            ROOT = ::Pathname.new("/").freeze
+          RUBY
+        end
+
+        def test_offense_on_multiline_constant_constructor
+          assert_offense(<<~RUBY)
+            GITHUB_ERROR = T.let(
+                           ^^^^^^ #{CONSTRUCTOR_MSG}
+              Regexp.new("some error"),
+              Regexp,
+            )
+          RUBY
+
+          assert_correction(<<~RUBY)
+            GITHUB_ERROR = Regexp.new("some error")
+          RUBY
+        end
+
+        # Sorbet infers generic constructors as applied types (e.g.
+        # `T::Set[T.untyped]`), does not infer through `.tap` or kernel
+        # casting methods like `Pathname()`, and only matches when the
+        # annotation is exactly the instantiated class.
+        def test_no_offense_on_constant_constructors_sorbet_cannot_infer
+          assert_no_offenses(<<~RUBY)
+            SET = T.let(Set.new.freeze, Set)
+            LICENSES = T.let(Set.new(["mit"]).freeze, T::Set[String])
+            MISMATCH = T.let(Regexp.new("foo"), Pathname)
+            NILABLE = T.let(Pathname.new("/x"), T.nilable(Pathname))
+            KERNEL_METHOD = T.let(Pathname("/x").freeze, Pathname)
+            TAPPED = T.let(Version.new("NULL").tap { |v| v }.freeze, Version)
+          RUBY
+        end
+
+        # Instance variables are only inferred when assigned directly from a
+        # signature parameter, never from a constructor call.
+        def test_no_offense_on_ivar_assigned_constructor
+          assert_no_offenses(<<~RUBY)
+            sig { params(path: String).void }
+            def initialize(path)
+              @path = T.let(Pathname.new(path), Pathname)
             end
           RUBY
         end

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -241,6 +241,19 @@ module RuboCop
           RUBY
         end
 
+        # A numbered-parameter block is a `numblock` node, which Sorbet infers
+        # as the instantiated class just like a `{ |x| }` block.
+        def test_offense_on_constant_assigned_numbered_block_constructor
+          assert_offense(<<~RUBY)
+            CONFIG = T.let(Config.new { _1.enabled = true }.freeze, Config)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            CONFIG = Config.new { _1.enabled = true }.freeze
+          RUBY
+        end
+
         def test_offense_on_multiline_constant_constructor
           assert_offense(<<~RUBY)
             GITHUB_ERROR = T.let(
@@ -293,6 +306,26 @@ module RuboCop
           RUBY
         end
 
+        # When the `T.let` spans multiple lines a comment can trail the value on
+        # the heredoc marker line; extending the replaced range past the body
+        # must not swallow it.
+        def test_offense_on_constant_constructor_with_heredoc_and_marker_comment
+          assert_offense(<<~RUBY)
+            PATH = T.let(Pathname.new(<<~DIR), # keep me
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+              /usr/local
+            DIR
+              Pathname,
+            )
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATH = Pathname.new(<<~DIR) # keep me
+              /usr/local
+            DIR
+          RUBY
+        end
+
         # Sorbet infers generic constructors as applied types (e.g.
         # `T::Set[T.untyped]`), does not infer through `.tap` or kernel
         # casting methods like `Pathname()`, and only matches when the
@@ -308,8 +341,6 @@ module RuboCop
           RUBY
         end
 
-        # Instance variables are only inferred when assigned directly from a
-        # signature parameter, never from a constructor call.
         # In typed: strict, Sorbet requires T.let on constants assigned inside
         # a conditional or block, so those must not be flagged.
         def test_no_offense_on_constant_constructor_inside_conditional
@@ -320,6 +351,8 @@ module RuboCop
           RUBY
         end
 
+        # Instance variables are only inferred when assigned directly from a
+        # signature parameter, never from a constructor call.
         def test_no_offense_on_ivar_assigned_constructor
           assert_no_offenses(<<~RUBY)
             sig { params(path: String).void }
@@ -491,6 +524,25 @@ module RuboCop
           RUBY
         end
 
+        # Type comparison normalizes spacing after commas, so a `T.let` type
+        # matches the sig type even when their comma spacing differs.
+        def test_offense_when_type_comma_spacing_differs_from_sig
+          assert_offense(<<~RUBY)
+            sig { params(a: T.any(Integer, String)).void }
+            def initialize(a)
+              @a = T.let(a, T.any(Integer,String))
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            sig { params(a: T.any(Integer, String)).void }
+            def initialize(a)
+              @a = a
+            end
+          RUBY
+        end
+
         # Sorbet's initializer rewriter does not process ivar assignments when
         # the def is wrapped by a method modifier, so T.let remains required.
         def test_no_offense_with_method_modifier_wrapping_def
@@ -545,6 +597,9 @@ module RuboCop
             HASH = T.let(Hash.new(0).freeze, Hash)
             ARRAY = T.let(Array.new(3).freeze, Array)
             RANGE = T.let(Range.new(1, 2).freeze, Range)
+            ENUM = T.let(Enumerator.new { |y| y << 1 }.freeze, Enumerator)
+            KLASS = T.let(Class.new.freeze, Class)
+            MOD = T.let(Module.new.freeze, Module)
           RUBY
         end
 

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -275,6 +275,24 @@ module RuboCop
           RUBY
         end
 
+        # The closing `)` sits before the heredoc body, so extending the
+        # replaced range past the terminator must not swallow the trailing
+        # comment on the marker line.
+        def test_offense_on_constant_constructor_with_heredoc_and_trailing_comment
+          assert_offense(<<~RUBY)
+            PATH = T.let(Pathname.new(<<~DIR), Pathname) # keep me
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+              /usr/local
+            DIR
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATH = Pathname.new(<<~DIR) # keep me
+              /usr/local
+            DIR
+          RUBY
+        end
+
         # Sorbet infers generic constructors as applied types (e.g.
         # `T::Set[T.untyped]`), does not infer through `.tap` or kernel
         # casting methods like `Pathname()`, and only matches when the

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -12,6 +12,7 @@ module RuboCop
 
         def setup
           @cop = RedundantTLet.new
+          stub_sorbet_static_version("0.6.13304")
         end
 
         def test_offense_on_redundant_types
@@ -461,6 +462,89 @@ module RuboCop
               @a = T.let(a, Integer)
             end
           RUBY
+        end
+
+        # A constant inside `class << self` or a bare `module` body is still
+        # statically scoped, so the constructor offense applies there too.
+        def test_offense_on_constant_constructor_in_singleton_class
+          assert_offense(<<~RUBY)
+            class Foo
+              class << self
+                DEFAULT = T.let(Pathname.new("/x").freeze, Pathname)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+              end
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            class Foo
+              class << self
+                DEFAULT = Pathname.new("/x").freeze
+              end
+            end
+          RUBY
+        end
+
+        def test_offense_on_constant_constructor_in_module
+          assert_offense(<<~RUBY)
+            module Foo
+              DEFAULT = T.let(Pathname.new("/x").freeze, Pathname)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            module Foo
+              DEFAULT = Pathname.new("/x").freeze
+            end
+          RUBY
+        end
+
+        # The generic-class exclusion covers every entry in GENERIC_CLASSES,
+        # not just Set: their constructors infer as applied types.
+        def test_no_offense_on_other_generic_class_constructors
+          assert_no_offenses(<<~RUBY)
+            HASH = T.let(Hash.new(0).freeze, Hash)
+            ARRAY = T.let(Array.new(3).freeze, Array)
+            RANGE = T.let(Range.new(1, 2).freeze, Range)
+          RUBY
+        end
+
+        # `::T.let` (fully-qualified) is handled for the constructor path too.
+        def test_offense_on_constant_constructor_with_cbase_t_let
+          assert_offense(<<~RUBY)
+            ROOT = ::T.let(Pathname.new("/").freeze, Pathname)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{CONSTRUCTOR_MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            ROOT = Pathname.new("/").freeze
+          RUBY
+        end
+
+        # The constructor path relies on freeze-transparent inference added in
+        # Sorbet 0.6.13304, so it disables itself on older Sorbet (and when
+        # sorbet-static is absent from the lockfile). The signature-based ivar
+        # path is unaffected.
+        def test_no_offense_on_constructor_below_minimum_sorbet_version
+          stub_sorbet_static_version("0.6.13303")
+          assert_no_offenses(<<~RUBY)
+            DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+          RUBY
+        end
+
+        def test_no_offense_on_constructor_without_sorbet_static
+          stub_sorbet_static_version(nil)
+          assert_no_offenses(<<~RUBY)
+            DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
+          RUBY
+        end
+
+        private
+
+        def stub_sorbet_static_version(version)
+          specs = version ? [Gem::Specification.new("sorbet-static", version)] : []
+          ::Bundler.stubs(:locked_gems).returns(Struct.new(:specs).new(specs))
         end
       end
     end


### PR DESCRIPTION
Sorbet 0.6.13304 added freeze-transparent type inference for constants ("Infer `X = A.new.freeze` the same as `X = A.new`"), making more `T.let` annotations redundant. This extends both `RedundantTLet` cops to flag them. Inference boundaries were established empirically against Sorbet 0.6.13328 with `T.reveal_type` probes in a `typed: strict` file.

### `Sorbet/RedundantTLet`

Now also flags constants assigned a constructor call, optionally followed by `.freeze`, when the annotation is exactly the instantiated class. Block-form constructors (`Klass.new { ... }`, including numbered-parameter and `it` blocks) are recognized too, since Sorbet infers them as the instantiated class the same as a plain `.new`:

```ruby
# bad
DEFAULT_PATH = T.let(Pathname.new("/usr/local").freeze, Pathname)
PATTERN = T.let(Regexp.new("foo"), Regexp)
CONFIG = T.let(Config.new { |c| c.enabled = true }.freeze, Config)

# good
DEFAULT_PATH = Pathname.new("/usr/local").freeze
PATTERN = Regexp.new("foo")
CONFIG = Config.new { |c| c.enabled = true }.freeze
```

Excluded, because Sorbet cannot infer them:

- generic classes (`Array`, `Class`, `Enumerator`, `Hash`, `Module`, `Range`, `Set`): their constructors infer as applied types like `T::Set[T.untyped]`
- `.tap` chains and kernel casting methods (`Pathname("/x")`)
- annotations that are not the bare instantiated class (`T.nilable(Pathname)`)
- instance variable and local variable assignments: in `initialize`, only plain `@x = param` is inferred; `@x = A.new(...)` still requires `T.let`

The existing signature-based instance-variable path is unchanged in scope; its type comparison now also normalizes spacing after commas, so a `T.let` type matches a differently-spaced sig type (e.g. `T.any(Integer,String)` vs `T.any(Integer, String)`).

### `Sorbet/RedundantTLetForLiteral`

Now also flags **frozen regexp literals** and **array literals of simple literals**:

```ruby
# bad
PATTERN = T.let(/foo/.freeze, Regexp)
SHELLS  = T.let([:bash, :zsh].freeze, T::Array[Symbol])          # frozen -> tuple subtype
NAMES   = T.let(["alice", "bob"], T::Array[String])              # unfrozen, exact match
PATHS   = T.let(["#{root}/a", "#{root}/b"].freeze, T::Array[String])  # interpolated strings

# good
PATTERN = /foo/.freeze
SHELLS  = [:bash, :zsh].freeze
NAMES   = ["alice", "bob"]
PATHS   = ["#{root}/a", "#{root}/b"].freeze
```

Array handling, and why it is safe:

- A **frozen** array of simple literals infers as a fixed-size tuple. Because any already-valid `T::Array` annotation is a supertype of the actual elements, the tuple is always assignable back to that annotation, so removing the `T.let` only narrows to a safe subtype. Mixed-element and nested literal arrays are covered.
- An **unfrozen** array infers as `T::Array[<element type>]`. It is flagged only when that inferred type matches the annotation exactly, to avoid silently widening (e.g. `["a", nil]` infers `T::Array[T.nilable(String)]`, so `T.let(["a", nil], T::Array[String])` would not typecheck in the first place and mixed/wider cases are left alone).
- **Interpolated strings and symbols** (`"#{x}"`, `:"#{x}"`) infer as `String`/`Symbol`, so an array of them infers the same as an array of plain literals. `%W[...]`/`%I[...]` word arrays and adjacent-string-concatenation arrays are therefore covered too.

Still excluded (verified to degrade to `T.untyped` or otherwise not match): arrays with regexp or range elements, empty arrays, arrays whose elements are constants or method calls, hash literals, and non-regexp frozen scalar literals (`"hello".freeze`, `:active.freeze`, frozen heredocs — all infer as `T.untyped`).

A fully-qualified `::T.let` call and `::T::Array` annotation are handled on every path (bare literals, frozen literals, and frozen/unfrozen arrays).

### Autocorrect

Both cops are `SafeAutoCorrect: false` (they require `-A`). Removing an annotation is sound at the definition, but can change inference at a consumer the cop cannot see — e.g. under `typed: strong` a `flatten` over the now-tuple constant yields `T.untyped`, or a local seeded from the constant can no longer widen in a loop. Both hazards surfaced when running the autocorrect across a large monorepo and are not statically detectable from the assignment alone.

The autocorrect unwraps `T.let(value, Type)` to `value`, preserving heredoc bodies (and any comment trailing the value on the marker line) whether the `T.let` is written on a single line or across multiple lines.

### Sorbet version requirement

The inference these cops rely on was added across two Sorbet releases:

- **Constant array/tuple inference** — Sorbet [#7993](https://github.com/sorbet/sorbet/pull/7993), first released in `0.5.11457` — backs the frozen/unfrozen literal-array cases.
- **Freeze-transparent inference** (`X = A.new.freeze` inferred the same as `X = A.new`) — Sorbet [#10377](https://github.com/sorbet/sorbet/pull/10377), released in `0.6.13304` — backs the frozen constructor and frozen regexp cases.

`0.6.13304` is the later of the two and covers every newly-added case. Rather than raise the gem-wide minimum, both cops `include TargetSorbetVersion` (as `ObsoleteStrictMemoization` already does) and read the `sorbet-static` version from the target project's `Gemfile.lock`: the version-dependent paths (constructor constants, frozen literals, literal arrays) disable themselves below `0.6.13304`, while the older cases (instance variables inferred from signatures, bare simple literals) remain active on any Sorbet. This way the autocorrect can no longer remove a `T.let` an older Sorbet still requires, and the README "Compatibility" gem-wide minimum stays at `0.5`.

### `typed: strict` vs `typed: strong`

The autocorrected output is designed to typecheck at `# typed: strict`. In strict, Sorbet requires a `T.let` on a constant only when the removed annotation would leave the inferred type as `T.untyped` (error 7027), and every case these cops flag infers a concrete type (the instantiated class, a tuple, or `T::Array[...]`).

`# typed: strong` is a stricter, **beta** feature (see https://sorbet.org/docs/strong) that disallows `T.untyped` entirely. One potential `typed: strong` violation to be aware of: a **user-defined generic class** (`extend T::Generic`) is not in the built-in `GENERIC_CLASSES` exclusion list, so `T.let(Box.new, Box)` would be autocorrected to `Box.new`, which infers `T::Box[T.untyped]`. That is accepted at `typed: strict` (the bare-generic annotation already emits error 5045 there, so this is not a regression), but would be rejected at `typed: strong`. Applied annotations (`T.let(Box.new, Box[String])`) are already left untouched because the annotation is not a bare const.

### Known limitation — frozen arrays assume the existing annotation typechecks

The frozen-array branch treats the inferred tuple as a subtype of the annotated `T::Array`, which holds whenever the annotation is already valid. If a frozen array carries an annotation *narrower* than its elements (e.g. `T.let([1, nil].freeze, T::Array[Integer])`, which already fails `srb tc` today with error 7007), the autocorrect removes both the annotation and that pre-existing error. Like other annotation-removal cops, this assumes the input already typechecks.

### Motivation and validation

The equivalent manual cleanup in Homebrew/brew#22949 removed `T.let` from ~30 constants (verified with a full `srb tc` run); its bulk was exactly these frozen literal-array constants, which the cops now flag and autocorrect. Running these cops with autocorrect over Homebrew produced Homebrew/brew#22974, the mechanized equivalent of that cleanup. The same cops were also run with autocorrect across a large internal monorepo and the result verified with `srb tc`.

The freeze-transparent inference and the interpolated-string cases were re-confirmed against Sorbet `0.6.13328` with `T.reveal_type` and `srb tc` (autocorrected output typechecks at `typed: strict`); interpolated symbols follow the same rule, since a dynamic symbol infers as `Symbol`. Running both cops across ~15k real files (Homebrew + an internal monorepo) surfaced only true positives and no cop-level crashes — including real interpolated `%W[...]` and string-concatenation arrays.

Tests: full suite passes (561 runs, 0 failures); internal RuboCop reports no offenses; `manual/cops_sorbet.md` regenerated via `rake generate_cops_documentation` (no drift).

---

AI disclosure: Claude Code was used to probe Sorbet's inference behaviour, write the cop changes and tests, run the validation above, and conduct a multi-agent review of the diff.
