### PR TITLE
Update ForbidTAbsurd autocorrection for new RBS syntax

### DIFF
--- a/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_absurd.rb
@@ -13,14 +13,24 @@ module RuboCop
       #   # bad
       #   T.absurd(foo)
       #
-      #   # good
+      #   # good (Sorbet before 0.6.99999)
       #   foo #: absurd
+      #
+      #   # good (Sorbet 0.6.99999 and later)
+      #   raise #: absurd(foo)
       class ForbidTAbsurd < RuboCop::Cop::Base
         include RBSAssertionCorrection
+        include TargetSorbetVersion
         extend AutoCorrector
 
         MSG = "Do not use `T.absurd`."
         RESTRICT_ON_SEND = [:absurd].freeze
+
+        # TODO: Replace with the real release version once https://github.com/Shopify/sorbet/pull/871 lands.
+        MINIMUM_RBS_ABSURD_VERSION = "0.6.99999"
+        SUPPORTED_ABSURD_VARIABLE_TYPES = [:lvar, :ivar, :cvar, :gvar, :self].freeze
+
+        minimum_target_sorbet_static_version MINIMUM_RBS_ABSURD_VERSION
 
         # @!method t_absurd?(node)
         def_node_matcher(:t_absurd?, "(send (const nil? :T) :absurd _)")
@@ -35,9 +45,26 @@ module RuboCop
         private
 
         def autocorrect_t_absurd_to_rbs(corrector, node)
+          argument = node.first_argument
+
+          if enabled_for_sorbet_static_version?
+            autocorrect_new_rbs_absurd(corrector, node, argument)
+          else
+            autocorrect_legacy_rbs_absurd(corrector, node, argument)
+          end
+        end
+
+        def autocorrect_new_rbs_absurd(corrector, node, argument)
+          return unless rbs_assertion_autocorrectable?(node)
+          return unless SUPPORTED_ABSURD_VARIABLE_TYPES.include?(argument.type)
+
+          corrector.replace(node, "raise #: absurd(#{argument.source})")
+        end
+
+        def autocorrect_legacy_rbs_absurd(corrector, node, argument)
           return unless rbs_assertion_autocorrectable?(node, allow_assignment: true)
 
-          corrector.replace(node, "#{node.first_argument.source} #: absurd")
+          corrector.replace(node, "#{argument.source} #: absurd")
         end
 
         def assertion_statement(node, allow_assignment:)

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -650,8 +650,11 @@ Set `AutocorrectToRBS: true` to replace supported calls with RBS inline comments
 # bad
 T.absurd(foo)
 
-# good
+# good (Sorbet before 0.6.99999)
 foo #: absurd
