### PR TITLE
Autocorrect T.must to RBS assertions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -253,7 +253,10 @@ Sorbet/ForbidTLet:
 Sorbet/ForbidTMust:
   Description: 'Forbid usage of T.must.'
   Enabled: false
+  AutocorrectToRBS: false
+  SafeAutoCorrect: false
   VersionAdded: 0.10.4
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTAnyWithNil:
   Description: 'Forbid usage of T.any(NilClass).'

--- a/lib/rubocop/cop/sorbet/forbid_t_must.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_must.rb
@@ -35,6 +35,7 @@ module RuboCop
         private
 
         def autocorrect_t_must_to_rbs(corrector, node)
+          return if node.first_argument.splat_type?
           return if t_must?(node.first_argument)
           return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
 

--- a/lib/rubocop/cop/sorbet/forbid_t_must.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_must.rb
@@ -6,6 +6,7 @@ module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.must` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -15,6 +16,9 @@ module RuboCop
       #   # good
       #   foo #: as !nil
       class ForbidTMust < RuboCop::Cop::Base
+        include RBSAssertionCorrection
+        extend AutoCorrector
+
         MSG = "Do not use `T.must`."
         RESTRICT_ON_SEND = [:must].freeze
 
@@ -22,9 +26,20 @@ module RuboCop
         def_node_matcher(:t_must?, "(send (const nil? :T) :must _)")
 
         def on_send(node)
-          add_offense(node) if t_must?(node)
+          return unless t_must?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_must_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_must_to_rbs(corrector, node)
+          return if t_must?(node.first_argument)
+          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
+
+          corrector.replace(node, "#{node.first_argument.source} #: as !nil")
+        end
       end
     end
   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -825,9 +825,10 @@ foo #: Integer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.10.4 | -
+Disabled | Yes | Yes (Unsafe) | 0.10.4 | <<next>>
 
 Disallows using `T.must` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -838,6 +839,12 @@ T.must(foo)
 # good
 foo #: as !nil
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTSig
 

--- a/test/rubocop/cop/sorbet/forbid_t_must_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_must_test.rb
@@ -42,6 +42,19 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrection_preserves_a_trailing_comment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.must(foo) # some comment
+            ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            foo #: as !nil # some comment
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_must_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 
@@ -60,6 +73,17 @@ module RuboCop
             T.must(T.must(foo))
             ^^^^^^^^^^^^^^^^^^^ #{MSG}
                    ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_must_with_a_splat_argument
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.must(*values)
+            ^^^^^^^^^^^^^^^ #{MSG}
           RUBY
 
           assert_no_corrections

--- a/test/rubocop/cop/sorbet/forbid_t_must_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_must_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTMustTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTMust: Do not use `T.must`."
-
-        def setup
-          @cop = ForbidTMust.new
-        end
+        MSG = "Do not use `T.must`."
 
         def test_adds_offense_when_using_t_must
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.must(foo)
             ^^^^^^^^^^^ #{MSG}
@@ -20,6 +18,68 @@ module RuboCop
             x = T.must(foo)
                 ^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_must_to_an_rbs_non_nil_assertion_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.must(foo)
+            ^^^^^^^^^^^ #{MSG}
+
+            x = T.must(foo)
+                ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            foo #: as !nil
+
+            x = foo #: as !nil
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_must_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.must(foo))
+                    ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_nested_t_must_calls
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.must(T.must(foo))
+            ^^^^^^^^^^^^^^^^^^^ #{MSG}
+                   ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_must_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.must(foo) #: as Existing
+            ^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTMust
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTMust`, replacing supported `T.must` calls with RBS inline non-nil assertions.

```ruby
# Before
T.must(value)

# After
value #: as !nil
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTMust:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe because it removes the runtime nil check performed by `T.must`.

## Autocorrection constraints

The cop supports standalone calls and direct assignment values. Calls nested in another expression, followed by an existing RBS annotation, or nested inside another `T.must` remain offenses without autocorrection.