### PR TITLE
Exempt Sorbet type declarations from Style/MutableConstant

### DIFF
--- a/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
+++ b/lib/rubocop/cop/sorbet/mutable_constant_sorbet_aware_behaviour.rb
@@ -12,10 +12,25 @@ module RuboCop
             base.def_node_matcher(:t_let, <<~PATTERN)
               (send (const nil? :T) :let $_constant _type)
             PATTERN
+
+            # @!method sorbet_type_declaration?(node)
+            base.def_node_matcher(:sorbet_type_declaration?, <<~PATTERN)
+              {
+                (send nil? {:type_member :type_template} ...)
+                (block (send nil? {:type_member :type_template} ...) ...)
+                (send (const nil? :T) :type_alias ...)
+                (block (send (const nil? :T) :type_alias ...) ...)
+              }
+            PATTERN
           end
         end
 
         def on_assignment(value)
+          # Sorbet type declarations such as `type_member`, `type_template`,
+          # and `T.type_alias` produce type objects that cannot be frozen
+          # (calling `.freeze` on them breaks Sorbet), so they are exempt.
+          return if sorbet_type_declaration?(value)
+
           t_let(value) do |constant|
             value = constant
           end

--- a/test/rubocop/cop/style/mutable_constant_test.rb
+++ b/test/rubocop/cop/style/mutable_constant_test.rb
@@ -177,6 +177,63 @@ module RuboCop
           RUBY
         end
 
+        def test_does_not_register_offense_when_using_type_member
+          @cop = target_cop.new(cop_config({
+            "EnforcedStyle" => "strict",
+          }))
+
+          assert_no_offenses(<<~RUBY)
+            Elem = type_member
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            Elem = type_member(:out)
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            Elem = type_member { { fixed: T::Hash[String, T.untyped] } }
+          RUBY
+        end
+
+        def test_does_not_register_offense_when_using_type_template
+          @cop = target_cop.new(cop_config({
+            "EnforcedStyle" => "strict",
+          }))
+
+          assert_no_offenses(<<~RUBY)
+            Cache = type_template
+          RUBY
+
+          assert_no_offenses(<<~RUBY)
+            Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+          RUBY
+        end
+
+        def test_does_not_register_offense_when_using_t_type_alias
+          @cop = target_cop.new(cop_config({
+            "EnforcedStyle" => "strict",
+          }))
+
+          assert_no_offenses(<<~RUBY)
+            StringOrSymbol = T.type_alias { T.any(String, Symbol) }
+          RUBY
+        end
+
+        def test_registers_offense_when_using_other_method_call_in_strict_mode
+          @cop = target_cop.new(cop_config({
+            "EnforcedStyle" => "strict",
+          }))
+
+          assert_offense(<<~RUBY)
+            CONST = some_method
+                    ^^^^^^^^^^^ Freeze mutable objects assigned to constants.
+          RUBY
+
+          assert_correction(<<~RUBY)
+            CONST = (some_method).freeze
+          RUBY
+        end
+
         def test_does_not_register_offense_when_using_fixed_size_methods
           assert_no_offenses(<<~RUBY)
             CONST = 'foo'.count


### PR DESCRIPTION
## Motivation

With `Style/MutableConstant` in `EnforcedStyle: strict` mode, the cop flags any method call it cannot prove returns an immutable object. This produces false positives for Sorbet's type declarations, which produce type objects that *cannot* be frozen — calling `.freeze` on them breaks Sorbet:

```ruby
# rubocop:disable Style/MutableConstant
Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
# rubocop:enable Style/MutableConstant

Key = type_member # rubocop:disable Style/MutableConstant
```

[Homebrew](https://github.com/search?q=repo%3AHomebrew%2Fbrew%20rubocop%3Adisable%20Style%2FMutableConstant&type=code) alone carries 30 such disable comments (plus paired `enable` lines). Since this gem already prepends Sorbet-aware behaviour into `Style/MutableConstant` (for `T.let` unwrapping), it's a natural place to exempt these declarations for every rubocop-sorbet user, with no configuration needed.

## Implementation

`MutableConstantSorbetAwareBehaviour#on_assignment` now returns early when the assigned value is:

- `type_member` / `type_template` — bare, with arguments (e.g. `type_member(:out)`), or with a block
- `T.type_alias` — with or without a block

## Tests

Added test cases for all exempted forms in strict mode, plus a sanity check that other method calls (`CONST = some_method`) are still flagged and autocorrected. `bundle exec rake` passes (511 runs, 0 failures).
