### PR TITLE
Autocorrect T.unsafe to RBS assertions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -270,8 +270,10 @@ Sorbet/ForbidTTypeAlias:
 Sorbet/ForbidTUnsafe:
   Description: 'Forbid usage of T.unsafe.'
   Enabled: false
+  AutocorrectToRBS: false
+  SafeAutoCorrect: false
   VersionAdded: 0.7.0
-  VersionChanged: 0.7.0
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTUntyped:
   Description: 'Forbid usage of T.untyped'

--- a/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
@@ -6,6 +6,7 @@ module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.unsafe` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -13,8 +14,11 @@ module RuboCop
       #   T.unsafe(foo)
       #
       #   # good
-      #   foo
+      #   foo #: as untyped
       class ForbidTUnsafe < RuboCop::Cop::Base
+        include RBSAssertionCorrection
+        extend AutoCorrector
+
         MSG = "Do not use `T.unsafe`."
         RESTRICT_ON_SEND = [:unsafe].freeze
 
@@ -22,9 +26,19 @@ module RuboCop
         def_node_matcher(:t_unsafe?, "(send (const nil? :T) :unsafe _)")
 
         def on_send(node)
-          add_offense(node) if t_unsafe?(node)
+          return unless t_unsafe?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_unsafe_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_unsafe_to_rbs(corrector, node)
+          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
+
+          corrector.replace(node, "#{node.first_argument.source} #: as untyped")
+        end
       end
     end
   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -959,9 +959,10 @@ STRING_OR_INTEGER = T.type_alias { T.any(Integer, String) }
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.7.0 | 0.7.0
+Disabled | Yes | Yes (Unsafe) | 0.7.0 | <<next>>
 
 Disallows using `T.unsafe` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -970,8 +971,14 @@ Disallows using `T.unsafe` anywhere.
 T.unsafe(foo)
 
 # good
-foo
+foo #: as untyped
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTUntyped
 

--- a/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
@@ -42,6 +42,19 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrection_preserves_a_trailing_comment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.unsafe(foo) # some comment
+            ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            foo #: as untyped # some comment
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_unsafe_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 

--- a/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTUnsafeTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTUnsafe: Do not use `T.unsafe`."
-
-        def setup
-          @cop = ForbidTUnsafe.new
-        end
+        MSG = "Do not use `T.unsafe`."
 
         def test_adds_offense_when_using_t_unsafe
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.unsafe(foo)
             ^^^^^^^^^^^^^ #{MSG}
@@ -20,6 +18,56 @@ module RuboCop
             x = T.unsafe(foo)
                 ^^^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_unsafe_to_an_rbs_untyped_assertion_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.unsafe(foo)
+            ^^^^^^^^^^^^^ #{MSG}
+
+            x = T.unsafe(foo)
+                ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            foo #: as untyped
+
+            x = foo #: as untyped
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_unsafe_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.unsafe(foo))
+                    ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_unsafe_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.unsafe(foo) #: as Existing
+            ^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTUnsafe
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTUnsafe`, replacing supported `T.unsafe` calls with RBS inline untyped assertions.

```ruby
# Before
T.unsafe(value)

# After
value #: as untyped
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTUnsafe:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe and only runs when the expression can be replaced without changing the surrounding Ruby syntax.

## Autocorrection constraints

The cop supports standalone calls and direct assignment values. Calls nested in another expression or followed by an existing RBS annotation remain offenses without autocorrection.