### PR TITLE
Fix Sorbet/EnforceSignatures to generate correct RBS signature comments for attr_*

### DIFF
--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -154,6 +154,11 @@ module RuboCop
           method = node.children[1]
           symbol = node.children[2]
 
+          if suggest.is_a?(RBSSuggestion)
+            suggest.attribute = true
+            return
+          end
+
           add_accessor_parameter_if_needed(suggest, symbol, method)
           set_void_return_for_writer(suggest, method)
         end
@@ -299,12 +304,13 @@ module RuboCop
         end
 
         class RBSSuggestion
-          attr_accessor :params, :returns, :has_block
+          attr_accessor :params, :returns, :has_block, :attribute
 
           def initialize(indent)
             @params = []
             @returns = nil
             @has_block = false
+            @attribute = false
             @indent = indent
           end
 
@@ -315,6 +321,8 @@ module RuboCop
           private
 
           def generate_signature
+            return @returns || "untyped" if @attribute
+
             param_types = @params.map { |param| rbs_param(param) }.join(", ")
             return_type = @returns || "untyped"
 

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -118,9 +118,16 @@ module RuboCop
         end
 
         def autocorrect_with_signature_type(corrector, node, type)
-          suggest = create_signature_suggestion(node, type)
+          target = leftmost_send_ancestor(node)
+          suggest = create_signature_suggestion(target, type)
           populate_signature_suggestion(suggest, node)
-          corrector.insert_before(node, suggest.to_autocorrect)
+          corrector.insert_before(target, suggest.to_autocorrect)
+        end
+
+        def leftmost_send_ancestor(node)
+          ancestor = node
+          ancestor = ancestor.parent while ancestor.parent&.send_type?
+          ancestor
         end
 
         def create_signature_suggestion(node, type)
@@ -141,6 +148,8 @@ module RuboCop
         end
 
         def populate_method_definition_suggestion(suggest, node)
+          suggest.returns = "void" if instance_initialize?(node)
+
           node.arguments.each do |arg|
             if arg.blockarg_type? && suggest.respond_to?(:has_block=)
               suggest.has_block = true
@@ -148,6 +157,21 @@ module RuboCop
               suggest.params << Param.new(arg.children.first, arg.type)
             end
           end
+        end
+
+        def instance_initialize?(node)
+          node.def_type? && node.method?(:initialize) && !in_sclass_context?(node)
+        end
+
+        def in_sclass_context?(node)
+          parent = node.parent
+          while parent
+            return true if parent.sclass_type?
+            return false if parent.type?(:class, :module)
+
+            parent = parent.parent
+          end
+          false
         end
 
         def populate_accessor_suggestion(suggest, node)

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -232,11 +232,11 @@ module RuboCop
           def test_makes_no_offense_if_accessor_has_rbs_signature
             assert_no_offenses(<<~RUBY)
               class Foo
-                #: -> String
+                #: String
                 attr_reader :foo
-                #: (String) -> void
+                #: String
                 attr_writer :bar
-                #: (String) -> String
+                #: String
                 attr_accessor :baz
               end
             RUBY
@@ -321,7 +321,7 @@ module RuboCop
           def test_does_not_check_rbs_signature_for_accessors
             assert_no_offenses(<<~RUBY)
               class Foo
-                #: -> void
+                #: void
                 attr_reader :foo, :bar
               end
             RUBY
@@ -569,7 +569,7 @@ module RuboCop
                 ^^^^^^^^^^^^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
                 attr_reader :foo
 
-                #: -> String
+                #: String
                 attr_reader :bar
 
                 attr_writer :baz
@@ -644,11 +644,11 @@ module RuboCop
 
             assert_correction(<<~RUBY)
               class Foo
-                #: () -> untyped
+                #: untyped
                 attr_reader :foo
-                #: (untyped) -> void
+                #: untyped
                 attr_writer :bar
-                #: (untyped) -> untyped
+                #: untyped
                 attr_accessor :baz
               end
             RUBY

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -312,7 +312,7 @@ module RuboCop
           def test_does_not_check_signature_for_accessors
             assert_no_offenses(<<~RUBY)
               class Foo
-                sig { void }
+                sig { returns(String) }
                 attr_reader :foo, :bar
               end
             RUBY
@@ -321,7 +321,7 @@ module RuboCop
           def test_does_not_check_rbs_signature_for_accessors
             assert_no_offenses(<<~RUBY)
               class Foo
-                #: void
+                #: String
                 attr_reader :foo, :bar
               end
             RUBY

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -654,6 +654,206 @@ module RuboCop
             RUBY
           end
 
+          def test_autocorrects_initialize_with_void_return
+            assert_offense(<<~RUBY)
+              def initialize(a, b)
+              ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { params(a: T.untyped, b: T.untyped).void }
+              def initialize(a, b)
+              end
+            RUBY
+          end
+
+          def test_autocorrects_singleton_initialize_keeps_placeholder
+            assert_offense(<<~RUBY)
+              def self.initialize(a, b)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { params(a: T.untyped, b: T.untyped).returns(T.untyped) }
+              def self.initialize(a, b)
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_initialize_with_void_return
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              def initialize(a, b)
+              ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: (untyped, untyped) -> void
+              def initialize(a, b)
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_singleton_initialize_keeps_placeholder
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              def self.initialize(a, b)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: (untyped, untyped) -> untyped
+              def self.initialize(a, b)
+              end
+            RUBY
+          end
+
+          def test_autocorrects_sclass_initialize_keeps_placeholder
+            assert_offense(<<~RUBY)
+              class Foo
+                class << self
+                  def initialize(a, b)
+                  ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+                  end
+                end
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                class << self
+                  sig { params(a: T.untyped, b: T.untyped).returns(T.untyped) }
+                  def initialize(a, b)
+                  end
+                end
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_sclass_initialize_keeps_placeholder
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              class Foo
+                class << self
+                  def initialize(a, b)
+                  ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+                  end
+                end
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                class << self
+                  #: (untyped, untyped) -> untyped
+                  def initialize(a, b)
+                  end
+                end
+              end
+            RUBY
+          end
+
+          def test_autocorrects_nested_class_initialize_inside_sclass_gets_void
+            assert_offense(<<~RUBY)
+              class Foo
+                class << self
+                  class Bar
+                    def initialize(a, b)
+                    ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+                    end
+                  end
+                end
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                class << self
+                  class Bar
+                    sig { params(a: T.untyped, b: T.untyped).void }
+                    def initialize(a, b)
+                    end
+                  end
+                end
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_nested_class_initialize_inside_sclass_gets_void
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              class Foo
+                class << self
+                  class Bar
+                    def initialize(a, b)
+                    ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+                    end
+                  end
+                end
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                class << self
+                  class Bar
+                    #: (untyped, untyped) -> void
+                    def initialize(a, b)
+                    end
+                  end
+                end
+              end
+            RUBY
+          end
+
+          def test_autocorrects_private_def_initialize
+            assert_offense(<<~RUBY)
+              private def initialize(a, b)
+                      ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { params(a: T.untyped, b: T.untyped).void }
+              private def initialize(a, b)
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_private_def_initialize
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              private def initialize(a, b)
+                      ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: (untyped, untyped) -> void
+              private def initialize(a, b)
+              end
+            RUBY
+          end
+
           def test_enforce_rbs_autocorrects_with_proper_indentation
             @cop = target_cop.new(cop_config({
               "Style" => "rbs",


### PR DESCRIPTION
Before it was generating `#: () -> untyped` that is incorrect.