### PR TITLE
Fix TLetCorrection corrupting files with interior heredocs

### DIFF
--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -13,10 +13,10 @@ module RuboCop
 
         # Replaces `T.let(value, Type)` with `value`.
         def replace_t_let(corrector, t_let_node, value_node)
-          heredocs = tail_heredocs(value_node)
-          return corrector.replace(t_let_node, value_node.source) if heredocs.empty?
+          heredocs_to_reattach = tail_heredocs(value_node)
+          return corrector.replace(t_let_node, value_node.source) if heredocs_to_reattach.empty?
 
-          replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs)
+          replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs_to_reattach)
         end
 
         # Heredocs at the tail of the value, whose body sits past `value_node`'s

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -19,11 +19,9 @@ module RuboCop
           replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs)
         end
 
-        # The heredocs whose body sits past the value node's own source range,
-        # so `value_node.source` stops at the marker and drops them. Only these
-        # need reattaching. An "interior" heredoc, followed by more of the value
-        # (e.g. `Foo.new(a: <<~X, b: 2)`), already lives inside `value_node.source`;
-        # re-appending it would duplicate the body and corrupt the file.
+        # Heredocs at the tail of the value, whose body sits past `value_node`'s
+        # source range. An interior heredoc, e.g. `Foo.new(a: <<~X, b: 2)`, already
+        # lives inside `value_node.source` and must not be reattached.
         def tail_heredocs(value_node)
           value_end = value_node.source_range.end_pos
           value_node.each_node(:any_str).select do |node|

--- a/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/t_let_correction.rb
@@ -13,10 +13,22 @@ module RuboCop
 
         # Replaces `T.let(value, Type)` with `value`.
         def replace_t_let(corrector, t_let_node, value_node)
-          heredocs = value_node.each_node(:any_str).select(&:heredoc?)
+          heredocs = tail_heredocs(value_node)
           return corrector.replace(t_let_node, value_node.source) if heredocs.empty?
 
           replace_t_let_preserving_heredocs(corrector, t_let_node, value_node, heredocs)
+        end
+
+        # The heredocs whose body sits past the value node's own source range,
+        # so `value_node.source` stops at the marker and drops them. Only these
+        # need reattaching. An "interior" heredoc, followed by more of the value
+        # (e.g. `Foo.new(a: <<~X, b: 2)`), already lives inside `value_node.source`;
+        # re-appending it would duplicate the body and corrupt the file.
+        def tail_heredocs(value_node)
+          value_end = value_node.source_range.end_pos
+          value_node.each_node(:any_str).select do |node|
+            node.heredoc? && node.loc.heredoc_end.end_pos > value_end
+          end
         end
 
         # Replaces `T.let(value, Type)` with `value` without losing any heredocs

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -326,6 +326,34 @@ module RuboCop
           RUBY
         end
 
+        # An "interior" heredoc is followed by more of the value's own source
+        # (here `b: 2` and the closing `)`), so `value_node.source` already
+        # contains the heredoc body inline. The correction must not re-append
+        # it, which would duplicate the body and corrupt the file.
+        def test_offense_on_constant_constructor_with_interior_heredoc
+          assert_offense(<<~RUBY)
+            PATH = T.let(
+                   ^^^^^^ #{CONSTRUCTOR_MSG}
+              Foo.new(
+                a: <<~DIR,
+                  /usr/local
+                DIR
+                b: 2,
+              ),
+              Foo,
+            )
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATH = Foo.new(
+                a: <<~DIR,
+                  /usr/local
+                DIR
+                b: 2,
+              )
+          RUBY
+        end
+
         # Sorbet infers generic constructors as applied types (e.g.
         # `T::Set[T.untyped]`), does not infer through `.tap` or kernel
         # casting methods like `Pathname()`, and only matches when the

--- a/test/rubocop/cop/sorbet/redundant_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_test.rb
@@ -327,9 +327,7 @@ module RuboCop
         end
 
         # An "interior" heredoc is followed by more of the value's own source
-        # (here `b: 2` and the closing `)`), so `value_node.source` already
-        # contains the heredoc body inline. The correction must not re-append
-        # it, which would duplicate the body and corrupt the file.
+        # (`b: 2` here), so it must not be re-appended like a tail heredoc.
         def test_offense_on_constant_constructor_with_interior_heredoc
           assert_offense(<<~RUBY)
             PATH = T.let(


### PR DESCRIPTION
### Problem

`TLetCorrection` (shared by `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral`) corrupts files when the `T.let` value contains an **interior** heredoc — one that is followed by more of the value's own source.

The mixin was written for heredocs at the *tail* of the value, where `value_node.source` stops at the marker and the body must be reattached. But when a heredoc sits in the interior of a larger value (e.g. a constructor call that continues after the heredoc), `value_node.source` already contains the heredoc body inline, so reattaching it duplicates the body.

Minimal repro:

```ruby
PATH = T.let(
  Foo.new(
    a: <<~DIR,
      /usr/local
    DIR
    b: 2,
  ),
  Foo,
)
```

Autocorrect currently produces a duplicated, syntactically broken body:

```ruby
PATH = Foo.new(
    a: <<~DIR,
      /usr/local
    DIR
    b: 2,
  )
      /usr/local   # <- duplicated
    DIR            # <- duplicated
```

### Fix

Only reattach heredocs whose body/terminator extend **past** the value node's own source range (the tail heredocs). Interior heredocs already live inside `value_node.source`, so the plain `corrector.replace(t_let_node, value_node.source)` path handles them correctly.

### Tests

Added `test_offense_on_constant_constructor_with_interior_heredoc` covering the case above. Full suite green (`bundle exec rake test`).
