### PR TITLE
Extend RedundantTLetForLiteral to trailing RBS annotations

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -348,8 +348,8 @@ Sorbet/RedundantExtendTSig:
 
 Sorbet/RedundantTLetForLiteral:
   Description: >-
-    Checks for redundant `T.let` declarations on constants where the value
-    is a simple literal whose type Sorbet can infer automatically.
+    Checks for redundant `T.let` declarations and trailing RBS annotations
+    on constants whose literal values have types Sorbet can infer automatically.
   Enabled: pending
   Safe: true
   SafeAutoCorrect: false

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -5,9 +5,9 @@ require "rubocop"
 module RuboCop
   module Cop
     module Sorbet
-      # Checks for redundant `T.let` declarations where the first argument
-      # is a literal whose type Sorbet can infer automatically, so wrapping
-      # it in `T.let` is redundant.
+      # Checks for redundant `T.let` declarations and trailing RBS annotations
+      # where the assigned value is a literal whose type Sorbet can infer
+      # automatically.
       #
       # Simple literals (strings, symbols, integers, floats, regexps) infer as
       # their own class. Regexp literals are the only simple literals whose
@@ -36,6 +36,8 @@ module RuboCop
       #   STATUS = T.let(:active, Symbol)
       #   SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
       #   NAMES = T.let(["alice", "bob"], T::Array[String])
+      #   RBS_GREETING = "hello" #: String
+      #   RBS_NAMES = ["alice", "bob"] #: Array[String]
       #
       #   # good
       #   MAX_RETRIES = 3
@@ -46,6 +48,8 @@ module RuboCop
       #   STATUS = :active
       #   SHELLS = [:bash, :zsh].freeze
       #   NAMES = ["alice", "bob"]
+      #   RBS_GREETING = "hello"
+      #   RBS_NAMES = ["alice", "bob"]
       #
       #   # good — non-regexp frozen simple literals are not inferred
       #   GREETING = T.let("hello".freeze, String)
@@ -70,15 +74,14 @@ module RuboCop
         include TLetCorrection
         extend AutoCorrector
 
-        # The frozen-literal and literal-array inference the newer cases rely on
-        # was added up to Sorbet 0.6.13304 (frozen regexp via freeze-transparent
-        # inference; literal arrays via constant tuple inference). Flagging them
-        # against an older Sorbet could remove a `T.let` it still requires, so
-        # those paths disable themselves below that version. Bare simple
-        # literals (`T.let(3, Integer)`) predate this and are not gated.
+        # Frozen-literal and literal-array inference require Sorbet 0.6.13304 or
+        # newer. Those paths disable themselves for older targets, while bare
+        # simple literals predate that version and remain eligible for both
+        # `T.let` and RBS annotations.
         minimum_target_sorbet_static_version "0.6.13304"
 
-        MSG = "Redundant `T.let` for %{type} literal. Sorbet can infer this type automatically."
+        MSG = "Redundant %{annotation} for %{type} literal. Sorbet can infer this type automatically."
+        RBS_ANNOTATION = /\A#\s*:\s*(?<type>.+?)\s*\z/
 
         # Simple literal node types Sorbet infers, mapped to the class name.
         # Interpolated strings/symbols (`dstr`/`dsym`) infer as `String`/`Symbol`.
@@ -131,26 +134,29 @@ module RuboCop
             register_offense(node, value_node, class_name)
           end
 
-          return unless enabled_for_sorbet_static_version?
+          if enabled_for_sorbet_static_version?
+            t_let_with_array?(node) do |value_node, type_node|
+              frozen = value_node.send_type?
+              array_node = frozen ? value_node.receiver : value_node
+              next unless inferable_array?(array_node)
+              next unless redundant_array_annotation?(array_node, type_node, frozen: frozen)
 
-          t_let_with_array?(node) do |value_node, type_node|
-            frozen = value_node.send_type?
-            array_node = frozen ? value_node.receiver : value_node
-            next unless inferable_array?(array_node)
-            next unless redundant_array_annotation?(array_node, type_node, frozen: frozen)
-
-            register_offense(node, value_node, :Array)
+              register_offense(node, value_node, :Array)
+            end
           end
+
+          check_rbs_annotation(node)
         end
 
         private
 
         # Returns the underlying literal when its inference is supported by the
