### PR TITLE
Remove obsolete RBS marker spacing test

### DIFF
--- a/test/rubocop/sorbet/rbs_parser_test.rb
+++ b/test/rubocop/sorbet/rbs_parser_test.rb
@@ -75,12 +75,6 @@ module RuboCop
         assert_equal("String", annotation)
       end
 
-      def test_annotation_after_accepts_marker_spacing
-        _comment, annotation = annotation_after('GREETING = "hello" #  :  String')
-
-        assert_equal("String", annotation)
-      end
-
       def test_annotation_after_handles_multiline_expression
         _comment, annotation = annotation_after(<<~RUBY)
           NAMES = [


### PR DESCRIPTION
Fix a merge race on `main`. This test is incorrect since #402.
