### PR TITLE
Autocorrect Sorbet assertions in method arguments

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_cast.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_cast.rb
@@ -37,10 +37,11 @@ module RuboCop
 
         def autocorrect_t_cast_to_rbs(corrector, node)
           return if t_cast?(node.first_argument)
-          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
 
-          type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
-          corrector.replace(node, "#{node.first_argument.source} #: as #{type}")
+          autocorrect_rbs_assertion(corrector, node, allow_assignment: true) do
+            type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
+            [node.first_argument.source, "as #{type}"]
+          end
         rescue ::RBI::Type::Error
           nil
         end

--- a/lib/rubocop/cop/sorbet/forbid_t_let.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_let.rb
@@ -37,10 +37,11 @@ module RuboCop
 
         def autocorrect_t_let_to_rbs(corrector, node)
           return if t_let?(node.first_argument)
-          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
 
-          type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
-          corrector.replace(node, "#{node.first_argument.source} #: #{type}")
+          autocorrect_rbs_assertion(corrector, node, allow_assignment: true) do
+            type = ::RBI::Type.parse_string(node.last_argument.source).rbs_string
+            [node.first_argument.source, type]
+          end
         rescue ::RBI::Type::Error
           nil
         end

--- a/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_unsafe.rb
@@ -35,9 +35,9 @@ module RuboCop
         private
 
         def autocorrect_t_unsafe_to_rbs(corrector, node)
-          return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
-
-          corrector.replace(node, "#{node.first_argument.source} #: as untyped")
+          autocorrect_rbs_assertion(corrector, node, allow_assignment: true) do
+            [node.first_argument.source, "as untyped"]
+          end
         end
       end
     end

--- a/lib/rubocop/cop/sorbet/mixin/rbs_assertion_correction.rb
+++ b/lib/rubocop/cop/sorbet/mixin/rbs_assertion_correction.rb
@@ -3,15 +3,132 @@
 module RuboCop
   module Cop
     module Sorbet
-      # Shared guards for replacing Sorbet runtime assertions with RBS inline
-      # comments without changing the surrounding Ruby syntax.
+      # Shared guards and rewrites for replacing Sorbet runtime assertions
+      # with equivalent RBS inline comments.
       module RBSAssertionCorrection
         include RangeHelp
+        include Alignment
 
         COMMENT_START = "#"
         NEWLINES = ["\n", "\r"].freeze
 
         private
+
+        def autocorrect_rbs_assertion(corrector, node, allow_assignment: false)
+          context = rbs_assertion_correction_context(node, allow_assignment: allow_assignment)
+          return unless context
+
+          expression, annotation = yield
+          case context.first
+          when :direct
+            corrector.replace(node, "#{expression} #: #{annotation}")
+          when :arguments
+            autocorrect_argument_list(corrector, node, expression, annotation, context)
+          end
+        end
+
+        def rbs_assertion_correction_context(node, allow_assignment:)
+          return [:direct] if rbs_assertion_autocorrectable?(node, allow_assignment: allow_assignment)
+          return unless nested_rbs_assertion_autocorrectable?(node)
+
+          call_argument_context(node)
+        end
+
+        def call_argument_context(node)
+          parent = node.parent
+          if parent&.type?(:call) && parent.arguments.include?(node)
+            call = parent
+            target = node
+          elsif parent&.splat_type?
+            call = parent.parent
+            return unless call&.type?(:call) && call.arguments.include?(parent)
+
+            target = parent
+          elsif parent&.kwsplat_type?
+            argument = node.first_argument
+            return if argument.hash_type? && !argument.loc.begin
+
+            hash = parent.parent
+            return unless hash&.hash_type? && !hash.loc.begin
+
+            call = hash.parent
+            return unless call&.type?(:call) && call.arguments.include?(hash)
+
+            target = parent
+          elsif parent&.pair_type? && parent.value.equal?(node)
+            hash = parent.parent
+            return unless hash&.hash_type? && !hash.loc.begin
+
+            call = hash.parent
+            return unless call&.type?(:call) && call.arguments.include?(hash)
+
+            target = parent
+          else
+            return
+          end
+
+          return unless call.single_line? && call.loc.begin && call.loc.end
+          return if comments_within?(call)
+          return unless one_matching_assertion?(call, node)
+
+          items = call.arguments.flat_map do |argument|
+            argument.hash_type? && !argument.loc.begin ? argument.children : argument
+          end
+          return unless items.include?(target)
+
+          [:arguments, call, items, target]
+        end
+
+        def autocorrect_argument_list(corrector, node, expression, annotation, context)
+          _, container, items, target = context
+          indentation = container.source_range.source_line[/\A[ \t]*/]
+          item_indentation = indentation + (" " * configured_indentation_width)
+          splat = target.type?(:splat, :kwsplat)
+          target_index = items.index(target)
+          replacement = "#{expression} #: #{annotation}"
+          if splat
+            nested_indentation = item_indentation + (" " * configured_indentation_width)
+            replacement = "(\n#{nested_indentation}#{replacement}\n#{item_indentation})"
+          elsif target_index < items.length - 1
+            replacement = "#{expression}, #: #{annotation}"
+          end
+          corrector.replace(node, replacement)
+
+          corrector.replace(container.loc.begin.end.join(items.first.source_range.begin), "\n#{item_indentation}")
+          items.each_cons(2) do |item, next_item|
+            separator = item.equal?(target) && !splat ? "" : ","
+            corrector.replace(item.source_range.end.join(next_item.source_range.begin), "#{separator}\n#{item_indentation}")
+          end
+          corrector.replace(items.last.source_range.end.join(container.loc.end.begin), "\n#{indentation}")
+        end
+
+        def comments_within?(node)
+          range = node.source_range
+          processed_source.comments.any? do |comment|
+            comment.source_range.begin_pos >= range.begin_pos && comment.source_range.end_pos <= range.end_pos
+          end
+        end
+
+        def one_matching_assertion?(container, node)
+          container.each_node(:send).count do |candidate|
+            candidate.method?(node.method_name) &&
+              candidate.receiver&.const_type? &&
+              candidate.receiver.const_name == "T"
+          end == 1
+        end
+
+        def nested_rbs_assertion_autocorrectable?(node)
+          return false unless cop_config["AutocorrectToRBS"]
+          return false unless node.single_line?
+          return false if inside_single_line_block?(node)
+          return false if ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
+
+          true
+        end
+
+        def inside_single_line_block?(node)
+          node.each_ancestor.any? { |ancestor| ancestor.type?(:block, :numblock) && ancestor.single_line? }
+        end
 
         def rbs_assertion_autocorrectable?(node, allow_assignment: false)
           return false unless cop_config["AutocorrectToRBS"]