-        # target Sorbet version. Bare literals are always supported; for example,
-        # `3` returns its integer node. Frozen literals are version-gated, so
-        # `/foo/.freeze` returns its regexp node only for supported targets.
+        # target Sorbet version. Bare literals return themselves. A frozen value
+        # returns its receiver only for regexps, whose inference survives
+        # `.freeze` on supported targets.
         def inferable_literal_node(value_node)
           return value_node unless value_node.send_type?
+          return unless value_node.method?(:freeze) && value_node.receiver&.regexp_type?
           return unless enabled_for_sorbet_static_version?
 
           value_node.receiver
@@ -158,9 +164,64 @@ module RuboCop
 
         def register_offense(node, value_node, type)
           t_let_node = node.children[2]
-          add_offense(t_let_node, message: format(MSG, type: type)) do |corrector|
+          add_offense(t_let_node, message: format(MSG, annotation: "`T.let`", type: type)) do |corrector|
             replace_t_let(corrector, t_let_node, value_node)
           end
+        end
+
+        def check_rbs_annotation(node)
+          value_node = node.children[2]
+          comment, annotated_type = trailing_rbs_annotation(node)
+          return unless comment
+
+          literal_node = inferable_literal_node(value_node)
+          if literal_node
+            inferred_type = LITERAL_TYPE_TO_CLASS[literal_node.type]
+            if inferred_type
+              return unless annotated_type.delete_prefix("::") == inferred_type.to_s
+
+              return register_rbs_offense(node, comment, inferred_type)
+            end
+          end
+
+          return unless enabled_for_sorbet_static_version?
+
+          frozen = value_node.send_type? && value_node.method?(:freeze)
+          array_node = frozen ? value_node.receiver : value_node
+          return unless inferable_array?(array_node)
+          return unless redundant_rbs_array_annotation?(array_node, annotated_type, frozen: frozen)
+
+          register_rbs_offense(node, comment, :Array)
+        end
+
+        def trailing_rbs_annotation(node)
+          last_line = node.source_range.last_line
+          comment = processed_source.each_comment_in_lines(last_line..last_line).find do |candidate|
+            next false if candidate.source_range.begin_pos < node.source_range.end_pos
+
+            gap = processed_source.buffer.source[node.source_range.end_pos...candidate.source_range.begin_pos]
+            gap.match?(/\A[ \t]*\z/)
+          end
+          return unless comment
+
+          match = RBS_ANNOTATION.match(comment.text)
+          return unless match
+
+          [comment, normalize(match[:type])]
+        end
+
+        def register_rbs_offense(node, comment, type)
+          add_offense(comment, message: format(MSG, annotation: "RBS annotation", type: type)) do |corrector|
+            range = comment.source_range.with(begin_pos: node.source_range.end_pos)
+            corrector.remove(range)
+          end
+        end
+
+        def redundant_rbs_array_annotation?(array_node, type, frozen:)
+          rbs_type = type.delete_prefix("::")
+          return rbs_type.match?(/\AArray\[(?:.+)\]\z/) if frozen
+
+          inferred_array_type(array_node)&.delete_prefix("T::") == rbs_type
         end
 
         # An array literal is inferable only when every element is one of the

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -81,7 +81,6 @@ module RuboCop
         minimum_target_sorbet_static_version "0.6.13304"
 
         MSG = "Redundant %{annotation} for %{type} literal. Sorbet can infer this type automatically."
-        RBS_ANNOTATION = /\A#\s*:\s*(?<type>.+?)\s*\z/
 
         # Simple literal node types Sorbet infers, mapped to the class name.
         # Interpolated strings/symbols (`dstr`/`dsym`) infer as `String`/`Symbol`.
@@ -171,8 +170,10 @@ module RuboCop
 
         def check_rbs_annotation(node)
           value_node = node.children[2]
-          comment, annotated_type = trailing_rbs_annotation(node)
+          comment, annotation = ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
           return unless comment
+
+          annotated_type = normalize(annotation)
 
           literal_node = inferable_literal_node(value_node)
           if literal_node
@@ -186,28 +187,12 @@ module RuboCop
 
           return unless enabled_for_sorbet_static_version?
 