+
+# good (Sorbet 0.6.99999 and later)
+raise #: absurd(foo)
 ```
 
 ### Configurable attributes

--- a/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_absurd_test.rb
@@ -7,6 +7,11 @@ module RuboCop
     module Sorbet
       class ForbidTAbsurdTest < ::Minitest::Test
         MSG = "Do not use `T.absurd`."
+        DUMMY_RBS_ABSURD_VERSION = ForbidTAbsurd::MINIMUM_RBS_ABSURD_VERSION
+
+        def setup
+          stub_sorbet_static_version("0.6.99998")
+        end
 
         def test_adds_offense_when_using_t_absurd
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => false))
@@ -40,6 +45,84 @@ module RuboCop
 
             x = foo #: absurd
           RUBY
+        end
+
+        def test_autocorrects_t_absurd_with_the_new_syntax
+          stub_sorbet_static_version(DUMMY_RBS_ABSURD_VERSION)
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            def check(foo)
+              T.absurd(foo)
+              ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            def check(foo)
+              raise #: absurd(foo)
+            end
+          RUBY
+        end
+
+        def test_does_not_autocorrect_t_absurd_in_an_assignment_with_the_new_syntax
+          stub_sorbet_static_version(DUMMY_RBS_ABSURD_VERSION)
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            def check(foo)
+              x = T.absurd(foo)
+                  ^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_no_corrections
+        end
+
+        def test_autocorrects_supported_absurd_variables
+          stub_sorbet_static_version(DUMMY_RBS_ABSURD_VERSION)
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            def check(foo)
+              T.absurd(foo)
+              ^^^^^^^^^^^^^ #{MSG}
+              T.absurd(@foo)
+              ^^^^^^^^^^^^^^ #{MSG}
+              T.absurd(@@foo)
+              ^^^^^^^^^^^^^^^ #{MSG}
+              T.absurd($foo)
+              ^^^^^^^^^^^^^^ #{MSG}
+              T.absurd(self)
+              ^^^^^^^^^^^^^^ #{MSG}
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            def check(foo)
+              raise #: absurd(foo)
+              raise #: absurd(@foo)
+              raise #: absurd(@@foo)
+              raise #: absurd($foo)
+              raise #: absurd(self)
+            end
+          RUBY
+        end
+
+        def test_does_not_autocorrect_unsupported_absurd_operands_with_the_new_syntax
+          stub_sorbet_static_version(DUMMY_RBS_ABSURD_VERSION)
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.absurd(Foo)
+            ^^^^^^^^^^^^^ #{MSG}
+            T.absurd(foo)
+            ^^^^^^^^^^^^^ #{MSG}
+            T.absurd(foo.bar)
+            ^^^^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_no_corrections
         end
 
         def test_autocorrection_preserves_a_trailing_comment
@@ -126,6 +209,20 @@ module RuboCop
           assert_no_corrections
         end
 
+        def test_new_syntax_autocorrection_preserves_a_trailing_comment
+          stub_sorbet_static_version(DUMMY_RBS_ABSURD_VERSION)
+          @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
+
+          assert_offense(<<~RUBY)
+            T.absurd(@foo) # some comment
+            ^^^^^^^^^^^^^^ #{MSG}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            raise #: absurd(@foo) # some comment
+          RUBY
+        end
+
         def test_does_not_autocorrect_t_absurd_nested_in_an_expression
           @cop = target_cop.new(cop_config("AutocorrectToRBS" => true))
 
@@ -149,6 +246,11 @@ module RuboCop
         end
 
         private
+
+        def stub_sorbet_static_version(version)
+          specs = version ? [Gem::Specification.new("sorbet-static", version)] : []
+          ::Bundler.stubs(:locked_gems).returns(Struct.new(:specs).new(specs))
+        end
 
         def target_cop
           ForbidTAbsurd


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on [Shopify/sorbet#871](https://github.com/Shopify/sorbet/pull/871). That PR must be merged and released first so `0.6.99999` can be replaced with the actual `sorbet-static` version before this PR merges.

## Summary

Updates the opt-in `Sorbet/ForbidTAbsurd` autocorrection to support the new RBS `absurd` syntax introduced by [Shopify/sorbet#871](https://github.com/Shopify/sorbet/pull/871).

The correction depends on the project's `sorbet-static` version.

Before the new syntax is available:

```ruby
# Before
T.absurd(value)

# After
value #: absurd
```

With the new syntax:

```ruby
# Before
T.absurd(value)

# After
raise #: absurd(value)
```

`AutocorrectToRBS` remains disabled by default:

```yaml
Sorbet/ForbidTAbsurd:
  Enabled: true
  AutocorrectToRBS: true
```

## Version gate

The new correction is gated using `TargetSorbetVersion`.

For now, `0.6.99999` is used as a placeholder cutoff:

- `< 0.6.99999`: use the existing `value #: absurd` correction
- `>= 0.6.99999`: use `raise #: absurd(value)`

The placeholder must be replaced with the actual `sorbet-static` release containing Shopify/sorbet#871.

## New-syntax constraints

The new RBS syntax requires `absurd` to annotate a standalone `raise` and explicitly name the exhaustiveness subject.

Autocorrection is therefore limited to operands supported by Sorbet:

- local variables
- instance variables
- class variables
- global variables
- `self`

Calls with constants, method calls, or other expressions remain offenses without autocorrection.

Assignment contexts are also left uncorrected with the new syntax:

```ruby
result = T.absurd(value)
```

Replacing only the call would make the trailing RBS annotation bind incorrectly. The legacy correction continues to support assignment contexts.