### PR TITLE
Add autocorrect for RBS comments ↔ sig blocks signatures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rubocop-sorbet (0.13.2)
       lint_roller
       rubocop (>= 1.75.2)
+      spoom (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,7 @@ GEM
     drb (2.2.3)
     erb (4.0.4)
       cgi (>= 0.3.3)
+    erubi (1.13.1)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -25,6 +27,7 @@ GEM
     json (2.21.1)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
+    logger (1.7.0)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -44,12 +47,20 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
+    rbi (0.4.1)
+      prism (~> 1.0)
+      rbs (>= 4.0.1)
+    rbs (4.1.1)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     regexp_parser (2.12.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    rexml (3.4.4)
     rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -72,14 +83,34 @@ GEM
       rubocop (~> 1.62)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sorbet (0.6.13386)
+      sorbet-static (= 0.6.13386)
+    sorbet-runtime (0.6.13386)
+    sorbet-static (0.6.13386-universal-darwin)
+    sorbet-static (0.6.13386-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13386)
+      sorbet (= 0.6.13386)
+      sorbet-runtime (= 0.6.13386)
+    spoom (1.8.6)
+      erubi (>= 1.10.0)
+      prism (>= 0.28.0)
+      rbi (>= 0.4.1)
+      rbs (>= 4.0.0.dev.5)
+      rexml (>= 3.2.6)
+      sorbet-static-and-runtime (>= 0.5.10187)
+      thor (>= 0.19.2)
     stringio (3.1.7)
+    thor (1.5.0)
+    tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     yard (0.9.37)
 
 PLATFORMS
-  ruby
+  arm64-darwin-23
+  arm64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   debug
@@ -93,4 +124,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.4.18
+   2.6.9

--- a/config/default.yml
+++ b/config/default.yml
@@ -109,7 +109,7 @@ Sorbet/EnforceSignatures:
   AutocorrectStyle: sig
   SafeAutoCorrect: false
   VersionAdded: 0.3.4
-  VersionChanged: '0.13.0'
+  VersionChanged: '<<next>>'
 
 Sorbet/EnforceSingleSigil:
   Description: 'Ensures that there is only one Sorbet sigil in a file.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -107,6 +107,7 @@ Sorbet/EnforceSignatures:
   Enabled: false
   Style: sig
   AutocorrectStyle: sig
+  SafeAutoCorrect: false
   VersionAdded: 0.3.4
   VersionChanged: '0.13.0'
 

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -164,8 +164,25 @@ module RuboCop
 
         def autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
           range = sig_correction_range(sig_nodes)
-          translated = translate_sigs_to_rbs("#{range.source}\n#{node.source}")
-          corrector.replace(range, translated_signature_prefix(translated).rstrip)
+          sig_source = normalize_runtime_sig_receivers(range, sig_nodes)
+          translated = translate_sigs_to_rbs("#{sig_source}\n#{node.source}")
+          replacement = translated_signature_prefix(translated, reject_sig: true)
+          return unless replacement
+
+          corrector.replace(range, replacement.rstrip)
+        end
+
+        def normalize_runtime_sig_receivers(range, sig_nodes)
+          source = range.source.dup
+          sig_nodes.reverse_each do |sig_node|
+            next unless sig_with_runtime?(sig_node)
+
+            send_node = sig_node.send_node
+            receiver_start = send_node.receiver.source_range.begin_pos - range.begin_pos
+            selector_start = send_node.loc.selector.begin_pos - range.begin_pos
+            source[receiver_start...selector_start] = ""
+          end
+          source
         end
 
         def remove_sigs(corrector, sig_nodes)
@@ -192,15 +209,18 @@ module RuboCop
         end
 
         def translate_signature_to_rbs(signature, node)
-          translated_signature_prefix(translate_sigs_to_rbs("#{signature}#{node.source}"))
+          translated = translate_sigs_to_rbs("#{signature}#{node.source}")
+          translated_signature_prefix(translated, reject_sig: true)
         end
 
-        def translated_signature_prefix(translated)
+        def translated_signature_prefix(translated, reject_sig: false)
           translated_source = RuboCop::ProcessedSource.new(
             translated,
             [processed_source.ruby_version, 3.3].max,
             parser_engine: processed_source.parser_engine,
           )
+          return if reject_sig && translated_source.ast&.each_node&.any? { |child| signature?(child) }
+
           signable_node = translated_source.ast&.each_node&.find do |child|
             child.any_def_type? || accessor?(child)
           end

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -77,7 +77,7 @@ module RuboCop
         def check_node(node)
           scope = self.scope(node)
           sig_nodes = sig_checker.signature_nodes(scope)
-          rbs_node = rbs_checker.signature_node(node)
+          rbs_signatures = rbs_checker.signatures(node)
 
           case signature_style
           when "rbs"
@@ -89,21 +89,26 @@ module RuboCop
               return
             end
 
-            unless rbs_node
+            if rbs_signatures.empty?
               add_offense(node, message: "Each method is required to have an RBS signature.") do |corrector|
                 autocorrect_with_signature_type(corrector, node, "rbs")
               end
             end
           when "both"
             # Both styles allowed - require at least one
-            if sig_nodes.empty? && !rbs_node
+            if sig_nodes.empty? && rbs_signatures.empty?
               add_offense(node, message: "Each method is required to have a signature.") do |corrector|
                 autocorrect_with_signature_type(corrector, node, autocorrect_style)
               end
             end
           else # "sig" (default)
             # Sig style - only sig signatures allowed
-            if sig_nodes.empty?
+            if sig_nodes.empty? && !rbs_signatures.empty?
+              first_comment = rbs_signatures.first.comments.first
+              add_offense(first_comment, message: "Use sig block signatures rather than RBS signature comments.") do |corrector|
+                autocorrect_rbs_to_sigs(corrector, node, rbs_signatures)
+              end
+            elsif sig_nodes.empty?
               add_offense(node, message: "Each method is required to have a sig block signature.") do |corrector|
                 autocorrect_with_signature_type(corrector, node, "sig")
               end
@@ -131,15 +136,53 @@ module RuboCop
           corrector.insert_before(target, correction)
         end
 
+        def autocorrect_rbs_to_sigs(corrector, node, rbs_signatures)
+          comments = rbs_signatures.flat_map(&:comments)
+          range = rbs_correction_range(comments)
+          rbs_source = range.source.lines.map(&:lstrip).join
+          translated = translate_rbs_to_sigs("#{rbs_source}\n#{node.source}")
+          replacement = translated_signature_prefix(translated).rstrip
+          indent = " " * range.column
+          corrector.replace(range, replacement.gsub("\n", "\n#{indent}"))
+        end
+
         def autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
           range = sig_nodes.first.source_range.with(end_pos: sig_nodes.last.source_range.end_pos)
           translated = translate_sigs_to_rbs("#{range.source}\n#{node.source}")
-          corrector.replace(range, translated.delete_suffix(node.source).rstrip)
+          corrector.replace(range, translated_signature_prefix(translated).rstrip)
+        end
+
+        def rbs_correction_range(comments)
+          first_comment = comments.first
+          expected_line = first_comment.loc.line
+          processed_source.comments.reverse_each do |comment|
+            next if comment.loc.line >= first_comment.loc.line
+            break unless comment.loc.line + 1 == expected_line && comment.text.start_with?("# @")
+
+            first_comment = comment
+            expected_line = comment.loc.line
+          end
+
+          first_comment.source_range.with(end_pos: comments.last.source_range.end_pos)
         end
 
         def translate_signature_to_rbs(signature, node)
-          source = node.source
-          translate_sigs_to_rbs("#{signature}#{source}").delete_suffix(source)
+          translated_signature_prefix(translate_sigs_to_rbs("#{signature}#{node.source}"))
+        end
+
+        def translated_signature_prefix(translated)
+          translated_source = RuboCop::ProcessedSource.new(
+            translated,
+            [processed_source.ruby_version, 3.3].max,
+            parser_engine: processed_source.parser_engine,
+          )
+          signable_node = translated_source.ast&.each_node&.find do |child|
+            child.any_def_type? || accessor?(child)
+          end
+          raise "Spoom translation did not produce a method or accessor" unless signable_node
+
+          target = leftmost_send_ancestor(signable_node)
+          translated.byteslice(0, target.source_range.begin_pos)
         end
 
         def translate_sigs_to_rbs(input)
@@ -148,6 +191,13 @@ module RuboCop
             file: processed_source.file_path,
             positional_names: false,
           )
+        end
+
+        def translate_rbs_to_sigs(input)
+          ::Spoom::Sorbet::Translate::RBSCommentsToSorbetSigs::HumanReadableTranslator.new(
+            input,
+            file: processed_source.file_path,
+          ).rewrite
         end
 
         def leftmost_send_ancestor(node)
@@ -256,8 +306,8 @@ module RuboCop
         end
 
         class RBSSignatureChecker < SignatureChecker
-          def signature_node(node)
-            ::RuboCop::Sorbet::RBSParser.rbs_signatures_before(processed_source, node).first&.comments&.first
+          def signatures(node)
+            ::RuboCop::Sorbet::RBSParser.rbs_signatures_before(processed_source, node)
           end
         end
 

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "spoom"
+
 module RuboCop
   module Cop
     module Sorbet
@@ -74,14 +76,16 @@ module RuboCop
 
         def check_node(node)
           scope = self.scope(node)
-          sig_node = sig_checker.signature_node(scope)
+          sig_nodes = sig_checker.signature_nodes(scope)
           rbs_node = rbs_checker.signature_node(node)
 
           case signature_style
           when "rbs"
             # RBS style - only RBS signatures allowed
-            if sig_node
-              add_offense(sig_node, message: "Use RBS signature comments rather than sig blocks.")
+            unless sig_nodes.empty?
+              add_offense(sig_nodes.first, message: "Use RBS signature comments rather than sig blocks.") do |corrector|
+                autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
+              end
               return
             end
 
@@ -92,14 +96,14 @@ module RuboCop
             end
           when "both"
             # Both styles allowed - require at least one
-            unless sig_node || rbs_node
+            if sig_nodes.empty? && !rbs_node
               add_offense(node, message: "Each method is required to have a signature.") do |corrector|
                 autocorrect_with_signature_type(corrector, node, autocorrect_style)
               end
             end
           else # "sig" (default)
             # Sig style - only sig signatures allowed
-            unless sig_node
+            if sig_nodes.empty?
               add_offense(node, message: "Each method is required to have a sig block signature.") do |corrector|
                 autocorrect_with_signature_type(corrector, node, "sig")
               end
@@ -119,24 +123,37 @@ module RuboCop
 
         def autocorrect_with_signature_type(corrector, node, type)
           target = leftmost_send_ancestor(node)
-          suggest = create_signature_suggestion(target, type)
+          suggest = SigSuggestion.new(target.loc.column, param_type_placeholder, return_type_placeholder)
           populate_signature_suggestion(suggest, node)
-          corrector.insert_before(target, suggest.to_autocorrect)
+
+          correction = suggest.to_autocorrect
+          correction = translate_signature_to_rbs(correction, node) if type == "rbs"
+          corrector.insert_before(target, correction)
+        end
+
+        def autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
+          range = sig_nodes.first.source_range.with(end_pos: sig_nodes.last.source_range.end_pos)
+          translated = translate_sigs_to_rbs("#{range.source}\n#{node.source}")
+          corrector.replace(range, translated.delete_suffix(node.source).rstrip)
+        end
+
+        def translate_signature_to_rbs(signature, node)
+          source = node.source
+          translate_sigs_to_rbs("#{signature}#{source}").delete_suffix(source)
+        end
+
+        def translate_sigs_to_rbs(input)
+          ::Spoom::Sorbet::Translate.sorbet_sigs_to_rbs_comments(
+            input,
+            file: processed_source.file_path,
+            positional_names: false,
+          )
         end
 
         def leftmost_send_ancestor(node)
           ancestor = node
           ancestor = ancestor.parent while ancestor.parent&.send_type?
           ancestor
-        end
-
-        def create_signature_suggestion(node, type)
-          case type
-          when "rbs"
-            RBSSuggestion.new(node.loc.column)
-          else # "sig"
-            SigSuggestion.new(node.loc.column, param_type_placeholder, return_type_placeholder)
-          end
         end
 
         def populate_signature_suggestion(suggest, node)
@@ -151,11 +168,7 @@ module RuboCop
           suggest.returns = "void" if instance_initialize?(node)
 
           node.arguments.each do |arg|
-            if arg.blockarg_type? && suggest.respond_to?(:has_block=)
-              suggest.has_block = true
-            else
-              suggest.params << Param.new(arg.children.first, arg.type)
-            end
+            suggest.params << Param.new(arg.children.first, arg.type)
           end
         end
 
@@ -177,11 +190,6 @@ module RuboCop
         def populate_accessor_suggestion(suggest, node)
           method = node.children[1]
           symbol = node.children[2]
-
-          if suggest.is_a?(RBSSuggestion)
-            suggest.attribute = true
-            return
-          end
 
           add_accessor_parameter_if_needed(suggest, symbol, method)
           set_void_return_for_writer(suggest, method)
@@ -254,21 +262,23 @@ module RuboCop
         end
 
         class SigSignatureChecker < SignatureChecker
+          EMPTY_SIGNATURES = [].freeze
+
           def initialize(processed_source)
             super(processed_source)
-            @last_sig_for_scope = {}
+            @signatures_for_scope = {}
           end
 
-          def signature_node(scope)
-            @last_sig_for_scope[scope]
+          def signature_nodes(scope)
+            @signatures_for_scope.fetch(scope, EMPTY_SIGNATURES)
           end
 
           def on_signature(node, scope)
-            @last_sig_for_scope[scope] = node
+            (@signatures_for_scope[scope] ||= []) << node
           end
 
           def clear_signature(scope)
-            @last_sig_for_scope[scope] = nil
+            @signatures_for_scope.delete(scope)
           end
         end
 
@@ -303,59 +313,6 @@ module RuboCop
               "void"
             else
               "returns(#{@returns})"
-            end
-          end
-        end
-
-        class RBSSuggestion
-          attr_accessor :params, :returns, :has_block, :attribute
-
-          def initialize(indent)
-            @params = []
-            @returns = nil
-            @has_block = false
-            @attribute = false
-            @indent = indent
-          end
-
-          def to_autocorrect
-            "#: #{generate_signature}\n#{" " * @indent}"
-          end
-
-          private
-
-          def generate_signature
-            return @returns || "untyped" if @attribute
-
-            param_types = @params.map { |param| rbs_param(param) }.join(", ")
-            return_type = @returns || "untyped"
-
-            signature = if @params.empty?
-              "()"
-            else
-              "(#{param_types})"
-            end
-
-            signature += " { (?) -> untyped }" if @has_block
-            signature += " -> #{return_type}"
-
-            signature
-          end
-
-          def rbs_param(param)
-            case param.kind
-            when :kwarg
-              "#{param.name}: untyped"
-            when :kwoptarg
-              "?#{param.name}: untyped"
-            when :optarg
-              "?untyped"
-            when :restarg
-              "*untyped"
-            when :kwrestarg
-              "**untyped"
-            else
-              "untyped"
             end
           end
         end

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -27,6 +27,7 @@ module RuboCop
       # * `Style`: signature style to enforce - 'sig' for sig blocks, 'rbs' for RBS comments, 'both' to allow either (default: 'sig')
       # * `AutocorrectStyle`: signature style to use when autocorrecting - 'sig' for sig blocks, 'rbs' for RBS comments (default: 'sig'). Only used when `Style` is 'both'.
       class EnforceSignatures < ::RuboCop::Cop::Base
+        include RangeHelp
         extend AutoCorrector
         include SignatureHelp
 
@@ -78,13 +79,18 @@ module RuboCop
           scope = self.scope(node)
           sig_nodes = sig_checker.signature_nodes(scope)
           rbs_signatures = rbs_checker.signatures(node)
+          rbs_signatures = rbs_checker.signatures(sig_nodes.first) if rbs_signatures.empty? && !sig_nodes.empty?
 
           case signature_style
           when "rbs"
             # RBS style - only RBS signatures allowed
             unless sig_nodes.empty?
               add_offense(sig_nodes.first, message: "Use RBS signature comments rather than sig blocks.") do |corrector|
-                autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
+                if rbs_signatures.empty?
+                  autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
+                else
+                  remove_sigs(corrector, sig_nodes)
+                end
               end
               return
             end
@@ -147,9 +153,18 @@ module RuboCop
         end
 
         def autocorrect_sigs_to_rbs(corrector, node, sig_nodes)
-          range = sig_nodes.first.source_range.with(end_pos: sig_nodes.last.source_range.end_pos)
+          range = sig_correction_range(sig_nodes)
           translated = translate_sigs_to_rbs("#{range.source}\n#{node.source}")
           corrector.replace(range, translated_signature_prefix(translated).rstrip)
+        end
+
+        def remove_sigs(corrector, sig_nodes)
+          range = range_by_whole_lines(sig_correction_range(sig_nodes), include_final_newline: true)
+          corrector.remove(range)
+        end
+
+        def sig_correction_range(sig_nodes)
+          sig_nodes.first.source_range.with(end_pos: sig_nodes.last.source_range.end_pos)
         end
 
         def rbs_correction_range(comments)

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -109,10 +109,14 @@ module RuboCop
             end
           else # "sig" (default)
             # Sig style - only sig signatures allowed
-            if sig_nodes.empty? && !rbs_signatures.empty?
+            if rbs_signatures.any?
               first_comment = rbs_signatures.first.comments.first
               add_offense(first_comment, message: "Use sig block signatures rather than RBS signature comments.") do |corrector|
-                autocorrect_rbs_to_sigs(corrector, node, rbs_signatures)
+                if sig_nodes.empty?
+                  autocorrect_rbs_to_sigs(corrector, node, rbs_signatures)
+                else
+                  remove_rbs(corrector, rbs_signatures)
+                end
               end
             elsif sig_nodes.empty?
               add_offense(node, message: "Each method is required to have a sig block signature.") do |corrector|
@@ -150,6 +154,12 @@ module RuboCop
           replacement = translated_signature_prefix(translated).rstrip
           indent = " " * range.column
           corrector.replace(range, replacement.gsub("\n", "\n#{indent}"))
+        end
+
+        def remove_rbs(corrector, rbs_signatures)
+          comments = rbs_signatures.flat_map(&:comments)
+          range = range_by_whole_lines(rbs_correction_range(comments), include_final_newline: true)
+          corrector.remove(range)
         end
 
         def autocorrect_sigs_to_rbs(corrector, node, sig_nodes)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -310,7 +310,7 @@ other comments or magic comments are left in the same place.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | Yes (Unsafe) | 0.3.4 | 0.13.0
+Disabled | Yes | Yes (Unsafe) | 0.3.4 | <<next>>
 
 Checks that every method definition and attribute accessor has a Sorbet signature.
 

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -310,7 +310,7 @@ other comments or magic comments are left in the same place.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | Yes  | 0.3.4 | 0.13.0
+Disabled | Yes | Yes (Unsafe) | 0.3.4 | 0.13.0
 
 Checks that every method definition and attribute accessor has a Sorbet signature.
 

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("lint_roller")
   spec.add_runtime_dependency("rubocop", ">= 1.75.2")
+  spec.add_runtime_dependency("spoom", "~> 1.8")
 end

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -1001,6 +1001,31 @@ module RuboCop
             RUBY
           end
 
+          def test_enforce_rbs_autocorrects_qualified_sig_signatures
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              T::Sig.sig { void }
+              ^^^^^^^^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
+              def foo; end
+
+              T::Sig::WithoutRuntime.sig { void }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
+              def bar; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: -> void
+              def foo; end
+
+              # @without_runtime
+              #: -> void
+              def bar; end
+            RUBY
+          end
+
           def test_enforce_rbs_removes_sig_when_rbs_signature_already_exists
             @cop = target_cop.new(cop_config({
               "Style" => "rbs",

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -984,6 +984,24 @@ module RuboCop
             RUBY
           end
 
+          def test_enforce_rbs_removes_sig_when_rbs_signature_already_exists
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              #: -> void
+              sig { void }
+              ^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
+              def foo; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: -> void
+              def foo; end
+            RUBY
+          end
+
           def test_enforce_rbs_autocorrects_abstract_sig_without_changing_method
             @cop = target_cop.new(cop_config({
               "Style" => "rbs",

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -445,6 +445,23 @@ module RuboCop
             RUBY
           end
 
+          def test_enforce_sig_removes_rbs_signature_when_sig_already_exists
+            @cop = target_cop.new(cop_config({
+              "Style" => "sig",
+            }))
+            assert_offense(<<~RUBY)
+              #: -> void
+              ^^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
+              sig { void }
+              def foo; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { void }
+              def foo; end
+            RUBY
+          end
+
           def test_enforce_sig_autocorrects_abstract_rbs_signature_without_changing_method
             @cop = target_cop.new(cop_config({
               "Style" => "sig",

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -429,14 +429,70 @@ module RuboCop
             RUBY
           end
 
-          def test_makes_offense_if_allow_rbs_false
+          def test_enforce_sig_autocorrects_rbs_signature
             @cop = target_cop.new(cop_config({
               "Style" => "sig",
             }))
             assert_offense(<<~RUBY)
               #: -> void
+              ^^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
               def foo; end
-              ^^^^^^^^^^^^ #{MSG_SIG}
+            RUBY
+
+            assert_correction(<<~RUBY)
+              sig { void }
+              def foo; end
+            RUBY
+          end
+
+          def test_enforce_sig_autocorrects_abstract_rbs_signature_without_changing_method
+            @cop = target_cop.new(cop_config({
+              "Style" => "sig",
+            }))
+            assert_offense(<<~RUBY)
+              # @abstract
+              #: -> Integer
+              ^^^^^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
+              def foo; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              # @abstract
+              sig { abstract.returns(Integer) }
+              def foo; end
+            RUBY
+          end
+
+          def test_enforce_sig_autocorrects_rbs_overloads_continuations_and_accessors
+            @cop = target_cop.new(cop_config({
+              "Style" => "sig",
+            }))
+
+            assert_offense(<<~RUBY)
+              class Foo
+                #: (String, ?Symbol) -> String
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
+                #: (
+                #| Integer,
+                #| ?Symbol
+                #| ) -> Integer
+                def foo(x, y = nil); end
+
+                #: String
+                ^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
+                attr_reader :name
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                sig { params(x: String, y: Symbol).returns(String) }
+                sig { params(x: Integer, y: Symbol).returns(Integer) }
+                def foo(x, y = nil); end
+
+                sig { returns(String) }
+                attr_reader :name
+              end
             RUBY
           end
 
@@ -928,6 +984,24 @@ module RuboCop
             RUBY
           end
 
+          def test_enforce_rbs_autocorrects_abstract_sig_without_changing_method
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              sig { abstract.returns(Integer) }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
+              def foo; end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              # @abstract
+              #: -> Integer
+              def foo; end
+            RUBY
+          end
+
           def test_enforce_rbs_autocorrects_sig_overloads
             @cop = target_cop.new(cop_config({
               "Style" => "rbs",
@@ -990,8 +1064,8 @@ module RuboCop
 
             assert_offense(<<~RUBY)
               #: -> void
+              ^^^^^^^^^^ Use sig block signatures rather than RBS signature comments.
               def foo; end
-              ^^^^^^^^^^^^ #{MSG_SIG}
             RUBY
           end
 

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -590,6 +590,19 @@ module RuboCop
                 ^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
               end
             RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                #: String
+                attr_reader :foo
+
+                #: String
+                attr_reader :bar
+
+                #: untyped
+                attr_writer :baz
+              end
+            RUBY
           end
 
           def test_enforce_rbs_takes_precedence_over_allow_rbs
@@ -625,15 +638,15 @@ module RuboCop
             RUBY
 
             assert_correction(<<~RUBY)
-              #: () -> untyped
+              #: -> untyped
               def foo; end
               #: (untyped, ?untyped, ?c: untyped) -> untyped
               def bar(a, b = 2, c: Foo.new); end
-              #: () { (?) -> untyped } -> untyped
+              #: ?{ (?) -> untyped } -> untyped
               def baz(&blk); end
-              #: (untyped, untyped) { (?) -> untyped } -> untyped
+              #: (untyped, untyped) ?{ (?) -> untyped } -> untyped
               def self.foo(a, b, &c); end
-              #: (untyped, *untyped, **untyped) -> untyped
+              #: (untyped, *untyped, **untyped c) -> untyped
               def self.bar(a, *b, **c); end
               #: (a: untyped) -> untyped
               def self.baz(a:); end
@@ -887,7 +900,7 @@ module RuboCop
 
             assert_correction(<<~RUBY)
               class Foo
-                #: () -> untyped
+                #: -> untyped
                 def foo
                 end
 
@@ -898,7 +911,7 @@ module RuboCop
             RUBY
           end
 
-          def test_enforce_rbs_does_not_autocorrect_sig_signatures
+          def test_enforce_rbs_autocorrects_sig_signatures
             @cop = target_cop.new(cop_config({
               "Style" => "rbs",
             }))
@@ -909,7 +922,33 @@ module RuboCop
               def foo; end
             RUBY
 
-            assert_no_corrections
+            assert_correction(<<~RUBY)
+              #: -> void
+              def foo; end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_sig_overloads
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+            }))
+
+            assert_offense(<<~RUBY)
+              class Foo
+                sig { params(x: String).returns(String) }
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use RBS signature comments rather than sig blocks.
+                sig { params(x: Integer).returns(Integer) }
+                def foo(x); end
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              class Foo
+                #: (String) -> String
+                #: (Integer) -> Integer
+                def foo(x); end
+              end
+            RUBY
           end
 
           def test_enforce_rbs_rejects_sig_signatures
@@ -991,7 +1030,7 @@ module RuboCop
             RUBY
 
             assert_correction(<<~RUBY)
-              #: () -> untyped
+              #: -> untyped
               def foo; end
               #: (untyped, untyped, untyped) -> untyped
               def bar(a, b, c); end


### PR DESCRIPTION
Add an autocorrect to `Sorbet/EnforceSignatures` to use Spoom for translation between Sorbet `sig` blocks and RBS comments:

   - generate missing RBS signatures through Spoom
   - translate existing `sig` blocks to RBS with `Style: rbs`
   - translate existing RBS comments to `sig` blocks with `Style: sig`
   - support overloads, multiline continuations, accessors, and annotations
   - mark autocorrection as unsafe

## Examples

With `Style: rbs`:

```ruby
  sig { params(x: String).returns(Integer) }
  def foo(x); end
```

becomes:

```ruby
  #: (String) -> Integer
  def foo(x); end
```

With Style: sig:

```ruby
  #: (String) -> Integer
  def foo(x); end
```

becomes:

```ruby
  sig { params(x: String).returns(Integer) }
  def foo(x); end
```