-          frozen = value_node.send_type? && value_node.method?(:freeze)
+          frozen = value_node.send_type? && value_node.method?(:freeze) && !value_node.receiver.nil?
           array_node = frozen ? value_node.receiver : value_node
           return unless inferable_array?(array_node)
           return unless redundant_rbs_array_annotation?(array_node, annotated_type, frozen: frozen)
 
           register_rbs_offense(node, comment, :Array)
-        end
-
-        def trailing_rbs_annotation(node)
-          last_line = node.source_range.last_line
-          comment = processed_source.each_comment_in_lines(last_line..last_line).find do |candidate|
-            next false if candidate.source_range.begin_pos < node.source_range.end_pos
-
-            gap = processed_source.buffer.source[node.source_range.end_pos...candidate.source_range.begin_pos]
-            gap.match?(/\A[ \t]*\z/)
-          end
-          return unless comment
-
-          match = RBS_ANNOTATION.match(comment.text)
-          return unless match
-
-          [comment, normalize(match[:type])]
         end
 
         def register_rbs_offense(node, comment, type)

--- a/lib/rubocop/sorbet/rbs_parser.rb
+++ b/lib/rubocop/sorbet/rbs_parser.rb
@@ -11,8 +11,8 @@ module RuboCop
     # No Cop::Base state is required.
     #
     # `rbs_signatures_before` returns `Signature` objects that encapsulate one
-    # RBS overload each; ask them for `return_type`, `return_type_range`, and
-    # `void?` rather than reaching back into the parser for those facts.
+    # RBS overload each. `rbs_annotation_after` returns the trailing RBS
+    # annotation attached to an expression and its comment node.
     module RBSParser
       # `#:` begins an RBS signature (each repeated `#:` line is a new overload).
       RBS_SIGNATURE_PREFIX = /\A#\s*:/
@@ -28,6 +28,25 @@ module RuboCop
           node = node.parent while node.parent&.send_type?
           rbs_signature_groups(comments_above(processed_source, node))
             .map { |group| Signature.new(processed_source, group) }
+        end
+
+        # The trailing RBS annotation attached to `node`, as `[comment, text]`.
+        # The comment must follow the expression on its final line with only
+        # horizontal whitespace between them.
+        def rbs_annotation_after(processed_source, node)
+          last_line = node.source_range.last_line
+          comment = processed_source.each_comment_in_lines(last_line..last_line).find do |candidate|
+            next false if candidate.source_range.begin_pos < node.source_range.end_pos
+
+            gap = processed_source.buffer.source[node.source_range.end_pos...candidate.source_range.begin_pos]
+            gap.match?(/\A[ \t]*\z/)
+          end
+          return unless comment&.text&.match?(RBS_SIGNATURE_PREFIX)
+
+          annotation = comment.text.sub(RBS_SIGNATURE_PREFIX, "").strip
+          return if annotation.empty?
+
+          [comment, annotation]
         end
 
         private

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1241,9 +1241,9 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes (Unsafe) | 0.13.0 | -
 
-Checks for redundant `T.let` declarations where the first argument
-is a literal whose type Sorbet can infer automatically, so wrapping
-it in `T.let` is redundant.
+Checks for redundant `T.let` declarations and trailing RBS annotations
+where the assigned value is a literal whose type Sorbet can infer
+automatically.
 
 Simple literals (strings, symbols, integers, floats, regexps) infer as
 their own class. Regexp literals are the only simple literals whose
@@ -1274,6 +1274,8 @@ FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
 STATUS = T.let(:active, Symbol)
 SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
 NAMES = T.let(["alice", "bob"], T::Array[String])
+RBS_GREETING = "hello" #: String
+RBS_NAMES = ["alice", "bob"] #: Array[String]
 
 # good
 MAX_RETRIES = 3
@@ -1284,6 +1286,8 @@ FROZEN_PATTERN = /foo/.freeze
 STATUS = :active
 SHELLS = [:bash, :zsh].freeze
 NAMES = ["alice", "bob"]
+RBS_GREETING = "hello"
+RBS_NAMES = ["alice", "bob"]
 
 # good — non-regexp frozen simple literals are not inferred
 GREETING = T.let("hello".freeze, String)

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -839,6 +839,12 @@ module RuboCop
           RUBY
         end
 
