### PR TITLE
Autocorrect T.cast to RBS assertions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -243,7 +243,10 @@ Sorbet/ForbidTBindInAssignment:
 Sorbet/ForbidTCast:
   Description: 'Forbid usage of T.cast.'
   Enabled: false
+  AutocorrectToRBS: false
+  SafeAutoCorrect: false
   VersionAdded: 0.10.4
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTLet:
   Description: 'Forbid usage of T.let.'

--- a/lib/rubocop/cop/sorbet/forbid_t_cast.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_cast.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rbi"
 
 module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.cast` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -15,6 +17,9 @@ module RuboCop
       #   # good
       #   foo #: as Integer
       class ForbidTCast < RuboCop::Cop::Base
+        include RBSAssertionCorrection
+        extend AutoCorrector
+
         MSG = "Do not use `T.cast`."
         RESTRICT_ON_SEND = [:cast].freeze
 
@@ -22,9 +27,23 @@ module RuboCop
         def_node_matcher(:t_cast?, "(send (const nil? :T) :cast _ _)")
 
         def on_send(node)
-          add_offense(node) if t_cast?(node)
+          return unless t_cast?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_cast_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_cast_to_rbs(corrector, node)
+          return if t_cast?(node.first_argument)
+          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
+
+          type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
+          corrector.replace(node, "#{node.first_argument.source} #: as #{type}")
+        rescue ::RBI::Type::Error
+          nil
+        end
       end
     end
   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -733,9 +733,10 @@ foo = T.cast(self, Integer)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.10.4 | -
+Disabled | Yes | Yes (Unsafe) | 0.10.4 | <<next>>
 
 Disallows using `T.cast` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -746,6 +747,12 @@ T.cast(foo, Integer)
 # good
 foo #: as Integer
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTEnum
 

--- a/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTCastTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTCast: Do not use `T.cast`."
-
-        def setup
-          @cop = ForbidTCast.new
-        end
+        MSG = "Do not use `T.cast`."
 
         def test_adds_offense_when_using_t_cast
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.cast(foo, String)
             ^^^^^^^^^^^^^^^^^^^ #{MSG}
@@ -20,6 +18,79 @@ module RuboCop
             x = T.cast(foo, String)
                 ^^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_cast_to_an_rbs_type_assertion_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.cast(foo, T::Array[String])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+            x = T.cast(foo, T.any(String, Symbol))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            foo #: as Array[String]
+
+            x = foo #: as (String | Symbol)
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_cast_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.cast(foo, String))
+                    ^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_nested_t_cast_calls
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.cast(T.cast(foo, String), Object)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+                   ^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_cast_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.cast(foo, String) #: as Existing
+            ^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_an_untranslatable_type
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.cast(foo, type)
+            ^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTCast
         end
       end
     end

--- a/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
@@ -42,6 +42,19 @@ module RuboCop
           RUBY
         end
 
+        def test_adds_rbs_assertion_before_a_trailing_comment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.cast(foo, String) # why this cast is needed
+            ^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            foo #: as String # why this cast is needed
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_cast_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 


### PR DESCRIPTION
## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTCast`, replacing supported `T.cast` calls with RBS inline type assertions.

```ruby
# Before
T.cast(value, T::Array[String])

# After
value #: as Array[String]
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTCast:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe because it removes the runtime type check performed by `T.cast`. RBI translates Sorbet type expressions to RBS.

## Autocorrection constraints

The cop supports standalone calls and direct assignment values. Calls nested in another expression, nested inside another `T.cast`, followed by an existing RBS annotation, or using an untranslatable type remain offenses without autocorrection.