### PR TITLE
Autocorrect inline else T.absurd calls

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         def inline_else_statement(node)
           parent = node.parent
-          return unless parent&.case_type?
+          return unless parent&.type?(:case, :if)
           return unless parent.children.last.equal?(node)
 
           else_range = parent.loc.else

--- a/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
@@ -39,6 +39,22 @@ module RuboCop
 
           corrector.replace(node, "#{node.first_argument.source} #: absurd")
         end
+
+        def assertion_statement(node, allow_assignment:)
+          inline_else = inline_else_statement(node)
+          return super(inline_else, allow_assignment: allow_assignment) if inline_else
+
+          super
+        end
+
+        def inline_else_statement(node)
+          parent = node.parent
+          return unless parent&.case_type?
+          return unless parent.children.last.equal?(node)
+
+          else_range = parent.loc.else
+          parent if else_range&.source == "else" && else_range.line == node.first_line
+        end
       end
     end
   end

--- a/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
@@ -50,10 +50,18 @@ module RuboCop
         def inline_else_statement(node)
           parent = node.parent
           return unless parent&.type?(:case, :if)
-          return unless parent.children.last.equal?(node)
+          return unless inline_else_branch(parent).equal?(node)
 
           else_range = parent.loc.else
           parent if else_range&.source == "else" && else_range.line == node.first_line
+        end
+
+        # `unless` is represented as an `if` node with its branches swapped, so its source
+        # `else` branch is the second child. For `if` and `case`, it is the last child.
+        def inline_else_branch(parent)
+          return parent.children.last unless parent.if_type? && parent.keyword == "unless"
+
+          parent.children[1]
         end
       end
     end

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -74,6 +74,25 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrects_t_absurd_after_an_inline_if_else
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            if false
+            then 42
+            else T.absurd(foo) # exhaustive
+                 ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            if false
+            then 42
+            else foo #: absurd # exhaustive
+            end
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_absurd_nested_after_an_inline_else
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -93,6 +93,25 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrects_t_absurd_after_an_inline_unless_else
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            unless true
+            then 42
+            else T.absurd(foo) # exhaustive
+                 ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            unless true
+            then 42
+            else foo #: absurd # exhaustive
+            end
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_absurd_nested_after_an_inline_else
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -55,6 +55,39 @@ module RuboCop
           RUBY
         end
 
+        def test_autocorrects_t_absurd_after_an_inline_else
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            case foo
+            when String then foo
+            else T.absurd(foo) # exhaustive
+                 ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            case foo
+            when String then foo
+            else foo #: absurd # exhaustive
+            end
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_absurd_nested_after_an_inline_else
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            case foo
+            when String then foo
+            else consume(T.absurd(foo))
+                         ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_no_corrections
+        end
+
         def test_does_not_autocorrect_t_absurd_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 


### PR DESCRIPTION
So this case with an inline annotation after the `else`:

```
case foo
when Foo
  ...
else T.absurd(foo)
end
```

get autocorrect to this:

```
case foo
when Foo
  ...
else foo #: absurd
end
```