+        def test_no_offense_for_receiverless_freeze_with_rbs_annotation
+          assert_no_offenses(<<~RUBY)
+            VALUE = freeze #: Array[String]
+          RUBY
+        end
+
         def test_no_offense_for_trailing_rbs_annotation_inside_conditional
           assert_no_offenses(<<~RUBY)
             if enabled?

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module Sorbet
       class RedundantTLetForLiteralTest < ::Minitest::Test
-        MSG = "Sorbet/RedundantTLetForLiteral: Redundant `T.let` for %{type} literal. " \
+        MSG = "Sorbet/RedundantTLetForLiteral: Redundant %{annotation} for %{type} literal. " \
           "Sorbet can infer this type automatically."
 
         def setup
@@ -19,7 +19,7 @@ module RuboCop
         def test_registers_offense_for_double_quoted_string
           assert_offense(<<~RUBY)
             GREETING = T.let("hello", String)
-                       ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "String")}
+                       ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -30,7 +30,7 @@ module RuboCop
         def test_registers_offense_for_single_quoted_string
           assert_offense(<<~RUBY)
             GREETING = T.let('hello', String)
-                       ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "String")}
+                       ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -43,7 +43,7 @@ module RuboCop
         def test_registers_offense_for_positive_integer
           assert_offense(<<~RUBY)
             MAX_RETRIES = T.let(3, Integer)
-                          ^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+                          ^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -54,7 +54,7 @@ module RuboCop
         def test_registers_offense_for_negative_integer
           assert_offense(<<~RUBY)
             ERROR_CODE = T.let(-32601, Integer)
-                         ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+                         ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -67,7 +67,7 @@ module RuboCop
         def test_registers_offense_for_float
           assert_offense(<<~RUBY)
             RATE = T.let(1.5, Float)
-                   ^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Float")}
+                   ^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Float")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -80,7 +80,7 @@ module RuboCop
         def test_registers_offense_for_symbol
           assert_offense(<<~RUBY)
             STATUS = T.let(:active, Symbol)
-                     ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Symbol")}
+                     ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Symbol")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -92,7 +92,7 @@ module RuboCop
         def test_registers_offense_for_interpolated_symbol
           assert_offense(<<~RUBY)
             STATUS = T.let(:"active_\#{n}", Symbol)
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Symbol")}
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Symbol")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -105,7 +105,7 @@ module RuboCop
         def test_registers_offense_for_regexp_literal
           assert_offense(<<~RUBY)
             PATTERN = T.let(/foo/, Regexp)
