### PR TITLE
Add `Sorbet/SetterReturnType` cop and extract RBSParser helper

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -361,6 +361,13 @@ Sorbet/SelectByIsA:
   Safe: true
   SafeAutoCorrect: true
 
+Sorbet/SetterReturnType:
+  Description: 'Checks that setter methods declare a `void` return type in their signature.'
+  Enabled: pending
+  Safe: true
+  SafeAutoCorrect: false
+  VersionAdded: '<<next>>'
+
 Sorbet/SignatureBuildOrder:
   Description: >-
                   Enforces the order of parts in a signature.

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -245,31 +245,11 @@ module RuboCop
           protected
 
           attr_reader :processed_source
-
-          def preceding_comments(node)
-            processed_source.ast_with_comments[node].select { |comment| comment.loc.line < node.loc.line }
-          end
         end
 
         class RBSSignatureChecker < SignatureChecker
-          RBS_COMMENT_REGEX = /^#\s*:.*$/
-
           def signature_node(node)
-            node = find_non_send_ancestor(node)
-            comments = preceding_comments(node)
-            return if comments.empty?
-
-            last_comment = comments.last
-            return if last_comment.loc.line + 1 < node.loc.line
-
-            comments.find { |comment| RBS_COMMENT_REGEX.match?(comment.text) }
-          end
-
-          private
-
-          def find_non_send_ancestor(node)
-            node = node.parent while node.parent&.send_type?
-            node
+            ::RuboCop::Sorbet::RBSParser.rbs_signatures_before(processed_source, node).first&.comments&.first
           end
         end
 

--- a/lib/rubocop/cop/sorbet/signatures/setter_return_type.rb
+++ b/lib/rubocop/cop/sorbet/signatures/setter_return_type.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Checks that setter methods (methods whose name ends with `=`)
+      # declare a `void` return type, in either a Sorbet `sig` block or an
+      # RBS inline comment signature.
+      #
+      # Sorbet requires setter methods to return `void`. Declaring any other
+      # return type violates the setter contract and is rejected by Sorbet
+      # under `#typed: strict` and above.
+      #
+      # @example
+      #
+      #   # bad
+      #   sig { params(name: String).returns(String) }
+      #   def name=(name); end
+      #
+      #   # good
+      #   sig { params(name: String).void }
+      #   def name=(name); end
+      #
+      #   # bad
+      #   #: (String) -> String
+      #   def name=(name); end
+      #
+      #   # good
+      #   #: (String) -> void
+      #   def name=(name); end
+      #
+      #   # bad
+      #   #: (
+      #   #|   String name
+      #   #| ) -> String
+      #   def name=(name); end
+      #
+      #   # good
+      #   #: (
+      #   #|   String name
+      #   #| ) -> void
+      #   def name=(name); end
+      #
+      class SetterReturnType < ::RuboCop::Cop::Base
+        include SignatureHelp
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = "Setter methods must declare a `void` return type."
+
+        NON_SETTER_OPERATORS = ["==", "===", "!=", "<=", ">="].freeze
+
+        def on_def(node)
+          check(node)
+        end
+        alias_method :on_defs, :on_def
+
+        private
+
+        def check(node)
+          return unless setter?(node)
+
+          target = outermost_send_ancestor(node)
+          sigs = preceding_sigs(target)
+          if sigs.any?
+            sigs.each { |sig| check_sig(sig) }
+          else
+            check_rbs(target)
+          end
+        end
+
+        def setter?(node)
+          name = node.method_name.to_s
+          name.end_with?("=") && !NON_SETTER_OPERATORS.include?(name)
+        end
+
+        # Climb past `private`/`public`/`protected` and other send wrappers so
+        # sig/RBS lookup runs against the real surrounding siblings rather than
+        # the send's other arguments.
+        def outermost_send_ancestor(node)
+          node = node.parent while node.parent&.send_type?
+          node
+        end
+
+        # The `sig` blocks immediately preceding `target` among its siblings,
+        # supporting consecutive overload sigs. The scan stops at the first
+        # non-signature sibling so a setter never inherits another method's sig.
+        def preceding_sigs(target)
+          parent = target.parent
+          return [] unless parent
+
+          siblings = parent.children
+          index = siblings.index { |sibling| sibling.equal?(target) }
+          sigs = []
+          siblings[0...index].reverse_each do |sibling|
+            break unless sibling && signature?(sibling)
+
+            sigs.unshift(sibling)
+          end
+          sigs
+        end
+
+        def check_sig(sig)
+          decl = return_declaration(sig.body)
+          return unless decl # incomplete signature: nothing declared to check
+          return if decl.method?(:void)
+
+          return unless decl.first_argument # malformed returns
+
+          sig_return_range = sig_return_range(decl)
+
+          add_offense(sig_return_range) do |corrector|
+            corrector.replace(sig_return_range, "void")
+          end
+        end
+
+        # Walks the receiver chain of the sig body (the builder call chain)
+        # and returns the outermost `void` or `returns` node, so a `void` or
+        # `returns` nested inside a type argument (e.g. `T.proc.void`) is not
+        # mistaken for the method's return declaration.
+        def return_declaration(node)
+          return unless node&.send_type?
+
+          if node.method?(:void) || node.method?(:returns)
+            node
+          else
+            return_declaration(node.receiver)
+          end
+        end
+
+        # Range covering `returns(TYPE)` (selector through the closing
+        # paren / last argument), to be replaced with `void`.
+        def sig_return_range(returns_node)
+          end_pos = returns_node.loc.end&.end_pos
+          end_pos ||= returns_node.last_argument&.source_range&.end_pos
+          end_pos ||= returns_node.loc.selector.end_pos
+          range_between(returns_node.loc.selector.begin_pos, end_pos)
+        end
+
+        def check_rbs(node)
+          ::RuboCop::Sorbet::RBSParser.rbs_signatures_before(processed_source, node).each do |sig|
+            range = sig.return_type_range
+            next unless range
+            next if sig.void?
+
+            offense_range, replace_range = range
+            add_offense(offense_range) do |corrector|
+              corrector.replace(replace_range, "void")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -55,6 +55,7 @@ require_relative "sorbet/signatures/forbid_sig_with_runtime"
 require_relative "sorbet/signatures/forbid_sig_without_runtime"
 require_relative "sorbet/signatures/keyword_argument_ordering"
 require_relative "sorbet/signatures/runtime_on_failure_depends_on_checked"
