### PR TITLE
Use RBI and RBS gems to parse and generate RBS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,8 @@ PATH
   specs:
     rubocop-sorbet (0.16.0)
       lint_roller
-      rbi (~> 0.4)
+      rbi (~> 0.4, >= 0.4.3)
+      rbs (>= 4.1.1)
       rubocop (>= 1.75.2)
       spoom (~> 1.8)
 
@@ -48,7 +49,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
-    rbi (0.4.1)
+    rbi (0.4.3)
       prism (~> 1.0)
       rbs (>= 4.0.1)
     rbs (4.1.1)

--- a/lib/rubocop/cop/sorbet/forbid_t_struct.rb
+++ b/lib/rubocop/cop/sorbet/forbid_t_struct.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rbi"
 
 module RuboCop
   module Cop
@@ -129,12 +130,6 @@ module RuboCop
         end
 
         class Property
-          # Sorbet `T::X[...]` generics that have a direct RBS equivalent.
-          GENERIC_BASE_NAMES = [:Array, :Hash, :Set, :Range].freeze
-
-          # Sorbet bare `T::X` constants that map to an RBS built-in.
-          T_CONST_MAP = { Boolean: "bool" }.freeze
-
           attr_reader :node, :kind, :name, :default, :factory
 
           def initialize(node, kind, name, type, default:, factory:, style: "sig")
@@ -142,7 +137,6 @@ module RuboCop
             @kind = kind
             @name = name
             @type = type
-            @type_node = node.arguments[1]
             @default = default
             @factory = factory
             @style = style
@@ -212,94 +206,9 @@ module RuboCop
           end
 
           def rbs_type
-            sorbet_type_to_rbs(@type_node)
-          end
-
-          # Translate a Sorbet type expression AST node into RBS syntax.
-          # Handles the constructs most commonly found on `T::Struct` props:
-          # `T.nilable`, `T.any`, `T.all`, `T.untyped`, `T.class_of`, and
-          # generics like `T::Array[X]`. Any unrecognized node falls back to
-          # the valid RBS `untyped` rather than emitting malformed Sorbet
-          # syntax (e.g. `T.proc...`) into an RBS annotation.
-          def sorbet_type_to_rbs(node)
-            return "untyped" if node.nil?
-
-            case node.type
-            when :const
-              translate_const(node)
-            when :send
-              translate_send_type(node)
-            else
-              "untyped"
-            end
-          end
-
-          def translate_send_type(node)
-            receiver = node.receiver
-            method = node.method_name
-            args = node.arguments
-
-            if t_const?(receiver)
-              translate_t_method(method, args)
-            elsif method == :[] && (base = generic_base(receiver))
-              "#{base}[#{args.map { |arg| sorbet_type_to_rbs(arg) }.join(", ")}]"
-            else
-              "untyped"
-            end
-          end
-
-          # Maps `T.xxx(...)` type constructors to RBS. Unknown `T.xxx` sends
-          # become `untyped` so the annotation stays valid RBS.
-          def translate_t_method(method, args)
-            case method
-            when :nilable
-              inner = sorbet_type_to_rbs(args.first)
-              inner = "(#{inner})" if inner.include?(" | ") || inner.include?(" & ")
-              "#{inner}?"
-            when :any
-              args.map { |arg| sorbet_type_to_rbs(arg) }.join(" | ")
-            when :all
-              args.map { |arg| sorbet_type_to_rbs(arg) }.join(" & ")
-            when :untyped
-              "untyped"
-            when :noreturn
-              "bot"
-            when :class_of
-              "singleton(#{sorbet_type_to_rbs(args.first)})"
-            else
-              "untyped"
-            end
-          end
-
-          def t_const?(node)
-            node&.const_type? && node.children[1] == :T
-          end
-
-          # Bare class constants are valid RBS class-instance types, except
-          # for Sorbet's `T::Boolean` (-> `bool`) and other `T::X` constants
-          # which have no RBS equivalent and fall back to `untyped`.
-          def translate_const(node)
-            return "untyped" if t_const?(node)
-
-            if t_const?(node.children[0])
-              T_CONST_MAP.fetch(node.children[1]) { "untyped" }
-            else
-              node.source
-            end
-          end
-
-          # `T::Array[X]`, `T::Hash[K, V]`, and `T::Set[X]` become the RBS
-          # generics `Array[X]`, `Hash[K, V]`, `Set[X]`. Other const receivers
-          # keep their class name (custom generics). Non-const receivers return
-          # nil so the caller falls back to `untyped` instead of `untyped[X]`.
-          def generic_base(node)
-            return unless node&.const_type?
-
-            if t_const?(node.children[0]) && GENERIC_BASE_NAMES.include?(node.children[1])
-              node.children[1].to_s
-            elsif !t_const?(node.children[0])
-              node.source
-            end
+            RBI::Type.parse_string(@type).rbs_string
+          rescue RBI::Type::Error
+            "untyped"
           end
         end
 