--- a/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_cast_test.rb
@@ -55,7 +55,7 @@ module RuboCop
           RUBY
         end
 
-        def test_does_not_autocorrect_t_cast_nested_in_an_expression
+        def test_autocorrects_t_cast_used_as_an_argument
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 
           assert_offense(<<~RUBY)
@@ -63,7 +63,11 @@ module RuboCop
                     ^^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
 
-          assert_no_corrections
+          assert_correction(<<~RUBY)
+            consume(
+              foo #: as String
+            )
+          RUBY
         end
 
         def test_does_not_autocorrect_nested_t_cast_calls

--- a/test/rubocop/cop/sorbet/forbid_t_let_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_let_test.rb
@@ -55,7 +55,7 @@ module RuboCop
           RUBY
         end
 
-        def test_does_not_autocorrect_t_let_nested_in_an_expression
+        def test_autocorrects_t_let_used_as_an_argument
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 
           assert_offense(<<~RUBY)
@@ -63,7 +63,11 @@ module RuboCop
                     ^^^^^^^^^^^^^^^^^^ #{MSG}
           RUBY
 
-          assert_no_corrections
+          assert_correction(<<~RUBY)
+            consume(
+              foo #: String
+            )
+          RUBY
         end
 
         def test_does_not_autocorrect_nested_t_let_calls

--- a/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_unsafe_test.rb
@@ -55,12 +55,81 @@ module RuboCop
           RUBY
         end
 
-        def test_does_not_autocorrect_t_unsafe_nested_in_an_expression
+        def test_autocorrects_t_unsafe_used_as_an_argument
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 
           assert_offense(<<~RUBY)
             consume(T.unsafe(foo))
                     ^^^^^^^^^^^^^ #{MSG}
+            consume(first, T.unsafe(foo), last)
+                           ^^^^^^^^^^^^^ #{MSG}
+            consume(value: T.unsafe(foo))
+                           ^^^^^^^^^^^^^ #{MSG}
+            consume(first, T.unsafe("already #: marker"), last)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            consume(
+              foo #: as untyped
+            )
+            consume(
+              first,
+              foo, #: as untyped
+              last
+            )
+            consume(
+              value: foo #: as untyped
+            )
+            consume(
+              first,
+              "already #: marker", #: as untyped
+              last
+            )
+          RUBY
+        end
+
+        def test_autocorrects_positional_and_keyword_splats
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(*T.unsafe(values))
+                     ^^^^^^^^^^^^^^^^ #{MSG}
+            consume(**T.unsafe(options))
+                      ^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            consume(
+              *(
+                values #: as untyped
+              )
+            )
+            consume(
+              **(
+                options #: as untyped
+              )
+            )
+          RUBY
+        end
+
+        def test_does_not_autocorrect_a_keyword_splat_of_an_implicit_hash
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            consume(**T.unsafe(required: value, **options))
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_does_not_autocorrect_inside_a_single_line_block
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            assert_raises { consume(T.unsafe(foo)) }
+                                    ^^^^^^^^^^^^^ #{MSG}
           RUBY
 
           assert_no_corrections


### PR DESCRIPTION
## Summary

Extend the shared RBS assertion autocorrector to support Sorbet assertions used as method arguments.

This applies to:

- `Sorbet/ForbidTCast`
- `Sorbet/ForbidTLet`
- `Sorbet/ForbidTUnsafe`

It supports:

- Positional arguments
- Keyword arguments
- Positional splats
- Keyword splats whose asserted value is a regular expression

## Examples

```ruby
consume(first, T.unsafe(value), last)
```

is corrected to:

```ruby
consume(
  first,
  value, #: as untyped
  last
)
```

For splats:

```ruby
consume(*T.unsafe(values))
```

is corrected to:

```ruby
consume(
  *(
    values #: as untyped
  )
)
```

The parentheses are required so the RBS comment applies to the value being splatted without swallowing the closing syntax.

## Guardrails

The autocorrect declines cases where rewriting the enclosing call is ambiguous or would introduce invalid layout:

- Calls inside single-line blocks
- Calls without usable delimiters
- Already-multiline calls
- Calls containing comments
- Calls containing multiple matching assertions
- Keyword splats where `T.unsafe` receives an implicit hash

For example, this remains uncorrected:

```ruby
consume(**T.unsafe(required: value, **options))
```

Materializing that implicit hash belongs in the hash-focused follow-up.

Receiver chains are also out of scope. Core testing showed that Sorbet does not reliably apply an RBS assertion when the asserted expression continues as a receiver.

## Follow-ups

- Explicit array elements
- Explicit hash values
- Single-line block expansion
- Already-multiline calls
- Multiple assertions in one argument list