### PR TITLE
Autocorrect T.absurd to RBS assertions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -221,7 +221,10 @@ Sorbet/ForbidTStruct:
 Sorbet/ForbidTAbsurd:
   Description: 'Forbid usage of T.absurd.'
   Enabled: false
+  AutocorrectToRBS: false
   VersionAdded: 0.10.4
+  SafeAutoCorrect: false
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTBind:
   Description: 'Forbid usage of T.bind.'

--- a/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
@@ -6,6 +6,7 @@ module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.absurd` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -13,8 +14,11 @@ module RuboCop
       #   T.absurd(foo)
       #
       #   # good
-      #   x #: absurd
+      #   foo #: absurd
       class ForbidTAbsurd < RuboCop::Cop::Base
+        include RBSAssertionCorrection
+        extend AutoCorrector
+
         MSG = "Do not use `T.absurd`."
         RESTRICT_ON_SEND = [:absurd].freeze
 
@@ -22,9 +26,19 @@ module RuboCop
         def_node_matcher(:t_absurd?, "(send (const nil? :T) :absurd _)")
 
         def on_send(node)
-          add_offense(node) if t_absurd?(node)
+          return unless t_absurd?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_absurd_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_absurd_to_rbs(corrector, node)
+          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
+
+          corrector.replace(node, "#{node.first_argument.source} #: absurd")
+        end
       end
     end
   end

--- a/lib/rubocop/cop/sorbet/forbid_t_bind.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_bind.rb
@@ -17,11 +17,10 @@ module RuboCop
       #   # good
       #   #: self as Integer
       class ForbidTBind < RuboCop::Cop::Base
-        include RangeHelp
+        include RBSAssertionCorrection
         extend AutoCorrector
 
         MSG = "Do not use `T.bind`."
-        LINE_ENDINGS = ["", "\n", "\r", "#"].freeze
         RESTRICT_ON_SEND = [:bind].freeze
 
         # @!method t_bind?(node)
@@ -37,30 +36,13 @@ module RuboCop
         private
 
         def autocorrect_t_bind_to_rbs(corrector, node)
-          return unless cop_config["AutocorrectToRBS"]
-          return unless autocorrectable_t_bind?(node)
+          return unless node.first_argument&.self_type?
+          return unless rbs_assertion_autocorrectable?(node)
 
           type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
           corrector.replace(node, "#: self as #{type}")
         rescue ::RBI::Type::Error
           nil
-        end
-
-        def autocorrectable_t_bind?(node)
-          return false unless node.first_argument&.self_type?
-          return false unless assertion_ends_line?(node)
-          return false if ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
-
-          node.source_range.source_line.index(/\S/) == node.source_range.column
-        end
-
-        def assertion_ends_line?(node)
-          LINE_ENDINGS.include?(source_after_horizontal_whitespace(node))
-        end
-
-        def source_after_horizontal_whitespace(node, length: 1)
-          range = range_with_surrounding_space(node.source_range, side: :right, newlines: false)
-          range.source_buffer.source[range.end_pos, length]
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/mixin/rbs_assertion_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/rbs_assertion_correction.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sorbet
+      # Shared guards for replacing Sorbet runtime assertions with RBS inline
+      # comments without changing the surrounding Ruby syntax.
+      module RBSAssertionCorrection
+        include RangeHelp
+
+        COMMENT_START = "#"
+        NEWLINES = ["\n", "\r"].freeze
+
+        private
+
+        def rbs_assertion_autocorrectable?(node, allow_assignment: false)
+          return false unless cop_config["AutocorrectToRBS"]
+          return false unless assertion_ends_line?(node)
+          return false if ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
+
+          statement = assertion_statement(node, allow_assignment: allow_assignment)
+          statement && statement.source_range.source_line.index(/\S/) == statement.source_range.column
+        end
+
+        def assertion_statement(node, allow_assignment:)
+          parent = node.parent
+          return node unless parent&.assignment? && parent.children.last.equal?(node)
+
+          parent if allow_assignment
+        end
+
+        def assertion_ends_line?(node)
+          range = range_after_horizontal_whitespace(node)
+          character = range.source_buffer.source[range.end_pos]
+
+          character.nil? || NEWLINES.include?(character) || character == COMMENT_START
+        end
+
+        def range_after_horizontal_whitespace(node)
+          range_with_surrounding_space(node.source_range, side: :right, newlines: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sorbet_cops.rb
+++ b/lib/rubocop/cop/sorbet_cops.rb
@@ -5,6 +5,7 @@ require_relative "sorbet/mixin/t_enum"
 require_relative "sorbet/mixin/signature_help"
 require_relative "sorbet/mixin/constant_scope"
 require_relative "sorbet/mixin/t_let_correction"
+require_relative "sorbet/mixin/rbs_assertion_correction"
 
 require_relative "sorbet/binding_constant_without_type_alias"
 require_relative "sorbet/block_method_definition"

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -639,9 +639,10 @@ Exclude | `db/migrate/*.rb` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.10.4 | -
+Disabled | Yes | Yes (Unsafe) | 0.10.4 | <<next>>
 
 Disallows using `T.absurd` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -650,8 +651,14 @@ Disallows using `T.absurd` anywhere.
 T.absurd(foo)
 
 # good
-x #: absurd
+foo #: absurd
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTAnyWithNil
 

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTAbsurdTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTAbsurd: Do not use `T.absurd`."
-
-        def setup
-          @cop = ForbidTAbsurd.new
-        end
+        MSG = "Do not use `T.absurd`."
 
         def test_adds_offense_when_using_t_absurd
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.absurd(foo)
             ^^^^^^^^^^^^^ #{MSG}
@@ -20,6 +18,56 @@ module RuboCop
             x = T.absurd(foo)
                 ^^^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_absurd_to_an_rbs_absurd_assertion_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.absurd(foo)
+            ^^^^^^^^^^^^^ #{MSG}
+
+            x = T.absurd(foo)
+                ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            foo #: absurd
+
+            x = foo #: absurd
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_absurd_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.absurd(foo))
+                    ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_absurd_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.absurd(foo) #: absurd
+            ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTAbsurd
         end
       end
     end

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -42,6 +42,19 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrection_preserves_a_trailing_comment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.absurd(foo) # some comment
+            ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            foo #: absurd # some comment
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_absurd_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 


### PR DESCRIPTION
Stacked on #400.

## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTAbsurd`, replacing supported `T.absurd` calls with RBS inline absurd assertions.

```ruby
# Before
T.absurd(value)

# After
value #: absurd
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTAbsurd:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe because it removes the runtime `T.absurd` call.

## Shared assertion correction

Extracts the correction eligibility checks shared by `ForbidTBind` and `ForbidTAbsurd` into `RBSAssertionCorrection`.

The helper:

- checks the `AutocorrectToRBS` setting
- prevents inline comments from changing surrounding Ruby syntax
- supports assignment values when the cop opts in
- reuses `RBSParser.rbs_annotation_after` to avoid overwriting an existing RBS annotation

## Autocorrection constraints

Calls nested in another expression or followed by an existing RBS annotation remain offenses without autocorrection.