--- a/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
+++ b/lib/rubocop/cop/sorbet/signatures/enforce_signatures.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rbi"
 require "spoom"
 
 module RuboCop
@@ -138,12 +139,15 @@ module RuboCop
 
         def autocorrect_with_signature_type(corrector, node, type)
           target = leftmost_send_ancestor(node)
-          suggest = SigSuggestion.new(target.loc.column, param_type_placeholder, return_type_placeholder)
+          suggest = create_signature_suggestion(target, type)
           populate_signature_suggestion(suggest, node)
 
-          correction = suggest.to_autocorrect
-          correction = translate_signature_to_rbs(correction, node) if type == "rbs"
-          corrector.insert_before(target, correction)
+          corrector.insert_before(target, suggest.to_autocorrect)
+        end
+
+        def create_signature_suggestion(node, type)
+          suggestion_class = type == "rbs" ? RBSSuggestion : SigSuggestion
+          suggestion_class.new(node.loc.column, param_type_placeholder, return_type_placeholder)
         end
 
         def autocorrect_rbs_to_sigs(corrector, node, rbs_signatures)
@@ -206,11 +210,6 @@ module RuboCop
           end
 
           first_comment.source_range.with(end_pos: comments.last.source_range.end_pos)
-        end
-
-        def translate_signature_to_rbs(signature, node)
-          translated = translate_sigs_to_rbs("#{signature}#{node.source}")
-          translated_signature_prefix(translated, reject_sig: true)
         end
 
         def translated_signature_prefix(translated, reject_sig: false)
@@ -286,6 +285,7 @@ module RuboCop
           method = node.children[1]
           symbol = node.children[2]
 
+          suggest.accessor = method
           add_accessor_parameter_if_needed(suggest, symbol, method)
           set_void_return_for_writer(suggest, method)
         end
@@ -377,8 +377,76 @@ module RuboCop
           end
         end
 
