### PR TITLE
Support root-scoped T.bind calls

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_bind.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_bind.rb
@@ -19,7 +19,7 @@ module RuboCop
         RESTRICT_ON_SEND = [:bind].freeze
 
         # @!method t_bind?(node)
-        def_node_matcher(:t_bind?, "(send (const nil? :T) :bind _ _)")
+        def_node_matcher(:t_bind?, "(send (const {nil? cbase} :T) :bind _ _)")
 
         def on_send(node)
           add_offense(node) if t_bind?(node)

--- a/test/rubocop/cop/sorbet/forbid_t_bind_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_bind_test.rb
@@ -19,6 +19,9 @@ module RuboCop
 
             x = T.bind(self, String)
                 ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+            ::T.bind(self, String)
+            ^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
         end
       end


### PR DESCRIPTION
Recognize root-scoped `::T.bind` calls in `Sorbet/ForbidTBind` and add related test.