-                      ^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Regexp")}
+                      ^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Regexp")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -116,7 +116,7 @@ module RuboCop
         def test_registers_offense_for_percent_r_regexp
           assert_offense(<<~RUBY)
             PATTERN = T.let(%r{foo/bar}, Regexp)
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Regexp")}
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Regexp")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -149,7 +149,7 @@ module RuboCop
         def test_registers_offense_for_unfrozen_array_matching_annotation
           assert_offense(<<~RUBY)
             NAMES = T.let(["alice", "bob"], T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -160,7 +160,7 @@ module RuboCop
         def test_registers_offense_for_frozen_array
           assert_offense(<<~RUBY)
             SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -171,7 +171,7 @@ module RuboCop
         def test_registers_offense_for_frozen_percent_word_array
           assert_offense(<<~RUBY)
             WORDS = T.let(%w[a b c].freeze, T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -185,7 +185,7 @@ module RuboCop
         def test_registers_offense_for_frozen_interpolated_string_array
           assert_offense(<<~RUBY)
             PATHS = T.let(["\#{root}/a", "\#{root}/b"].freeze, T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -196,7 +196,7 @@ module RuboCop
         def test_registers_offense_for_unfrozen_interpolated_string_array
           assert_offense(<<~RUBY)
             PATHS = T.let(["\#{root}/a", "\#{root}/b"], T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -209,7 +209,7 @@ module RuboCop
         def test_registers_offense_for_unfrozen_mixed_plain_and_interpolated_string_array
           assert_offense(<<~RUBY)
             NAMES = T.let(["alice", "\#{prefix}bob"], T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -222,7 +222,7 @@ module RuboCop
         def test_registers_offense_for_interpolated_symbol_array
           assert_offense(<<~RUBY)
             KEYS = T.let(%I[key_\#{a} key_\#{b}], T::Array[Symbol])
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -236,7 +236,7 @@ module RuboCop
         def test_registers_offense_for_frozen_mixed_array
           assert_offense(<<~RUBY)
             VALUES = T.let([1, "a", nil].freeze, T::Array[T.nilable(T.any(Integer, String))])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -247,7 +247,7 @@ module RuboCop
         def test_registers_offense_for_frozen_nested_array
           assert_offense(<<~RUBY)
             PAIRS = T.let([["a"], ["b"]].freeze, T::Array[T::Array[String]])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -318,7 +318,7 @@ module RuboCop
             # typed: strong
             class Report
               CATEGORIES = T.let(["a", "b"].freeze, T::Array[String])
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
 
               def all
                 [CATEGORIES].flatten
@@ -346,7 +346,7 @@ module RuboCop
           assert_offense(<<~RUBY)
             class Builder
               BASIC = T.let([:a, :b].freeze, T::Array[Symbol])
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
 
               def build
                 acc = BASIC
@@ -392,7 +392,7 @@ module RuboCop
         def test_registers_offense_for_heredoc_string
           assert_offense(<<~RUBY)
             MSG = T.let(<<~MESSAGE, String)
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "String")}
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
               hello world
             MESSAGE
           RUBY
@@ -410,7 +410,7 @@ module RuboCop
         def test_registers_offense_for_heredoc_string_with_trailing_comment
           assert_offense(<<~RUBY)
             MSG = T.let(<<~MESSAGE, String) # keep me
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "String")}
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
               hello world
             MESSAGE
           RUBY
@@ -425,7 +425,7 @@ module RuboCop
         def test_registers_offense_for_multiline_heredoc_string
           assert_offense(<<~RUBY)
             MSG = T.let(
-                  ^^^^^^ #{format(MSG, type: "String")}
+                  ^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
               <<~MESSAGE,
                 hello world
               MESSAGE
@@ -447,7 +447,7 @@ module RuboCop
         def test_registers_offense_for_frozen_array_of_multiple_heredocs
           assert_offense(<<~RUBY)
             MESSAGES = T.let([<<~A, <<~B].freeze, T::Array[String])
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
               first
             A
               second
@@ -509,7 +509,7 @@ module RuboCop
         def test_registers_offense_for_frozen_regexp_literal
           assert_offense(<<~RUBY)
             PATTERN = T.let(/foo/.freeze, Regexp)
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Regexp")}
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Regexp")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -587,7 +587,7 @@ module RuboCop
           assert_offense(<<~RUBY)
             class Foo
               MAX = T.let(100, Integer)
-                    ^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+                    ^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
             end
           RUBY
 
@@ -616,7 +616,7 @@ module RuboCop
             class Foo
               class << self
                 NAMES = T.let(["a", "b"].freeze, T::Array[String])
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
               end
             end
           RUBY
@@ -634,7 +634,7 @@ module RuboCop
           assert_offense(<<~RUBY)
             module Foo
               NAMES = T.let(["a", "b"].freeze, T::Array[String])
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
             end
           RUBY
 
@@ -661,7 +661,7 @@ module RuboCop
           stub_sorbet_static_version("0.6.13303")
           assert_offense(<<~RUBY)
             MAX = T.let(3, Integer)
-                  ^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+                  ^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -686,7 +686,7 @@ module RuboCop
         def test_handles_multiline_t_let_with_simple_literal
           assert_offense(<<~RUBY)
             MSG = T.let(
-                  ^^^^^^ #{format(MSG, type: "String")}
+                  ^^^^^^ #{format(MSG, annotation: "`T.let`", type: "String")}
               "out of order",
               String,
             )
@@ -701,7 +701,7 @@ module RuboCop
         def test_registers_offense_for_cbase_t_let
           assert_offense(<<~RUBY)
             MAX = ::T.let(3, Integer)
-                  ^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Integer")}
+                  ^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -713,7 +713,7 @@ module RuboCop
         def test_registers_offense_for_cbase_t_and_t_array
           assert_offense(<<~RUBY)
             SHELLS = ::T.let([:bash, :zsh].freeze, ::T::Array[Symbol])
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -726,7 +726,7 @@ module RuboCop
         def test_registers_offense_for_unfrozen_array_with_cbase_annotation
           assert_offense(<<~RUBY)
             NAMES = T.let(["alice", "bob"], ::T::Array[String])
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
           RUBY
 
           assert_correction(<<~RUBY)
@@ -739,7 +739,7 @@ module RuboCop
         def test_registers_offense_for_unfrozen_array_multiline_annotation
           assert_offense(<<~RUBY)
             NAMES = T.let(
-                    ^^^^^^ #{format(MSG, type: "Array")}
+                    ^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Array")}
               ["alice", "bob"],
               T::Array[
                 String,
@@ -749,6 +749,142 @@ module RuboCop
 
           assert_correction(<<~RUBY)
             NAMES = ["alice", "bob"]
+          RUBY
+        end
+
+        # Trailing RBS annotations are equivalent to `T.let`, and are redundant
+        # under the same literal-inference rules.
+        def test_registers_offense_for_trailing_rbs_annotation
+          assert_offense(<<~RUBY)
+            GREETING = "hello" #: String
+                               ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "String")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            GREETING = "hello"
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_string_with_trailing_rbs_annotation
+          assert_no_offenses(<<~RUBY)
+            GREETING = "hello".freeze #: String
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_symbol_with_trailing_rbs_annotation
+          assert_no_offenses(<<~RUBY)
+            STATUS = :active.freeze #: Symbol
+          RUBY
+        end
+
+        def test_registers_offense_for_frozen_regexp_with_trailing_rbs_annotation
+          assert_offense(<<~RUBY)
+            PATTERN = /foo/.freeze #: Regexp
+                                   ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Regexp")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            PATTERN = /foo/.freeze
+          RUBY
+        end
+
+        def test_registers_offense_for_fully_qualified_trailing_rbs_annotation
+          assert_offense(<<~RUBY)
+            COUNT = 1 #: ::Integer
+                      ^^^^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Integer")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            COUNT = 1
+          RUBY
+        end
+
+        def test_registers_offense_for_trailing_rbs_array_annotation
+          assert_offense(<<~RUBY)
+            NAMES = ["alice", "bob"] #: Array[String]
+                                     ^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = ["alice", "bob"]
+          RUBY
+        end
+
+        def test_registers_offense_for_multiline_trailing_rbs_array_annotation
+          assert_offense(<<~RUBY)
+            NAMES = [
+              "alice",
+              "bob",
+            ] #: Array[String]
+              ^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Array")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            NAMES = [
+              "alice",
+              "bob",
+            ]
+          RUBY
+        end
+
+        def test_no_offense_for_nonredundant_or_nonconstant_rbs_annotations
+          assert_no_offenses(<<~RUBY)
+            MAYBE = "hello" #: String?
+            WIDE = "hello" #: Object
+            CAST = "hello" #: as String
+
+            NAMES = ["alice", "bob"] #: Array[String?]
+            local = "hello" #: String
+            @greeting = "hello" #: String
+          RUBY
+        end
+
+        def test_no_offense_for_trailing_rbs_annotation_inside_conditional
+          assert_no_offenses(<<~RUBY)
+            if enabled?
+              GREETING = "hello" #: String
+              NAMES = ["alice", "bob"] #: Array[String]
+            end
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_and_array_rbs_annotations_below_minimum_sorbet_version
+          stub_sorbet_static_version("0.6.13303")
+          assert_no_offenses(<<~RUBY)
+            PATTERN = /foo/.freeze #: Regexp
+            NAMES = ["alice", "bob"] #: Array[String]
+          RUBY
+        end
+
+        def test_still_flags_bare_rbs_literal_below_minimum_sorbet_version
+          stub_sorbet_static_version("0.6.13303")
+          assert_offense(<<~RUBY)
+            GREETING = "hello" #: String
+                               ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "String")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            GREETING = "hello"
+          RUBY
+        end
+
+        def test_no_offense_for_frozen_and_array_rbs_annotations_without_sorbet_static
+          stub_sorbet_static_version(nil)
+          assert_no_offenses(<<~RUBY)
+            PATTERN = /foo/.freeze #: Regexp
+            NAMES = ["alice", "bob"] #: Array[String]
+          RUBY
+        end
+
+        def test_still_flags_bare_rbs_literal_without_sorbet_static
+          stub_sorbet_static_version(nil)
+          assert_offense(<<~RUBY)
+            GREETING = "hello" #: String
+                               ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "String")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            GREETING = "hello"
           RUBY
         end
 

--- a/test/rubocop/sorbet/rbs_parser_test.rb
+++ b/test/rubocop/sorbet/rbs_parser_test.rb
@@ -6,8 +6,7 @@ module RuboCop
   module Sorbet
     class RBSParserTest < ::Minitest::Test
       # `RBSParser` is a pure module over a `ProcessedSource` and comment
-      # nodes; these tests exercise its public API (`rbs_signatures_before`
-      # and the `Signature` objects it returns) directly, without a Cop.
+      # nodes; these tests exercise its public APIs directly without a Cop.
 
       def parse(source)
         RuboCop::ProcessedSource.new(source, 3.4)
@@ -65,6 +64,40 @@ module RuboCop
 
       def test_signatures_before_empty_when_no_comments
         assert_empty(signatures_before("def foo; end"))
+      end
+
+      # --- rbs_annotation_after ---
+
+      def test_annotation_after_returns_comment_and_text
+        comment, annotation = annotation_after('GREETING = "hello" #: String')
+
+        assert_equal("#: String", comment.text)
+        assert_equal("String", annotation)
+      end
+
+      def test_annotation_after_accepts_marker_spacing
+        _comment, annotation = annotation_after('GREETING = "hello" #  :  String')
+
+        assert_equal("String", annotation)
+      end
+
+      def test_annotation_after_handles_multiline_expression
+        _comment, annotation = annotation_after(<<~RUBY)
+          NAMES = [
+            "alice",
+            "bob",
+          ] #: Array[String]
+        RUBY
+
+        assert_equal("Array[String]", annotation)
+      end
+
+      def test_annotation_after_rejects_non_rbs_comment
+        assert_nil(annotation_after('GREETING = "hello" # String'))
+      end
+
+      def test_annotation_after_rejects_comment_separated_by_code
+        assert_nil(annotation_after('GREETING = "hello"; nil #: String'))
       end
 
       # --- Signature#return_type / return_type_range / void? ---
@@ -167,6 +200,13 @@ module RuboCop
       def signatures_before(source)
         ps = parse(source)
         RBSParser.rbs_signatures_before(ps, def_node(ps))
+      end
+
+      def annotation_after(source)
+        ps = parse(source)
+        node = ps.ast
+        node = node.each_node(:casgn).first unless node.casgn_type?
+        RBSParser.rbs_annotation_after(ps, node)
       end
 
       def signature(source)


### PR DESCRIPTION
## What

Extend `Sorbet/RedundantTLetForLiteral` to detect redundant trailing RBS type annotations on constants.

```ruby
# bad
GREETING = "hello" #: String
PATTERN = /foo/.freeze #: Regexp
NAMES = ["alice", "bob"] #: Array[String]

# good
GREETING = "hello"
PATTERN = /foo/.freeze
NAMES = ["alice", "bob"]
```

The cop autocorrects these offenses by removing the trailing annotation.

## Why

A trailing RBS annotation such as:

```ruby
GREETING = "hello" #: String
```

is equivalent to a `T.let` declaration. When Sorbet can already infer the constant's type from its literal value, the RBS annotation is redundant for the same reason as:

```ruby
GREETING = T.let("hello", String)
```

Supporting both syntaxes keeps the cop's behavior consistent for codebases adopting RBS comments.

## Details

The RBS path follows the existing `T.let` inference rules:

- Detects matching annotations for simple literals.
- Detects matching array annotations.
- Detects frozen regexp literals on supported Sorbet versions.
- Leaves widened or mismatched annotations unchanged.
- Leaves annotations on locals, instance variables, and conditionally assigned constants unchanged.
- Preserves annotations on frozen strings and symbols because Sorbet does not infer those constant types through `.freeze`.

```ruby
# These annotations remain required
GREETING = "hello".freeze #: String
STATUS = :active.freeze #: Symbol
```

Version gating also matches the existing `T.let` behavior:

- Bare literals remain eligible regardless of the target Sorbet version.
- Frozen regexp and array inference require Sorbet `0.6.13304` or newer.

The implementation uses one parameterized offense message for both `T.let` and RBS annotations.