### PR TITLE
Reject spaced RBS comment markers

### DIFF
--- a/lib/rubocop/sorbet/rbs_parser.rb
+++ b/lib/rubocop/sorbet/rbs_parser.rb
@@ -15,9 +15,9 @@ module RuboCop
     # `void?` rather than reaching back into the parser for those facts.
     module RBSParser
       # `#:` begins an RBS signature (each repeated `#:` line is a new overload).
-      RBS_SIGNATURE_PREFIX = /\A#\s*:/
+      RBS_SIGNATURE_PREFIX = /\A#:/
       # `#|` continues the preceding `#:` signature (e.g. multiline params/returns).
-      RBS_CONTINUATION_PREFIX = /\A#\s*\|/
+      RBS_CONTINUATION_PREFIX = /\A#\|/
 
       class << self
         # The RBS signatures attached to `node`, one `Signature` per overload.
@@ -177,7 +177,7 @@ module RuboCop
         # of characters consumed from the original text, for mapping
         # joined-content positions back to source offsets.
         def strip_rbs_prefix(text)
-          match = text.match(/\A#\s*[:|]\s*/)
+          match = text.match(/\A#[:|]\s*/)
           return [text, 0] unless match
 
           [match.post_match, match[0].length]

--- a/test/rubocop/sorbet/rbs_parser_test.rb
+++ b/test/rubocop/sorbet/rbs_parser_test.rb
@@ -140,19 +140,16 @@ module RuboCop
         assert_nil(sig.return_type_range)
       end
 
-      # Prefix-stripping robustness exercised through the public API: the
-      # marker may carry zero or multiple spaces before/after `:`/`|`.
+      # Whitespace is allowed after the `#:`/`#|` marker, but Sorbet requires
+      # the marker itself to be contiguous.
       def test_signature_return_type_with_no_space_after_marker
         sig = signature("#:-> void\ndef foo; end")
         assert_equal("void", sig.return_type)
         assert(sig.void?)
       end
 
-      def test_signature_return_type_with_multiple_spaces_after_marker
-        sig = signature("#  : (String) -> String\ndef foo; end")
-        assert_equal("String", sig.return_type)
-        highlight, = sig.return_type_range
-        assert_equal("String", highlight.source)
+      def test_signatures_before_rejects_space_within_marker
+        assert_empty(signatures_before("#  : (String) -> String\ndef foo; end"))
       end
 
       def test_signature_return_type_with_continuation_prefix_spacing
@@ -160,6 +157,11 @@ module RuboCop
         assert_equal("String", sig.return_type)
         highlight, = sig.return_type_range
         assert_equal("String", highlight.source)
+      end
+
+      def test_signatures_before_rejects_space_within_continuation_marker
+        sig = signature("#: (String) ->\n# | String\ndef foo; end")
+        assert_nil(sig.return_type)
       end
 
       private


### PR DESCRIPTION
## What changed

Update `RBSParser` to require contiguous RBS comment markers:

- Accept `#:` and `#|`
- Reject `# :`, `#  :`, and `# |`
- Continue allowing whitespace after the marker, such as `#: () -> void` and `#|   String`

## Why

Sorbet only recognizes RBS annotations when `#` is immediately followed by `:` or `|`. The existing `\s*` matching caused RuboCop to interpret comments such as `#  : () -> String` as signatures even though Sorbet ignores them.

This aligns `RBSParser` with Sorbet’s behavior and prevents cops from acting on annotations that Sorbet does not recognize.