### PR TITLE
Extend redundant literal checks to local variables

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -372,7 +372,7 @@ Sorbet/RedundantExtendTSig:
 Sorbet/RedundantTLetForLiteral:
   Description: >-
     Checks for redundant `T.let` declarations and trailing RBS annotations
-    on constants whose literal values have types Sorbet can infer automatically.
+    on assignments whose literal values have types Sorbet can infer automatically.
   Enabled: pending
   Safe: true
   SafeAutoCorrect: false

--- a/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
+++ b/lib/rubocop/cop/sorbet/redundant_t_let_for_literal.rb
@@ -14,6 +14,10 @@ module RuboCop
       # inference survives a `.freeze` call (Sorbet 0.6.13304+), so
       # `T.let(/foo/.freeze, Regexp)` is also redundant; other frozen simple
       # literals (e.g. `"hello".freeze`) are not inferred and still need `T.let`.
+      # Exact annotations on `true`, `false`, and `nil` are also redundant,
+      # whether expressed as `T.let(..., TrueClass)` or RBS singleton types.
+      # With RBS comments enabled, Sorbet infers the same `TrueClass`,
+      # `FalseClass`, and `NilClass` types without them.
       #
       # Array literals of simple literals are also inferred:
       #
@@ -36,7 +40,10 @@ module RuboCop
       #   STATUS = T.let(:active, Symbol)
       #   SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
       #   NAMES = T.let(["alice", "bob"], T::Array[String])
+      #   local_truth = T.let(true, TrueClass)
       #   RBS_GREETING = "hello" #: String
+      #   local_count = 1 #: Integer
+      #   local_tlet_count = T.let(1, Integer)
       #   RBS_NAMES = ["alice", "bob"] #: Array[String]
       #
       #   # good
@@ -48,7 +55,10 @@ module RuboCop
       #   STATUS = :active
       #   SHELLS = [:bash, :zsh].freeze
       #   NAMES = ["alice", "bob"]
+      #   local_truth = true
       #   RBS_GREETING = "hello"
+      #   local_count = 1
+      #   local_tlet_count = 1
       #   RBS_NAMES = ["alice", "bob"]
       #
       #   # good — non-regexp frozen simple literals are not inferred
@@ -63,11 +73,25 @@ module RuboCop
       #   # good — type is not the literal's own class
       #   value = T.let("hello", T.nilable(String))
       #
+      #   # good — bool annotations widen a singleton boolean type
+      #   local_bool = true #: bool
+      #   local_tlet_bool = T.let(true, T::Boolean)
+      #
+      #   # bad — the initializer annotation hides an untyped block assignment
+      #   observed_locale = T.let("", String)
+      #   records.each do |record|
+      #     observed_locale = record.locale
+      #   end
+      #
+      #   # good — cast the value at the untyped boundary
+      #   observed_locale = ""
+      #   records.each do |record|
+      #     observed_locale = record.locale #: as String
+      #   end
+      #
       #   # good — instance variables need T.let for Sorbet to track their type
       #   @max_retries = T.let(3, Integer)
       #
-      #   # good — local variables may need T.let so Sorbet allows reassignment
-      #   count = T.let(0, Integer)
       class RedundantTLetForLiteral < Base
         include ConstantScope
         include TargetSorbetVersion
@@ -87,12 +111,21 @@ module RuboCop
         LITERAL_TYPE_TO_CLASS = {
           dstr: :String,
           dsym: :Symbol,
+          false: :FalseClass,
           float: :Float,
           int: :Integer,
+          nil: :NilClass,
           regexp: :Regexp,
           str: :String,
           sym: :Symbol,
+          true: :TrueClass,
         }.freeze
+
+        RBS_LITERAL_TYPE = LITERAL_TYPE_TO_CLASS.merge(
+          false: :false,
+          nil: :nil,
+          true: :true,
+        ).freeze
 
         # Element node types allowed inside an inferable array literal: the
         # literals whose class Sorbet reflects into the array's element type.
