### PR TITLE
Allow configuring which style to use when autocorrecting signatures in `Sorbet/EnforceSignatures` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -102,6 +102,7 @@ Sorbet/EnforceSignatures:
   Description: 'Ensures all methods have a valid signature.'
   Enabled: false
   Style: sig
+  AutocorrectStyle: sig
   VersionAdded: 0.3.4
 
 Sorbet/EnforceSingleSigil:

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -23,11 +23,13 @@ module RuboCop
       # * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
       # * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
       # * `Style`: signature style to enforce - 'sig' for sig blocks, 'rbs' for RBS comments, 'both' to allow either (default: 'sig')
+      # * `AutocorrectStyle`: signature style to use when autocorrecting - 'sig' for sig blocks, 'rbs' for RBS comments (default: 'sig'). Only used when `Style` is 'both'.
       class EnforceSignatures < ::RuboCop::Cop::Base
         extend AutoCorrector
         include SignatureHelp
 
         VALID_STYLES = ["sig", "rbs", "both"].freeze
+        VALID_AUTOCORRECT_STYLES = ["sig", "rbs"].freeze
 
         # @!method accessor?(node)
         def_node_matcher(:accessor?, <<-PATTERN)
@@ -87,7 +89,7 @@ module RuboCop
             # Both styles allowed - require at least one
             unless sig_node || rbs_node
               add_offense(node, message: "Each method is required to have a signature.") do |corrector|
-                autocorrect_with_signature_type(corrector, node, "sig")
+                autocorrect_with_signature_type(corrector, node, autocorrect_style)
               end
             end
           else # "sig" (default)
@@ -190,6 +192,15 @@ module RuboCop
           return "both" if allow_rbs?
 
           "sig"
+        end
+
+        def autocorrect_style
+          config_value = cop_config["AutocorrectStyle"] || "sig"
+          unless VALID_AUTOCORRECT_STYLES.include?(config_value)
+            raise ArgumentError, "Invalid AutocorrectStyle option: '#{config_value}'. Valid options are: #{VALID_AUTOCORRECT_STYLES.join(", ")}"
+          end
+
+          config_value
         end
 
         class SignatureChecker

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -332,12 +332,14 @@ You can configure the placeholders used by changing the following options:
 * `ParameterTypePlaceholder`: placeholders used for parameter types (default: 'T.untyped')
 * `ReturnTypePlaceholder`: placeholders used for return types (default: 'T.untyped')
 * `Style`: signature style to enforce - 'sig' for sig blocks, 'rbs' for RBS comments, 'both' to allow either (default: 'sig')
+* `AutocorrectStyle`: signature style to use when autocorrecting - 'sig' for sig blocks, 'rbs' for RBS comments (default: 'sig'). Only used when `Style` is 'both'.
 
 ### Configurable attributes
 
 Name | Default value | Configurable values
 --- | --- | ---
 Style | `sig` | String
+AutocorrectStyle | `sig` | String
 
 ## Sorbet/EnforceSingleSigil
 

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -428,26 +428,26 @@ module RuboCop
 
           def test_autocorrects_with_custom_values
             @cop = target_cop.new(cop_config({
-              "Style" => "both",
+              "Style" => "sig",
               "ParameterTypePlaceholder" => "PARAM",
               "ReturnTypePlaceholder" => "RET",
             }))
 
             assert_offense(<<~RUBY)
               def foo; end
-              ^^^^^^^^^^^^ #{MSG}
+              ^^^^^^^^^^^^ #{MSG_SIG}
               def bar(a, b = 2, c: Foo.new); end
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG_SIG}
               def baz(&blk); end
-              ^^^^^^^^^^^^^^^^^^ #{MSG}
+              ^^^^^^^^^^^^^^^^^^ #{MSG_SIG}
 
               class Foo
                 def foo
-                ^^^^^^^ #{MSG}
+                ^^^^^^^ #{MSG_SIG}
                 end
 
                 def bar(a, b, c)
-                ^^^^^^^^^^^^^^^^ #{MSG}
+                ^^^^^^^^^^^^^^^^ #{MSG_SIG}
                 end
               end
             RUBY
@@ -473,18 +473,18 @@ module RuboCop
 
           def test_autocorrects_accessors_with_custom_values
             @cop = target_cop.new(cop_config({
-              "Style" => "both",
+              "Style" => "sig",
               "ParameterTypePlaceholder" => "PARAM",
               "ReturnTypePlaceholder" => "RET",
             }))
             assert_offense(<<~RUBY)
               class Foo
                 attr_reader :foo
-                ^^^^^^^^^^^^^^^^ #{MSG}
+                ^^^^^^^^^^^^^^^^ #{MSG_SIG}
                 attr_writer :bar
-                ^^^^^^^^^^^^^^^^ #{MSG}
+                ^^^^^^^^^^^^^^^^ #{MSG_SIG}
                 attr_accessor :baz
-                ^^^^^^^^^^^^^^^^^^ #{MSG}
+                ^^^^^^^^^^^^^^^^^^ #{MSG_SIG}
               end
             RUBY
             assert_correction(<<~RUBY)
@@ -740,6 +740,75 @@ module RuboCop
               def foo; end
               ^^^^^^^^^^^^ #{MSG_SIG}
             RUBY
+          end
+
+          def test_both_style_autocorrects_to_sig_when_autocorrect_style_is_sig
+            @cop = target_cop.new(cop_config({
+              "Style" => "both",
+              "AutocorrectStyle" => "sig",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo; end
+              ^^^^^^^^^^^^ #{MSG}
+              def bar(a, b, c); end
+              ^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { returns(T.untyped) }
+              def foo; end
+              sig { params(a: T.untyped, b: T.untyped, c: T.untyped).returns(T.untyped) }
+              def bar(a, b, c); end
+            RUBY
+          end
+
+          def test_both_style_autocorrects_to_rbs_when_autocorrect_style_is_rbs
+            @cop = target_cop.new(cop_config({
+              "Style" => "both",
+              "AutocorrectStyle" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo; end
+              ^^^^^^^^^^^^ #{MSG}
+              def bar(a, b, c); end
+              ^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: () -> untyped
+              def foo; end
+              #: (untyped, untyped, untyped) -> untyped
+              def bar(a, b, c); end
+            RUBY
+          end
+
+          def test_both_style_autocorrects_to_sig_by_default
+            @cop = target_cop.new(cop_config({
+              "Style" => "both",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo; end
+              ^^^^^^^^^^^^ #{MSG}
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { returns(T.untyped) }
+              def foo; end
+            RUBY
+          end
+
+          def test_invalid_autocorrect_style_raises_error
+            @cop = target_cop.new(cop_config({
+              "Style" => "both",
+              "AutocorrectStyle" => "invalid",
+            }))
+
+            assert_raises(ArgumentError, /Invalid AutocorrectStyle option/) do
+              @cop.send(:autocorrect_style)
+            end
           end
 
           private


### PR DESCRIPTION
When `Style: both` is configured, we were always autocorrecting to `sig` style. If your codebase is migration to RBS you want the autocorrection to be in RBS style. This change adds a new configuration option `AutocorrectStyle` which can be set to either `sig` or `rbs` to control which style is used when autocorrecting.