### PR TITLE
Autocorrect T.let to RBS annotations

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -248,7 +248,10 @@ Sorbet/ForbidTCast:
 Sorbet/ForbidTLet:
   Description: 'Forbid usage of T.let.'
   Enabled: false
+  AutocorrectToRBS: false
+  SafeAutoCorrect: false
   VersionAdded: 0.10.4
+  VersionChanged: '<<next>>'
 
 Sorbet/ForbidTMust:
   Description: 'Forbid usage of T.must.'

--- a/lib/rubocop/cop/sorbet/forbid_t_let.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_let.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rbi"
 
 module RuboCop
   module Cop
     module Sorbet
       # Disallows using `T.let` anywhere.
+      # Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
       #
       # @example
       #
@@ -15,6 +17,9 @@ module RuboCop
       #   # good
       #   foo #: Integer
       class ForbidTLet < RuboCop::Cop::Base
+        include RBSAssertionCorrection
+        extend AutoCorrector
+
         MSG = "Do not use `T.let`."
         RESTRICT_ON_SEND = [:let].freeze
 
@@ -22,9 +27,23 @@ module RuboCop
         def_node_matcher(:t_let?, "(send (const nil? :T) :let _ _)")
 
         def on_send(node)
-          add_offense(node) if t_let?(node)
+          return unless t_let?(node)
+
+          add_offense(node) { |corrector| autocorrect_t_let_to_rbs(corrector, node) }
         end
         alias_method :on_csend, :on_send
+
+        private
+
+        def autocorrect_t_let_to_rbs(corrector, node)
+          return if t_let?(node.first_argument)
+          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
+
+          type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
+          corrector.replace(node, "#{node.first_argument.source} #: #{type}")
+        rescue ::RBI::Type::Error
+          nil
+        end
       end
     end
   end

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -807,9 +807,10 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | 0.10.4 | -
+Disabled | Yes | Yes (Unsafe) | 0.10.4 | <<next>>
 
 Disallows using `T.let` anywhere.
+Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments.
 
 ### Examples
 
@@ -820,6 +821,12 @@ T.let(foo, Integer)
 # good
 foo #: Integer
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AutocorrectToRBS | `false` | Boolean
 
 ## Sorbet/ForbidTMust
 

--- a/test/rubocop/cop/sorbet/forbid_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_let_test.rb
@@ -42,6 +42,19 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrection_preserves_a_trailing_comment
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.let(foo, Bar) # some comment
+            ^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            foo #: Bar # some comment
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_let_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 

--- a/test/rubocop/cop/sorbet/forbid_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_let_test.rb
@@ -6,13 +6,11 @@ module RuboCop
   module Cop
     module Sorbet
       class ForbidTLetTest < ::Minitest::Test
-        MSG = "Sorbet/ForbidTLet: Do not use `T.let`."
-
-        def setup
-          @cop = ForbidTLet.new
-        end
+        MSG = "Do not use `T.let`."
 
         def test_adds_offense_when_using_t_let
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
+
           assert_offense(<<~RUBY)
             T.let(foo, String)
             ^^^^^^^^^^^^^^^^^^ #{MSG}
@@ -20,6 +18,79 @@ module RuboCop
             x = T.let(foo, String)
                 ^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_t_let_to_an_rbs_type_annotation_when_enabled
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            # café
+            T.let(foo, T.nilable(T::Array[String]))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+
+            x = T.let(foo, T.any(String, Symbol))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            # café
+            foo #: Array[String]?
+
+            x = foo #: (String | Symbol)
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_let_nested_in_an_expression
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(T.let(foo, String))
+                    ^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_nested_t_let_calls
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.let(T.let(foo, String), Object)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+                  ^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_t_let_with_an_existing_rbs_annotation
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.let(foo, String) #: Existing
+            ^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_an_untranslatable_type
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.let(foo, type)
+            ^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        private
+
+        def target_cop
+          ForbidTLet
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds opt-in autocorrection to `Sorbet/ForbidTLet`, replacing supported `T.let` calls with RBS inline type annotations.

```ruby
# Before
T.let(value, T.nilable(T::Array[String]))

# After
value #: Array[String]?
```

The autocorrection is disabled by default:

```yaml
Sorbet/ForbidTLet:
  Enabled: true
  AutocorrectToRBS: true
```

It is marked unsafe because it removes the runtime type check performed by `T.let`. RBI translates Sorbet type expressions to RBS.

## Autocorrection constraints

The cop supports standalone calls and direct assignment values. Calls nested in another expression, nested inside another `T.let`, followed by an existing RBS annotation, or using an untranslatable type remain offenses without autocorrection.