### PR TITLE
Enable AllowRBSInlineAnnotation for Lint/SelfAssignment by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,9 @@
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 
+Lint/SelfAssignment:
+  AllowRBSInlineAnnotation: true
+
 Sorbet/ForbidTHelpers:
   Description: 'Forbid usage of T::Helpers via `extend` or `include`.'
   Enabled: false


### PR DESCRIPTION
When using rubocop-sorbet we should allow RBS inline annotations in all cops that have that option.