@@ -115,6 +148,11 @@ module RuboCop
         # @!method t_let_with_literal_and_class?(node)
         def_node_matcher :t_let_with_literal_and_class?, <<~PATTERN
           (casgn _ _ (send (const {nil? cbase} :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
+        PATTERN
+
+        # @!method local_t_let_with_literal_and_class?(node)
+        def_node_matcher :local_t_let_with_literal_and_class?, <<~PATTERN
+          (lvasgn _ (send (const {nil? cbase} :T) :let ${literal? (send (regexp ...) :freeze)} (const nil? $_)))
         PATTERN
 
         # @!method t_let_with_array?(node)
@@ -144,7 +182,19 @@ module RuboCop
             end
           end
 
-          check_rbs_annotation(node)
+          check_rbs_annotation(node, include_arrays: true)
+        end
+
+        def on_lvasgn(node)
+          local_t_let_with_literal_and_class?(node) do |value_node, class_name|
+            literal_node = inferable_literal_node(value_node)
+            next unless literal_node
+            next unless LITERAL_TYPE_TO_CLASS[literal_node.type] == class_name
+
+            register_offense(node, value_node, class_name)
+          end
+
+          check_rbs_annotation(node, include_arrays: false)
         end
 
         private
@@ -162,14 +212,16 @@ module RuboCop
         end
 
         def register_offense(node, value_node, type)
-          t_let_node = node.children[2]
+          t_let_node = node.children.last
           add_offense(t_let_node, message: format(MSG, annotation: "`T.let`", type: type)) do |corrector|
             replace_t_let(corrector, t_let_node, value_node)
           end
         end
 
-        def check_rbs_annotation(node)
-          value_node = node.children[2]
+        def check_rbs_annotation(node, include_arrays:)
+          value_node = node.children.last
+          return unless value_node
+
           comment, annotation = ::RuboCop::Sorbet::RBSParser.rbs_annotation_after(processed_source, node)
           return unless comment
 
@@ -177,7 +229,7 @@ module RuboCop
 
           literal_node = inferable_literal_node(value_node)
           if literal_node
-            inferred_type = LITERAL_TYPE_TO_CLASS[literal_node.type]
+            inferred_type = RBS_LITERAL_TYPE[literal_node.type]
             if inferred_type
               return unless annotated_type.delete_prefix("::") == inferred_type.to_s
 
@@ -185,6 +237,7 @@ module RuboCop
             end
           end
 
+          return unless include_arrays
           return unless enabled_for_sorbet_static_version?
 
           frozen = value_node.send_type? && value_node.method?(:freeze) && !value_node.receiver.nil?

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1315,6 +1315,10 @@ their own class. Regexp literals are the only simple literals whose
 inference survives a `.freeze` call (Sorbet 0.6.13304+), so
 `T.let(/foo/.freeze, Regexp)` is also redundant; other frozen simple
 literals (e.g. `"hello".freeze`) are not inferred and still need `T.let`.
+Exact annotations on `true`, `false`, and `nil` are also redundant,
+whether expressed as `T.let(..., TrueClass)` or RBS singleton types.
+With RBS comments enabled, Sorbet infers the same `TrueClass`,
+`FalseClass`, and `NilClass` types without them.
 
 Array literals of simple literals are also inferred:
 
@@ -1340,6 +1344,9 @@ STATUS = T.let(:active, Symbol)
 SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
 NAMES = T.let(["alice", "bob"], T::Array[String])
 RBS_GREETING = "hello" #: String
+local_count = 1 #: Integer
+local_tlet_count = T.let(1, Integer)
+local_truth = T.let(true, TrueClass)
 RBS_NAMES = ["alice", "bob"] #: Array[String]
 
 # good
@@ -1352,6 +1359,9 @@ STATUS = :active
 SHELLS = [:bash, :zsh].freeze
 NAMES = ["alice", "bob"]
 RBS_GREETING = "hello"
+local_count = 1
+local_tlet_count = 1
+local_truth = true
 RBS_NAMES = ["alice", "bob"]
 
 # good — non-regexp frozen simple literals are not inferred
@@ -1366,11 +1376,24 @@ NAMES = T.let(["alice", "bob"], T::Array[T.nilable(String)])
 # good — type is not the literal's own class
 value = T.let("hello", T.nilable(String))
 
+# good — bool annotations widen a singleton boolean type
+local_bool = true #: bool
+local_tlet_bool = T.let(true, T::Boolean)
+
+# bad — the initializer annotation hides an untyped block assignment
+observed_locale = T.let("", String)
+records.each do |record|
+  observed_locale = record.locale
+end
+
+# good — cast the value at the untyped boundary
+observed_locale = ""
+records.each do |record|
+  observed_locale = record.locale #: as String
+end
+
 # good — instance variables need T.let for Sorbet to track their type
 @max_retries = T.let(3, Integer)
-
-# good — local variables may need T.let so Sorbet allows reassignment
-count = T.let(0, Integer)
 ```
 
 ## Sorbet/Refinement

--- a/manual/cops_sorbet.md
+++ b/manual/cops_sorbet.md
@@ -1343,10 +1343,10 @@ FROZEN_PATTERN = T.let(/foo/.freeze, Regexp)
 STATUS = T.let(:active, Symbol)
 SHELLS = T.let([:bash, :zsh].freeze, T::Array[Symbol])
 NAMES = T.let(["alice", "bob"], T::Array[String])
+local_truth = T.let(true, TrueClass)
 RBS_GREETING = "hello" #: String
 local_count = 1 #: Integer
 local_tlet_count = T.let(1, Integer)
-local_truth = T.let(true, TrueClass)
 RBS_NAMES = ["alice", "bob"] #: Array[String]
 
 # good
@@ -1358,10 +1358,10 @@ FROZEN_PATTERN = /foo/.freeze
 STATUS = :active
 SHELLS = [:bash, :zsh].freeze
 NAMES = ["alice", "bob"]
+local_truth = true
 RBS_GREETING = "hello"
 local_count = 1
 local_tlet_count = 1
-local_truth = true
 RBS_NAMES = ["alice", "bob"]
 
 # good — non-regexp frozen simple literals are not inferred

--- a/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
+++ b/test/rubocop/cop/sorbet/redundant_t_let_for_literal_test.rb
@@ -563,9 +563,54 @@ module RuboCop
 
         # Non-constant assignments
 
-        def test_no_offense_for_local_variable
-          assert_no_offenses(<<~RUBY)
+        def test_registers_offense_for_local_variable
+          assert_offense(<<~RUBY)
             x = T.let(42, Integer)
+                ^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            x = 42
+          RUBY
+        end
+
+        def test_registers_offense_for_local_t_let_with_exact_boolean_and_nil_classes
+          assert_offense(<<~RUBY)
+            exact_true = T.let(true, TrueClass)
+                         ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "TrueClass")}
+            exact_false = T.let(false, FalseClass)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "FalseClass")}
+            exact_nil = T.let(nil, NilClass)
+                        ^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "NilClass")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            exact_true = true
+            exact_false = false
+            exact_nil = nil
+          RUBY
+        end
+
+        def test_registers_offense_for_constant_t_let_with_exact_boolean_and_nil_classes
+          assert_offense(<<~RUBY)
+            EXACT_TRUE = T.let(true, TrueClass)
+                         ^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "TrueClass")}
+            EXACT_FALSE = T.let(false, FalseClass)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "FalseClass")}
+            EXACT_NIL = T.let(nil, NilClass)
+                        ^^^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "NilClass")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            EXACT_TRUE = true
+            EXACT_FALSE = false
+            EXACT_NIL = nil
+          RUBY
+        end
+
+        def test_no_offense_for_local_variable_with_wider_type
+          assert_no_offenses(<<~RUBY)
+            x = T.let(42, Numeric)
           RUBY
         end
 
@@ -765,6 +810,87 @@ module RuboCop
           RUBY
         end
 
+        def test_registers_offense_for_local_variable_literal_annotations
+          assert_offense(<<~RUBY)
+            local_var1 = 1 #: Integer
+                           ^^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Integer")}
+            local_var2 = "" #: String
+                            ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "String")}
+            local_var3 = 1.0 #: Float
+                             ^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Float")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            local_var1 = 1
+            local_var2 = ""
+            local_var3 = 1.0
+          RUBY
+        end
+
+        def test_registers_offense_for_t_let_with_trailing_rbs_annotation
+          assert_offense(<<~RUBY)
+            value = T.let(42, Integer) #: Integer
+                    ^^^^^^^^^^^^^^^^^^ #{format(MSG, annotation: "`T.let`", type: "Integer")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            value = 42
+          RUBY
+        end
+
+        def test_registers_offense_for_other_local_scalar_literal_annotations
+          assert_offense(<<~'RUBY')
+            negative = -1 #: Integer
+                          ^^^^^^^^^^ Sorbet/RedundantTLetForLiteral: Redundant RBS annotation for Integer literal. Sorbet can infer this type automatically.
+            symbol = :active #: Symbol
+                             ^^^^^^^^^ Sorbet/RedundantTLetForLiteral: Redundant RBS annotation for Symbol literal. Sorbet can infer this type automatically.
+            regexp = /foo/ #: Regexp
+                           ^^^^^^^^^ Sorbet/RedundantTLetForLiteral: Redundant RBS annotation for Regexp literal. Sorbet can infer this type automatically.
+            string = "#{prefix}value" #: String
+                                      ^^^^^^^^^ Sorbet/RedundantTLetForLiteral: Redundant RBS annotation for String literal. Sorbet can infer this type automatically.
+            interpolated_symbol = :"value_#{suffix}" #: Symbol
+                                                     ^^^^^^^^^ Sorbet/RedundantTLetForLiteral: Redundant RBS annotation for Symbol literal. Sorbet can infer this type automatically.
+          RUBY
+
+          assert_correction(<<~'RUBY')
+            negative = -1
+            symbol = :active
+            regexp = /foo/
+            string = "#{prefix}value"
+            interpolated_symbol = :"value_#{suffix}"
+          RUBY
+        end
+
+        def test_registers_offense_for_reassigned_local_variable
+          assert_offense(<<~RUBY)
+            count = 0 #: Integer
+                      ^^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "Integer")}
+            count = fetch_count
+          RUBY
+
+          assert_correction(<<~RUBY)
+            count = 0
+            count = fetch_count
+          RUBY
+        end
+
+        def test_registers_offense_when_local_variable_is_reassigned_in_block
+          assert_offense(<<~RUBY)
+            captured = "" #: String
+                          ^^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "String")}
+            values.each do |value|
+              captured = value
+            end
+          RUBY
+
+          assert_correction(<<~RUBY)
+            captured = ""
+            values.each do |value|
+              captured = value
+            end
+          RUBY
+        end
+
         def test_no_offense_for_frozen_string_with_trailing_rbs_annotation
           assert_no_offenses(<<~RUBY)
             GREETING = "hello".freeze #: String
@@ -799,6 +925,23 @@ module RuboCop
           RUBY
         end
 
+        def test_registers_offense_for_exact_boolean_and_nil_rbs_literal_types
+          assert_offense(<<~RUBY)
+            exact_true = true #: true
+                              ^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "true")}
+            exact_false = false #: false
+                                ^^^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "false")}
+            exact_nil = nil #: nil
+                            ^^^^^^ #{format(MSG, annotation: "RBS annotation", type: "nil")}
+          RUBY
+
+          assert_correction(<<~RUBY)
+            exact_true = true
+            exact_false = false
+            exact_nil = nil
+          RUBY
+        end
+
         def test_registers_offense_for_trailing_rbs_array_annotation
           assert_offense(<<~RUBY)
             NAMES = ["alice", "bob"] #: Array[String]
@@ -827,14 +970,17 @@ module RuboCop
           RUBY
         end
 
-        def test_no_offense_for_nonredundant_or_nonconstant_rbs_annotations
+        def test_no_offense_for_nonredundant_rbs_annotations
           assert_no_offenses(<<~RUBY)
             MAYBE = "hello" #: String?
             WIDE = "hello" #: Object
             CAST = "hello" #: as String
 
             NAMES = ["alice", "bob"] #: Array[String?]
-            local = "hello" #: String
+            local_array = ["alice", "bob"] #: Array[String]
+            local_boolean = true #: bool
+            local_tlet_boolean = T.let(true, T::Boolean)
+            local_optional = nil #: String?
             @greeting = "hello" #: String
           RUBY
         end


### PR DESCRIPTION
## Summary

Extend `Sorbet/RedundantTLetForLiteral` to detect redundant literal annotations on local variables.

The cop now handles both `T.let` and RBS inline annotations:

```ruby
# bad
count = T.let(1, Integer)
name = "" #: String
rate = 1.0 #: Float

# good
count = 1
name = ""
rate = 1.0
```

It also detects exact boolean and nil types:

```ruby
# bad
enabled = T.let(true, TrueClass)
disabled = false #: false
value = nil #: nil
```

Broader annotations remain valid because they widen the inferred singleton type:

```ruby
# good
enabled = T.let(true, T::Boolean)
disabled = false #: bool
value = nil #: String?
```

When a value from an untyped source is assigned inside a block, cast that value at the reassignment boundary rather than annotating the initial literal:

```ruby
# bad
observed_locale = T.let("", String)

records.each do |record|
  observed_locale = record.locale
end

# good
observed_locale = ""

records.each do |record|
  observed_locale = record.locale #: as String
end
```