+        class RBSSuggestion
+          attr_accessor :params, :accessor
+
+          def initialize(indent, param_placeholder, return_placeholder)
+            @params = []
+            @returns = nil
+            @accessor = nil
+            @indent = indent
+            @param_type = RBI::Type.parse_string(param_placeholder)
+            @return_type = RBI::Type.parse_string(return_placeholder)
+          end
+
+          def returns=(value)
+            @returns = value == "void" ? RBI::Type.void : value
+          end
+
+          def to_autocorrect
+            signature = if accessor
+              type = accessor == :attr_writer ? @param_type : @return_type
+              "#: #{type.rbs_string}"
+            else
+              method = RBI::Method.new("f")
+              sig = RBI::Sig.new(return_type: @returns || @return_type)
+              params.each do |param|
+                rbi_params(param).each do |method_param, sig_param|
+                  method << method_param
+                  sig << RBI::SigParam.new(sig_param, @param_type) if sig_param
+                end
+              end
+              method.sigs << sig
+              "#: #{method.rbs_string(positional_names: false).delete_prefix("def f: ").delete_suffix("\n")}"
+            end
+
+            "#{signature}\n#{" " * @indent}"
+          end
+
+          private
+
+          def rbi_params(param)
+            case param.kind
+            when :arg
+              [[RBI::ReqParam.new(param.name), param.name]]
+            when :optarg
+              [[RBI::OptParam.new(param.name, "nil"), param.name]]
+            when :restarg
+              [[RBI::RestParam.new(param.name), param.name || "*"]]
+            when :kwarg
+              [[RBI::KwParam.new(param.name), param.name]]
+            when :kwoptarg
+              [[RBI::KwOptParam.new(param.name, "nil"), param.name]]
+            when :kwrestarg
+              [[RBI::KwRestParam.new(param.name), param.name || "**"]]
+            when :blockarg
+              [[RBI::BlockParam.new(param.name), param.name || "&"]]
+            when :forward_arg
+              [
+                [RBI::RestParam.new(nil), "*"],
+                [RBI::KwRestParam.new(nil), "**"],
+                [RBI::BlockParam.new(nil), "&"],
+              ]
+            when :nokey, :kwnilarg
+              [[RBI::NoKwParam.new, nil]]
+            else
+              [[RBI::ReqParam.new("untyped"), "untyped"]]
+            end
+          end
+        end
+
         class SigSuggestion
-          attr_accessor :params, :returns
+          attr_accessor :params, :returns, :accessor
 
           def initialize(indent, param_placeholder, return_placeholder)
             @params = []

--- a/lib/rubocop/sorbet/rbs_parser.rb
+++ b/lib/rubocop/sorbet/rbs_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rbs"
+
 module RuboCop
   module Sorbet
     # Pure helpers for parsing RBS inline-comment signatures (`#:` / `#|`).
@@ -99,107 +101,57 @@ module RuboCop
           @comments = comments
         end
 
-        # The return type expression as a string (e.g. `"String"`, `"void"`,
-        # `"^(Integer) -> void"`, `"Integer | String"`), or nil if the
-        # signature has no return arrow or an empty return.
+        # The return type expression as a string, or nil if parsing fails.
         def return_type
-          parsed[:expr]
+          return_type_node&.to_s
         end
 
-        # `[highlight_range, replace_range]` covering the return type
-        # expression, or nil if there is no return type. `highlight_range`
-        # covers the first token (which may span `#|` lines); `replace_range`
-        # covers the entire return expression.
+        # `[highlight_range, replace_range]` covering the return type, or nil
+        # if parsing fails or the return type has no source location.
         def return_type_range
-          return unless parsed[:expr]
+          location = return_type_node&.location
+          return unless location
 
-          [parsed[:highlight], parsed[:replace]]
+          buffer = @processed_source.buffer
+          return_source = location.source
+          first_token = return_source.match(/\S+/)
+          return unless first_token
+
+          highlight_start = location.start_pos + return_source.byteslice(0, first_token.begin(0)).bytesize
+          highlight_end = highlight_start + first_token[0].bytesize
+          highlight = Parser::Source::Range.new(buffer, highlight_start, highlight_end)
+          replace = Parser::Source::Range.new(buffer, location.start_pos, location.end_pos)
+          [highlight, replace]
         end
 
         # True if the signature declares a `void` return type.
         def void?
-          return_type == "void"
+          return_type_node.is_a?(RBS::Types::Bases::Void)
         end
 
         private
 
-        def parsed
-          @parsed ||= compute
+        def return_type_node
+          parsed_method_type&.type&.return_type
         end
 
-        def compute
-          segments = @comments.map { |comment| strip_rbs_prefix(comment.text) }
-          joined = segments.map(&:first).join(" ")
-          arrow_idx = method_arrow_index(joined)
-          return {} unless arrow_idx
+        def parsed_method_type
+          return @parsed_method_type if defined?(@parsed_method_type)
 