+require_relative "sorbet/signatures/setter_return_type"
 require_relative "sorbet/signatures/signature_build_order"
 require_relative "sorbet/signatures/void_checked_tests"
 

--- a/lib/rubocop/sorbet.rb
+++ b/lib/rubocop/sorbet.rb
@@ -3,6 +3,7 @@
 require "rubocop"
 require "rubocop/sorbet/version"
 require "rubocop/sorbet/plugin"
+require "rubocop/sorbet/rbs_parser"
 require "pathname"
 require "yaml"
 

--- a/lib/rubocop/sorbet/rbs_parser.rb
+++ b/lib/rubocop/sorbet/rbs_parser.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Sorbet
+    # Pure helpers for parsing RBS inline-comment signatures (`#:` / `#|`).
+    #
+    # Every public method takes a `processed_source` and/or comment nodes
+    # explicitly, so this module is usable both from a Cop and from a plain
+    # service class such as
+    # `RuboCop::Cop::Sorbet::EnforceSignatures::RBSSignatureChecker`.
+    # No Cop::Base state is required.
+    #
+    # `rbs_signatures_before` returns `Signature` objects that encapsulate one
+    # RBS overload each; ask them for `return_type`, `return_type_range`, and
+    # `void?` rather than reaching back into the parser for those facts.
+    module RBSParser
+      # `#:` begins an RBS signature (each repeated `#:` line is a new overload).
+      RBS_SIGNATURE_PREFIX = /\A#\s*:/
+      # `#|` continues the preceding `#:` signature (e.g. multiline params/returns).
+      RBS_CONTINUATION_PREFIX = /\A#\s*\|/
+
+      class << self
+        # The RBS signatures attached to `node`, one `Signature` per overload.
+        # Climbs `private`/`public`/other send wrappers, collects the contiguous
+        # comment block above the unwrapped node, and groups the RBS comments.
+        # A signature separated from the method by a blank line is not attached.
+        def rbs_signatures_before(processed_source, node)
+          node = node.parent while node.parent&.send_type?
+          rbs_signature_groups(comments_above(processed_source, node))
+            .map { |group| Signature.new(processed_source, group) }
+        end
+
+        private
+
+        # Group already-collected comments into RBS signatures. A `#:` line begins
+        # a new overload; subsequent `#|` lines continue it. Non-RBS comments are
+        # skipped.
+        def rbs_signature_groups(comments)
+          groups = []
+          comments.each do |comment|
+            case comment.text
+            when RBS_SIGNATURE_PREFIX
+              groups << [comment]
+            when RBS_CONTINUATION_PREFIX
+              groups.last << comment if groups.any?
+            end
+          end
+          groups
+        end
+
+        # Comments forming a contiguous block immediately above `node`, in source
+        # order. A blank line or non-comment sibling breaks the run.
+        def comments_above(processed_source, node)
+          comments = processed_source
+            .ast_with_comments[node]
+            .select { |comment| comment.loc.line < node.loc.line }
+            .sort_by { |comment| comment.loc.line }
+          return [] if comments.empty?
+
+          block = []
+          expected = node.loc.line
+          comments.reverse_each do |comment|
+            break unless comment.loc.line + 1 == expected
+
+            block.unshift(comment)
+            expected = comment.loc.line
+          end
+          block
+        end
+      end
+
+      # One RBS signature (a `#:` line plus any `#|` continuation lines).
+      # Encapsulates the parsed structure so callers query the signature rather
+      # than re-parsing comments through the module.
+      class Signature
+        attr_reader :comments
+
+        def initialize(processed_source, comments)
+          @processed_source = processed_source
+          @comments = comments
+        end
+
+        # The return type expression as a string (e.g. `"String"`, `"void"`,
+        # `"^(Integer) -> void"`, `"Integer | String"`), or nil if the
+        # signature has no return arrow or an empty return.
+        def return_type
+          parsed[:expr]
+        end
+
+        # `[highlight_range, replace_range]` covering the return type
+        # expression, or nil if there is no return type. `highlight_range`
+        # covers the first token (which may span `#|` lines); `replace_range`
+        # covers the entire return expression.
+        def return_type_range
+          return unless parsed[:expr]
+
+          [parsed[:highlight], parsed[:replace]]
+        end
+
+        # True if the signature declares a `void` return type.
+        def void?
+          return_type == "void"
+        end
+
+        private
+
+        def parsed
+          @parsed ||= compute
+        end
+
+        def compute
+          segments = @comments.map { |comment| strip_rbs_prefix(comment.text) }
+          joined = segments.map(&:first).join(" ")
+          arrow_idx = method_arrow_index(joined)
+          return {} unless arrow_idx
+
+          expr = joined[(arrow_idx + 2)..].strip
+          return {} if expr.empty?
+
+          first_token = expr[/\S+/]
+          token_start = joined.index(first_token, arrow_idx + 2)
+          highlight = range_for_token(segments, token_start, first_token.length)
+          replace_end = return_end_pos(segments)
+          replace = Parser::Source::Range.new(@processed_source.buffer, highlight.begin_pos, replace_end)
+          { expr: expr, highlight: highlight, replace: replace }
+        end
+
+        # Index of the method return arrow: the first `->` at the top level,
+        # i.e. outside parameter/block/proc delimiters. A proc return type such
+        # as `^(Integer) -> void` has its own nested arrow that must not be
+        # mistaken for the method arrow.
+        def method_arrow_index(joined)
+          depth = 0
+          joined.each_char.with_index do |char, index|
+            case char
+            when "(", "[", "{"
+              depth += 1
+            when ")", "]", "}"
+              depth -= 1
+            when "-"
+              return index if depth.zero? && joined[index + 1] == ">"
+            end
+          end
+          nil
+        end
+
+        # Map a position within the joined signature back to the originating
+        # comment and build a source range covering `length` characters.
+        def range_for_token(segments, token_start, length)
+          offset = 0
+          @comments.each_with_index do |comment, index|
+            content, prefix_len = segments[index]
+            seg_end = offset + content.length
+            if token_start < seg_end
+              content_offset = token_start - offset
+              line_start = @processed_source.buffer.line_range(comment.loc.line).begin_pos
+              start_pos = line_start + comment.loc.column + prefix_len + content_offset
+              return Parser::Source::Range.new(@processed_source.buffer, start_pos, start_pos + length)
+            end
+            offset = seg_end + 1 # +1 for the join space
+          end
+          nil
+        end
+
+        # Source position at the end of the group's last non-blank signature
+        # content; the return type expression runs to here.
+        def return_end_pos(segments)
+          last_comment = @comments.last
+          _, prefix_len = segments.last
+          content = segments.last.first.rstrip
+          line_start = @processed_source.buffer.line_range(last_comment.loc.line).begin_pos
+          line_start + last_comment.loc.column + prefix_len + content.length
+        end
+
+        # Strip the leading `#:`/`#|` marker and surrounding whitespace,
+        # returning `[content, prefix_length]`. `prefix_length` is the number
+        # of characters consumed from the original text, for mapping
+        # joined-content positions back to source offsets.
+        def strip_rbs_prefix(text)
+          match = text.match(/\A#\s*[:|]\s*/)
+          return [text, 0] unless match
+
+          [match.post_match, match[0].length]
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -54,6 +54,7 @@ In the following section you find all available cops:
 * [Sorbet/Refinement](cops_sorbet.md#sorbetrefinement)
 * [Sorbet/RuntimeOnFailureDependsOnChecked](cops_sorbet.md#sorbetruntimeonfailuredependsonchecked)
 * [Sorbet/SelectByIsA](cops_sorbet.md#sorbetselectbyisa)
+* [Sorbet/SetterReturnType](cops_sorbet.md#sorbetsetterreturntype)
 * [Sorbet/SignatureBuildOrder](cops_sorbet.md#sorbetsignaturebuildorder)
 * [Sorbet/SingleLineRbiClassModuleDefinitions](cops_sorbet.md#sorbetsinglelinerbiclassmoduledefinitions)
 * [Sorbet/StrictSigil](cops_sorbet.md#sorbetstrictsigil)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1363,6 +1363,52 @@ strings_or_integers.select { |e| e.kind_of?(String) }
 strings_or_integers.grep(String)
 ```
 
+## Sorbet/SetterReturnType
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes (Unsafe) | <<next>> | -
+
+Checks that setter methods (methods whose name ends with `=`)
+declare a `void` return type, in either a Sorbet `sig` block or an
+RBS inline comment signature.
+
+Sorbet requires setter methods to return `void`. Declaring any other
+return type violates the setter contract and is rejected by Sorbet
+under `#typed: strict` and above.
+
+### Examples
+
+```ruby
+# bad
+sig { params(name: String).returns(String) }
+def name=(name); end
+
+# good
+sig { params(name: String).void }
+def name=(name); end
+
+# bad
+#: (String) -> String
+def name=(name); end
+
+# good
+#: (String) -> void
+def name=(name); end
+
+# bad
+#: (
+#|   String name
+#| ) -> String
+def name=(name); end
+
+# good
+#: (
+#|   String name
+#| ) -> void
+def name=(name); end
+```
+
 ## Sorbet/SignatureBuildOrder
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -309,6 +309,20 @@ module RuboCop
             RUBY
           end
 
+          # An RBS signature separated from the method by a blank line is not
+          # attached to it, even when an ordinary comment sits immediately
+          # above the method. The contiguous-comment lookup must not reach back
+          # past the blank line and pick up the stale `#:` signature.
+          def test_makes_offense_if_rbs_signature_separated_by_blank_line_from_adjacent_comment
+            assert_offense(<<~RUBY)
+              #: -> void
+
+              # note
+              def foo; end
+              ^^^^^^^^^^^^ #{MSG}
+            RUBY
+          end
+
           def test_does_not_check_signature_for_accessors
             assert_no_offenses(<<~RUBY)
               class Foo

--- a/test/rubocop/cop/sorbet/signatures/setter_return_type_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/setter_return_type_test.rb
@@ -1,0 +1,455 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Cop
+    module Sorbet
+      module Signatures
+        class SetterReturnTypeTest < ::Minitest::Test
+          MSG = "Setter methods must declare a `void` return type."
+
+          def setup
+            @cop = target_cop.new(cop_config)
+          end
+
+          def target_cop
+            SetterReturnType
+          end
+
+          def test_offense_for_sig_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_singleton_setter_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              def self.name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              def self.name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_index_setter_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(key: Symbol, value: String).returns(String) }
+                                                       ^^^^^^^^^^^^^^^ #{MSG}
+              def []=(key, value); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(key: Symbol, value: String).void }
+              def []=(key, value); end
+            RUBY
+          end
+
+          def test_offense_for_each_overload_sig_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              sig { params(name: Integer).returns(Integer) }
+                                          ^^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              sig { params(name: Integer).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_sig_with_returns_t_proc_void
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(T.proc.void) }
+                                         ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_multiline_sig_with_returns
+            assert_offense(<<~RUBY)
+              sig do
+                params(name: String)
+                  .returns(String)
+                   ^^^^^^^^^^^^^^^ #{MSG}
+              end
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig do
+                params(name: String)
+                  .void
+              end
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_final_sig_with_returns
+            assert_offense(<<~RUBY)
+              sig(:final) { params(name: String).returns(String) }
+                                                 ^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig(:final) { params(name: String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_private_def_setter_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              private def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              private def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_sig_with_returns_and_trailing_modifier
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String).soft }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void.soft }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_each_of_two_identical_setter_defs
+            assert_offense(<<~RUBY)
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+
+              sig { params(name: String).returns(String) }
+                                         ^^^^^^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(name: String).void }
+              def name=(name); end
+
+              sig { params(name: String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_with_non_void_return
+            assert_offense(<<~RUBY)
+              #: (String) -> String
+                             ^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_with_non_void_return_private_def
+            assert_offense(<<~RUBY)
+              #: (String) -> String
+                             ^^^^^^ #{MSG}
+              private def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              private def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_multiline_rbs_with_non_void_return
+            assert_offense(<<~RUBY)
+              #: (
+              #| String name
+              #| ) -> String
+                      ^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (
+              #| String name
+              #| ) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_multiline_rbs_class_method
+            assert_offense(<<~RUBY)
+              #: (
+              #| String name
+              #| ) -> String
+                      ^^^^^^ #{MSG}
+              def self.name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (
+              #| String name
+              #| ) -> void
+              def self.name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_overload_mixed_void_and_non_void
+            assert_offense(<<~RUBY)
+              #: (String) -> void
+              #: (Integer) -> Integer
+                              ^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              #: (Integer) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_overload_both_non_void
+            assert_offense(<<~RUBY)
+              #: (String) -> String
+                             ^^^^^^ #{MSG}
+              #: (Integer) -> Integer
+                              ^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              #: (Integer) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_multiline_rbs_overload_mixed
+            assert_offense(<<~RUBY)
+              #: (String) -> void
+              #: (
+              #| Integer name
+              #| ) -> Integer
+                      ^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              #: (
+              #| Integer name
+              #| ) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_proc_return
+            assert_offense(<<~RUBY)
+              #: (String) -> ^(Integer) -> void
+                             ^^^^^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_block_return
+            assert_offense(<<~RUBY)
+              #: () { (?) -> untyped } -> String
+                                          ^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: () { (?) -> untyped } -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_return_on_next_line
+            assert_offense(<<~RUBY)
+              #: (String) ->
+              #| String
+                 ^^^^^^ #{MSG}
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) ->
+              #| void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_offense_for_rbs_multiline_union_return
+            assert_offense(<<~RUBY)
+              #: (String) ->
+              #| Integer |
+                 ^^^^^^^ #{MSG}
+              #| String
+              def name=(name); end
+            RUBY
+            assert_correction(<<~RUBY)
+              #: (String) ->
+              #| void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_sig_with_void
+            assert_no_offenses(<<~RUBY)
+              sig { params(name: String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_sig_with_void_after_returns_chain
+            assert_no_offenses(<<~RUBY)
+              sig { params(name: String).returns(String).void }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_incomplete_sig_without_return
+            assert_no_offenses(<<~RUBY)
+              sig { params(name: String) }
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_multiline_sig_with_void
+            assert_no_offenses(<<~RUBY)
+              sig do
+                params(name: String).void
+              end
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_non_setter_method_with_returns
+            assert_no_offenses(<<~RUBY)
+              sig { params(name: String).returns(String) }
+              def name(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_operator_methods_ending_with_equals
+            assert_no_offenses(<<~RUBY)
+              sig { params(other: Object).returns(T::Boolean) }
+              def ==(other); end
+
+              sig { params(other: Object).returns(T::Boolean) }
+              def !=(other); end
+
+              sig { params(other: Object).returns(T::Boolean) }
+              def <=(other); end
+
+              sig { params(other: Object).returns(T::Boolean) }
+              def >=(other); end
+
+              sig { params(other: Object).returns(T::Boolean) }
+              def ===(other); end
+            RUBY
+          end
+
+          def test_offense_for_unicode_setter_with_returns
+            assert_offense(<<~RUBY)
+              sig { params(value: String).returns(String) }
+                                          ^^^^^^^^^^^^^^^ #{MSG}
+              def 名前=(value); end
+            RUBY
+            assert_correction(<<~RUBY)
+              sig { params(value: String).void }
+              def 名前=(value); end
+            RUBY
+          end
+
+          def test_does_not_inherit_sig_across_intervening_method
+            assert_no_offenses(<<~RUBY)
+              sig { params(x: Integer).returns(Integer) }
+              def foo(x); end
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_private_def_setter_with_void
+            assert_no_offenses(<<~RUBY)
+              sig { params(name: String).void }
+              private def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_with_void_return
+            assert_no_offenses(<<~RUBY)
+              #: (String) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_with_void_return_protected_def
+            assert_no_offenses(<<~RUBY)
+              #: (String) -> void
+              protected def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_non_rbs_comment_before_setter
+            assert_no_offenses(<<~RUBY)
+              # (String) -> String
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_block_void_return
+            assert_no_offenses(<<~RUBY)
+              #: () { (?) -> untyped } -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_return_void_on_next_line
+            assert_no_offenses(<<~RUBY)
+              #: (String) ->
+              #| void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_overload_both_void
+            assert_no_offenses(<<~RUBY)
+              #: (String) -> void
+              #: (Integer) -> void
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_without_return_type
+            assert_no_offenses(<<~RUBY)
+              #: (String)
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_setter_without_signature
+            assert_no_offenses(<<~RUBY)
+              def name=(name); end
+            RUBY
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/rubocop/sorbet/rbs_parser_test.rb
+++ b/test/rubocop/sorbet/rbs_parser_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RuboCop
+  module Sorbet
+    class RBSParserTest < ::Minitest::Test
+      # `RBSParser` is a pure module over a `ProcessedSource` and comment
+      # nodes; these tests exercise its public API (`rbs_signatures_before`
+      # and the `Signature` objects it returns) directly, without a Cop.
+
+      def parse(source)
+        RuboCop::ProcessedSource.new(source, 3.4)
+      end
+
+      # First `def`/`defs` node in the source, descending through send
+      # wrappers (`private def foo; end`) and `begin` bodies.
+      def def_node(ps)
+        ast = ps.ast
+        return ast if ast&.type?(:def, :defs)
+
+        ast&.each_node(:def, :defs)&.first
+      end
+
+      # --- rbs_signatures_before ---
+
+      def test_signatures_before_single_signature
+        sigs = signatures_before("#: (String) -> void\ndef foo; end")
+        assert_equal(1, sigs.size)
+        assert_equal(["#: (String) -> void"], sigs.first.comments.map(&:text))
+      end
+
+      def test_signatures_before_overloads
+        sigs = signatures_before("#: (String) -> void\n#: (Integer) -> void\ndef foo; end")
+        assert_equal(2, sigs.size)
+        assert_equal(["#: (String) -> void"], sigs[0].comments.map(&:text))
+        assert_equal(["#: (Integer) -> void"], sigs[1].comments.map(&:text))
+      end
+
+      def test_signatures_before_continuation_lines_join
+        sigs = signatures_before("#: (\n#| String name\n#| ) -> String\ndef foo; end")
+        assert_equal(1, sigs.size)
+        assert_equal(["#: (", "#| String name", "#| ) -> String"], sigs.first.comments.map(&:text))
+      end
+
+      def test_signatures_before_blank_line_separates
+        assert_empty(signatures_before("#: (String) -> void\n\ndef foo; end"))
+      end
+
+      def test_signatures_before_climbs_send_wrappers
+        sigs = signatures_before("#: -> void\nprivate def foo; end")
+        assert_equal(1, sigs.size)
+        assert_equal(["#: -> void"], sigs.first.comments.map(&:text))
+      end
+
+      def test_signatures_before_skips_adjacent_non_rbs_comments
+        sigs = signatures_before("# before\n#: (String) -> void\ndef foo; end")
+        assert_equal(1, sigs.size)
+        assert_equal(["#: (String) -> void"], sigs.first.comments.map(&:text))
+      end
+
+      def test_signatures_before_orphan_continuation_dropped
+        assert_empty(signatures_before("#| orphan\ndef foo; end"))
+      end
+
+      def test_signatures_before_empty_when_no_comments
+        assert_empty(signatures_before("def foo; end"))
+      end
+
+      # --- Signature#return_type / return_type_range / void? ---
+
+      def test_signature_return_type_simple
+        sig = signature("#: (String) -> String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("String", highlight.source)
+        assert_equal("String", replace.source)
+        refute(sig.void?)
+      end
+
+      def test_signature_return_type_multiline_params
+        sig = signature("#: (\n#| String name\n#| ) -> String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("String", highlight.source)
+        assert_equal("String", replace.source)
+      end
+
+      def test_signature_return_type_proc_return
+        sig = signature("#: (String) -> ^(Integer) -> void\ndef foo; end")
+        assert_equal("^(Integer) -> void", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("^(Integer)", highlight.source)
+        assert_equal("^(Integer) -> void", replace.source)
+      end
+
+      def test_signature_return_type_block_return
+        sig = signature("#: () { (?) -> untyped } -> String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("String", highlight.source)
+        assert_equal("String", replace.source)
+      end
+
+      def test_signature_return_type_on_next_line
+        sig = signature("#: (String) ->\n#| String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("String", highlight.source)
+        assert_equal("String", replace.source)
+      end
+
+      def test_signature_return_type_multiline_union
+        sig = signature("#: (String) ->\n#| Integer |\n#| String\ndef foo; end")
+        assert_equal("Integer | String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("Integer", highlight.source)
+        assert_equal("Integer |\n#| String", replace.source)
+      end
+
+      def test_signature_void_return
+        sig = signature("#: (String) -> void\ndef foo; end")
+        assert_equal("void", sig.return_type)
+        assert(sig.void?)
+        highlight, replace = sig.return_type_range
+        assert_equal("void", highlight.source)
+        assert_equal("void", replace.source)
+      end
+
+      def test_signature_return_type_nil_without_arrow
+        sig = signature("#: (String)\ndef foo; end")
+        assert_nil(sig.return_type)
+        assert_nil(sig.return_type_range)
+        refute(sig.void?)
+      end
+
+      def test_signature_return_type_nil_with_empty_return
+        sig = signature("#: (String) ->\ndef foo; end")
+        assert_nil(sig.return_type)
+        assert_nil(sig.return_type_range)
+      end
+
+      # Prefix-stripping robustness exercised through the public API: the
+      # marker may carry zero or multiple spaces before/after `:`/`|`.
+      def test_signature_return_type_with_no_space_after_marker
+        sig = signature("#:-> void\ndef foo; end")
+        assert_equal("void", sig.return_type)
+        assert(sig.void?)
+      end
+
+      def test_signature_return_type_with_multiple_spaces_after_marker
+        sig = signature("#  : (String) -> String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, = sig.return_type_range
+        assert_equal("String", highlight.source)
+      end
+
+      def test_signature_return_type_with_continuation_prefix_spacing
+        sig = signature("#: (String) ->\n#|   String\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, = sig.return_type_range
+        assert_equal("String", highlight.source)
+      end
+
+      private
+
+      def signatures_before(source)
+        ps = parse(source)
+        RBSParser.rbs_signatures_before(ps, def_node(ps))
+      end
+
+      def signature(source)
+        signatures_before(source).first
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new cop that flags setter methods (names ending in `=`, including `[]=` and Unicode identifiers, but excluding comparison operators like `==`, `<=`, `>=`, `!=`, `===`) whose signature does not declare a `void` return type. It supports both Sorbet `sig` blocks and RBS inline-comment signatures, with autocorrect that rewrites the return type to `void` (`SafeAutoCorrect: false` since the return contract changes).

Extract the RBS inline-comment parsing into a pure `RuboCop::Sorbet::RBSParser` module (used directly, not mixed in) whose public API is `rbs_signatures_before` plus the `Signature` value object exposing `return_type`, `return_type_range`, and `void?`. `EnforceSignatures::RBSSignatureChecker` now delegates to it.