### PR TITLE
Autocorrect T.bind to RBS self assertions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rubocop-sorbet (0.14.0)
       lint_roller
+      rbi (~> 0.4)
       rubocop (>= 1.75.2)
       spoom (~> 1.8)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -217,7 +217,10 @@ Sorbet/ForbidTAbsurd:
 Sorbet/ForbidTBind:
   Description: 'Forbid usage of T.bind.'
   Enabled: false
+  AutocorrectToRBS: false
   VersionAdded: 0.10.4
+  SafeAutoCorrect: false
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTBindInAssignment:
   Description: 'Forbid assigning the result of T.bind.'

--- a/lib/rubocop/cop/sorbet/forbid_t_bind.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_bind.rb
@@ -17,12 +17,11 @@ module RuboCop
       #   # good
       #   #: self as Integer
       class ForbidTBind < RuboCop::Cop::Base
+        include RangeHelp
         extend AutoCorrector
 
         MSG = "Do not use `T.bind`."
-        COMMENT_START = "#"
-        HORIZONTAL_WHITESPACE = ["\t", " "].freeze
-        NEWLINES = ["\n", "\r"].freeze
+        LINE_ENDINGS = ["", "\n", "\r", "#"].freeze
         RESTRICT_ON_SEND = [:bind].freeze
 
         # @!method t_bind?(node)
@@ -50,29 +49,18 @@ module RuboCop
         def autocorrectable_t_bind?(node)
           return false unless node.first_argument&.self_type?
           return false unless assertion_ends_line?(node)
-          return false if rbs_annotation_follows?(node)
+          return false if ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
 
           node.source_range.source_line.index(/\S/) == node.source_range.column
         end
 
         def assertion_ends_line?(node)
-          source = processed_source.buffer.source
-          position = skip_horizontal_whitespace(source, node.source_range.end_pos)
-          character = source[position]
-
-          character.nil? || NEWLINES.include?(character) || character == COMMENT_START
+          LINE_ENDINGS.include?(source_after_horizontal_whitespace(node))
         end
 
-        def rbs_annotation_follows?(node)
-          source = processed_source.buffer.source
-          position = skip_horizontal_whitespace(source, node.source_range.end_pos)
-
-          source[position, 2] == "#:"
-        end
-
-        def skip_horizontal_whitespace(source, position)
-          position += 1 while HORIZONTAL_WHITESPACE.include?(source[position])
-          position
+        def source_after_horizontal_whitespace(node, length: 1)
+          range = range_with_surrounding_space(node.source_range, side: :right, newlines: false)
+          range.source_buffer.source[range.end_pos, length]
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/forbid_t_bind.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_bind.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rbi"
 
 module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.bind` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -15,16 +17,63 @@ module RuboCop
       #   # good
       #   #: self as Integer
       class ForbidTBind < RuboCop::Cop::Base
+        extend AutoCorrector
+
         MSG = "Do not use `T.bind`."
+        COMMENT_START = "#"
+        HORIZONTAL_WHITESPACE = ["\t", " "].freeze
+        NEWLINES = ["\n", "\r"].freeze
         RESTRICT_ON_SEND = [:bind].freeze
 
         # @!method t_bind?(node)
         def_node_matcher(:t_bind?, "(send (const {nil? cbase} :T) :bind _ _)")
 
         def on_send(node)
-          add_offense(node) if t_bind?(node)
+          return unless t_bind?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_bind_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_bind_to_rbs(corrector, node)
+          return unless cop_config["AutocorrectToRBS"]
+          return unless autocorrectable_t_bind?(node)
+
+          type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
+          corrector.replace(node, "#: self as #{type}")
+        rescue ::RBI::Type::Error
+          nil
+        end
+
+        def autocorrectable_t_bind?(node)
+          return false unless node.first_argument&.self_type?
+          return false unless assertion_ends_line?(node)
+          return false if rbs_annotation_follows?(node)
+
+          node.source_range.source_line.index(/\S/) == node.source_range.column
+        end
+
+        def assertion_ends_line?(node)
+          source = processed_source.buffer.source
+          position = skip_horizontal_whitespace(source, node.source_range.end_pos)
+          character = source[position]
+
+          character.nil? || NEWLINES.include?(character) || character == COMMENT_START
+        end
+
+        def rbs_annotation_follows?(node)
+          source = processed_source.buffer.source
+          position = skip_horizontal_whitespace(source, node.source_range.end_pos)
+
+          source[position, 2] == "#:"
+        end
+
+        def skip_horizontal_whitespace(source, position)
+          position += 1 while HORIZONTAL_WHITESPACE.include?(source[position])
+          position
+        end
       end
     end
   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -679,9 +679,10 @@ T.nilable(T.any(Symbol, String))
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.10.4 | -
+Disabled | Yes | Yes (Unsafe) | 0.10.4 | <<next>>
 
 Disallows using `T.bind` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -692,6 +693,12 @@ T.bind(self, Integer)
 # good
 #: self as Integer
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTBindInAssignment
 

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("lint_roller")
+  spec.add_runtime_dependency("rbi", "~> 0.4")
   spec.add_runtime_dependency("rubocop", ">= 1.75.2")
   spec.add_runtime_dependency("spoom", "~> 1.8")
 end

--- a/test/rubocop/cop/sorbet/forbid_t_bind_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_bind_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTBindTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTBind: Do not use `T.bind`."
-
-        def setup
-          @cop = ForbidTBind.new
-        end
+        MSG = "Do not use `T.bind`."
 
         def test_adds_offense_when_using_t_bind
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.bind(self, String)
             ^^^^^^^^^^^^^^^^^^^^ #{MSG}
@@ -23,6 +21,69 @@ module RuboCop
             ::T.bind(self, String)
             ^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_bind_to_an_rbs_self_assertion_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.bind(self, T::Array[String])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+            ::T.bind(self, String)
+            ^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            #: self as Array[String]
+
+            #: self as String
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_bind_on_another_value_or_in_an_assignment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.bind(foo, String)
+            ^^^^^^^^^^^^^^^^^^^ #{MSG}
+            x = T.bind(self, String)
+                ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_bind_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.bind(self, String))
+                    ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_bind_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.bind(self, String) #: self as Existing
+            ^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTBind
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTBind`, replacing supported `T.bind` calls with RBS inline self-type assertions.

```ruby
# Before
T.bind(self, Foo)

# After
#: self as Foo
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTBind:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe because it removes the runtime `T.bind` call.

## Type translation

The cop extracts the type argument and uses `RBI::Type` to parse and render it as RBS:

```ruby
T.bind(self, T::Array[String])
```

becomes:

```ruby
#: self as Array[String]
```

This also handles Sorbet types such as `T.class_of(...)`, `T.all(...)`, and `T.untyped` through RBI's existing type translation.

`rbi ~> 0.4` is therefore added as a direct runtime dependency.

## Autocorrection constraints

The cop only autocorrects when an RBS comment can safely replace the expression:

- The first argument is `self`.
- The call is a standalone expression.
- The call ends the line.
- No RBS annotation already follows the call.
- RBI can parse the type argument.

Calls embedded in assignments, chained calls, or other expressions remain offenses without autocorrection:

```ruby
value = T.bind(self, Foo)
T.bind(self, Foo).call
consume(T.bind(self, Foo))
```