-          expr = joined[(arrow_idx + 2)..].strip
-          return {} if expr.empty?
-
-          first_token = expr[/\S+/]
-          token_start = joined.index(first_token, arrow_idx + 2)
-          highlight = range_for_token(segments, token_start, first_token.length)
-          replace_end = return_end_pos(segments)
-          replace = Parser::Source::Range.new(@processed_source.buffer, highlight.begin_pos, replace_end)
-          { expr: expr, highlight: highlight, replace: replace }
-        end
-
-        # Index of the method return arrow: the first `->` at the top level,
-        # i.e. outside parameter/block/proc delimiters. A proc return type such
-        # as `^(Integer) -> void` has its own nested arrow that must not be
-        # mistaken for the method arrow.
-        def method_arrow_index(joined)
-          depth = 0
-          joined.each_char.with_index do |char, index|
-            case char
-            when "(", "[", "{"
-              depth += 1
-            when ")", "]", "}"
-              depth -= 1
-            when "-"
-              return index if depth.zero? && joined[index + 1] == ">"
-            end
+          source_buffer = RBS::Buffer.new(
+            name: @processed_source.buffer.name,
+            content: @processed_source.buffer.source,
+          )
+          body_ranges = @comments.map do |comment|
+            marker = comment.text.match(/\A#[:|]\s*/)
+            range = comment.source_range
+            start_pos = range.begin_pos + marker[0].bytesize
+            start_pos...range.end_pos
           end
-          nil
-        end
-
-        # Map a position within the joined signature back to the originating
-        # comment and build a source range covering `length` characters.
-        def range_for_token(segments, token_start, length)
-          offset = 0
-          @comments.each_with_index do |comment, index|
-            content, prefix_len = segments[index]
-            seg_end = offset + content.length
-            if token_start < seg_end
-              content_offset = token_start - offset
-              line_start = @processed_source.buffer.line_range(comment.loc.line).begin_pos
-              start_pos = line_start + comment.loc.column + prefix_len + content_offset
-              return Parser::Source::Range.new(@processed_source.buffer, start_pos, start_pos + length)
-            end
-            offset = seg_end + 1 # +1 for the join space
-          end
-          nil
-        end
-
-        # Source position at the end of the group's last non-blank signature
-        # content; the return type expression runs to here.
-        def return_end_pos(segments)
-          last_comment = @comments.last
-          _, prefix_len = segments.last
-          content = segments.last.first.rstrip
-          line_start = @processed_source.buffer.line_range(last_comment.loc.line).begin_pos
-          line_start + last_comment.loc.column + prefix_len + content.length
-        end
-
-        # Strip the leading `#:`/`#|` marker and surrounding whitespace,
-        # returning `[content, prefix_length]`. `prefix_length` is the number
-        # of characters consumed from the original text, for mapping
-        # joined-content positions back to source offsets.
-        def strip_rbs_prefix(text)
-          match = text.match(/\A#[:|]\s*/)
-          return [text, 0] unless match
-
-          [match.post_match, match[0].length]
+          comment_buffer = source_buffer.sub_buffer(lines: body_ranges)
+          @parsed_method_type = RBS::Parser.parse_method_type(comment_buffer, require_eof: true)
+        rescue RBS::ParsingError
+          @parsed_method_type = nil
         end
       end
     end

--- a/rubocop-sorbet.gemspec
+++ b/rubocop-sorbet.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("lint_roller")
-  spec.add_runtime_dependency("rbi", "~> 0.4")
+  spec.add_runtime_dependency("rbi", "~> 0.4", ">= 0.4.3")
+  spec.add_runtime_dependency("rbs", ">= 4.1.1")
   spec.add_runtime_dependency("rubocop", ">= 1.75.2")
   spec.add_runtime_dependency("spoom", "~> 1.8")
 end

--- a/test/rubocop/cop/sorbet/forbid_t_struct_test.rb
+++ b/test/rubocop/cop/sorbet/forbid_t_struct_test.rb
@@ -332,7 +332,7 @@ module RuboCop
 
           assert_correction(<<~RUBY)
             class Foo
-              #: Integer | String
+              #: (Integer | String)
               attr_reader :a
 
               #: Array[String]
@@ -341,10 +341,10 @@ module RuboCop
               #: Hash[Symbol, Integer]
               attr_reader :c
 
-              #: Comparable & Numeric
+              #: (Comparable & Numeric)
               attr_reader :d
 
-              #: (a: Integer | String, b: Array[String], c: Hash[Symbol, Integer], d: Comparable & Numeric) -> void
+              #: (a: (Integer | String), b: Array[String], c: Hash[Symbol, Integer], d: (Comparable & Numeric)) -> void
               def initialize(a:, b:, c:, d:)
                 @a = a
                 @b = b
@@ -379,10 +379,10 @@ module RuboCop
               #: Hash[Symbol, bool]
               attr_reader :c
 
-              #: untyped
+              #: Enumerable[Integer]
               attr_reader :d
 
-              #: (a: bool, b: Range[Integer], c: Hash[Symbol, bool], d: untyped) -> void
+              #: (a: bool, b: Range[Integer], c: Hash[Symbol, bool], d: Enumerable[Integer]) -> void
               def initialize(a:, b:, c:, d:)
                 @a = a
                 @b = b
@@ -393,7 +393,7 @@ module RuboCop
           RUBY
         end
 
-        def test_autocorrects_rbs_maps_unsupported_types_to_untyped
+        def test_autocorrects_rbs_translates_special_types
           @cop = ForbidTStruct.new(cop_config("AutocorrectStyle" => "rbs"))
 
           assert_offense(<<~RUBY)
@@ -415,7 +415,7 @@ module RuboCop
               #: singleton(Foo)
               attr_reader :b
 
-              #: untyped
+              #: ^(Integer x) -> String
               attr_reader :c
 
               #: bot
@@ -424,7 +424,7 @@ module RuboCop
               #: untyped
               attr_reader :e
 
-              #: (a: untyped, b: singleton(Foo), c: untyped, d: bot, e: untyped) -> void
+              #: (a: untyped, b: singleton(Foo), c: ^(Integer x) -> String, d: bot, e: untyped) -> void
               def initialize(a:, b:, c:, d:, e:)
                 @a = a
                 @b = b

--- a/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb
@@ -708,8 +708,13 @@ module RuboCop
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
               def self.baz(a:); end
               ^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              def forward(...); end
+              ^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              def no_keywords(**nil); end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              def destructured((a, b)); end
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
             RUBY
-
             assert_correction(<<~RUBY)
               #: -> untyped
               def foo; end
@@ -723,6 +728,12 @@ module RuboCop
               def self.bar(a, *b, **c); end
               #: (a: untyped) -> untyped
               def self.baz(a:); end
+              #: (*untyped, **untyped) ?{ (?) -> untyped } -> untyped
+              def forward(...); end
+              #: (**nil) -> untyped
+              def no_keywords(**nil); end
+              #: (untyped) -> untyped
+              def destructured((a, b)); end
             RUBY
           end
 
@@ -751,6 +762,74 @@ module RuboCop
                 #: untyped
                 attr_accessor :baz
               end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_custom_placeholders
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+              "ParameterTypePlaceholder" => "PARAM",
+              "ReturnTypePlaceholder" => "RET",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo(a); end
+              ^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              class Foo
+                attr_reader :reader
+                ^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+                attr_writer :writer
+                ^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+                attr_accessor :accessor
+                ^^^^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+              end
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: (PARAM) -> RET
+              def foo(a); end
+              class Foo
+                #: RET
+                attr_reader :reader
+                #: PARAM
+                attr_writer :writer
+                #: RET
+                attr_accessor :accessor
+              end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_required_block_placeholder
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+              "ParameterTypePlaceholder" => "T.proc.void",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo(&block); end
+              ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: { -> void } -> untyped
+              def foo(&block); end
+            RUBY
+          end
+
+          def test_enforce_rbs_autocorrects_optional_block_placeholder
+            @cop = target_cop.new(cop_config({
+              "Style" => "rbs",
+              "ParameterTypePlaceholder" => "T.nilable(T.proc.void)",
+            }))
+
+            assert_offense(<<~RUBY)
+              def foo(&block); end
+              ^^^^^^^^^^^^^^^^^^^^ Each method is required to have an RBS signature.
+            RUBY
+
+            assert_correction(<<~RUBY)
+              #: ?{ -> void } -> untyped
+              def foo(&block); end
             RUBY
           end
 

--- a/test/rubocop/cop/sorbet/signatures/setter_return_type_test.rb
+++ b/test/rubocop/cop/sorbet/signatures/setter_return_type_test.rb
@@ -297,14 +297,20 @@ module RuboCop
           def test_offense_for_rbs_multiline_union_return
             assert_offense(<<~RUBY)
               #: (String) ->
-              #| Integer |
-                 ^^^^^^^ #{MSG}
-              #| String
+              #| (Integer | String)
+                  ^^^^^^^ #{MSG}
               def name=(name); end
             RUBY
             assert_correction(<<~RUBY)
               #: (String) ->
-              #| void
+              #| (void)
+              def name=(name); end
+            RUBY
+          end
+
+          def test_no_offense_for_rbs_unparenthesized_union_return
+            assert_no_offenses(<<~RUBY)
+              #: (String) -> Integer | String
               def name=(name); end
             RUBY
           end

--- a/test/rubocop/sorbet/rbs_parser_test.rb
+++ b/test/rubocop/sorbet/rbs_parser_test.rb
@@ -105,6 +105,14 @@ module RuboCop
         refute(sig.void?)
       end
 
+      def test_signature_return_type_parenthesized_simple
+        sig = signature("#: () -> (String)\ndef foo; end")
+        assert_equal("String", sig.return_type)
+        highlight, replace = sig.return_type_range
+        assert_equal("String", highlight.source)
+        assert_equal("String", replace.source)
+      end
+
       def test_signature_return_type_multiline_params
         sig = signature("#: (\n#| String name\n#| ) -> String\ndef foo; end")
         assert_equal("String", sig.return_type)
@@ -138,11 +146,18 @@ module RuboCop
       end
 
       def test_signature_return_type_multiline_union
-        sig = signature("#: (String) ->\n#| Integer |\n#| String\ndef foo; end")
+        sig = signature("#: (String) ->\n#| (Integer | String)\ndef foo; end")
         assert_equal("Integer | String", sig.return_type)
         highlight, replace = sig.return_type_range
         assert_equal("Integer", highlight.source)
-        assert_equal("Integer |\n#| String", replace.source)
+        assert_equal("Integer | String", replace.source)
+      end
+
+      def test_signature_return_type_nil_for_unparenthesized_union
+        sig = signature("#: (Integer) -> Integer | String\ndef foo; end")
+        assert_nil(sig.return_type)
+        assert_nil(sig.return_type_range)
+        refute(sig.void?)
       end
 
       def test_signature_void_return


### PR DESCRIPTION
## Summary

- Use RBI for Sorbet property type conversion in `Sorbet/ForbidTStruct`.
- Use RBI for new RBS signature suggestions, including unusual Ruby parameter forms.
- Use RBS parser locations for setter return corrections.
- Preserve the current Spoom signature conversion path from #397.

Supersedes #396.

## Test plan

- `bundle exec ruby -Itest test/rubocop/cop/sorbet/forbid_t_struct_test.rb`
- `bundle exec ruby -Itest test/rubocop/cop/sorbet/signatures/enforce_signatures_test.rb`
- `bundle exec ruby -Itest test/rubocop/sorbet/rbs_parser_test.rb`
- `bundle exec ruby -Itest test/rubocop/cop/sorbet/signatures/setter_return_type_test.rb`
- `bin/rake test`